### PR TITLE
SDKS-3505 -modified DavinicConnector , Session value 

### DIFF
--- a/PingDavinci/PingDavinci/Agent.swift
+++ b/PingDavinci/PingDavinci/Agent.swift
@@ -37,7 +37,7 @@ internal class CreateAgent: Agent {
     func authorize(oidcConfig: OidcConfig<T>) async throws -> AuthCode {
         // We don't get the state; The state may not be returned since this is primarily for
         // CSRF in redirect-based interactions, and pi.flow doesn't use redirect.
-        guard !session.value().isEmpty else {
+        guard !session.value.isEmpty else {
             throw OidcError.authorizeError(message: "Please start DaVinci flow to authenticate.")
         }
         guard !used else {
@@ -53,6 +53,6 @@ internal class CreateAgent: Agent {
 extension Session {
     func authCode(pkce: Pkce?) -> AuthCode {
         // parse the response and return the auth code
-        return AuthCode(code: value(), codeVerifier: pkce?.codeVerifier)
+        return AuthCode(code: value, codeVerifier: pkce?.codeVerifier)
     }
 }

--- a/PingDavinci/PingDavinci/User.swift
+++ b/PingDavinci/PingDavinci/User.swift
@@ -71,38 +71,40 @@ extension SuccessNode {
 /// - property user: The user.
 /// - property session: The session.
 struct UserDelegate: User, Session {
-    private let daVinci: DaVinci
-    private let user: User
-    private let session: Session
-    
-    init(daVinci: DaVinci, user: User, session: Session) {
-        self.daVinci = daVinci
-        self.user = user
-        self.session = session
+  private let daVinci: DaVinci
+  private let user: User
+  private let session: Session
+  
+  init(daVinci: DaVinci, user: User, session: Session) {
+    self.daVinci = daVinci
+    self.user = user
+    self.session = session
+  }
+  
+  /// Method to log out the user.
+  /// This method removes the cached user from the context and signs off the user.
+  func logout() async {
+    // remove the cached user from the context
+    _ = daVinci.sharedContext.removeValue(forKey: SharedContext.Keys.userKey)
+    // instead of calling `OidcClient.endSession` directly, we call `DaVinci.signOff` to sign off the user
+    _ = await daVinci.signOff()
+  }
+  
+  func token() async -> Result<Token, OidcError> {
+    return await user.token()
+  }
+  
+  func revoke() async {
+    await user.revoke()
+  }
+  
+  func userinfo(cache: Bool) async -> Result<UserInfo, OidcError> {
+    await user.userinfo(cache: cache)
+  }
+  
+  var value: String {
+    get {
+      return session.value
     }
-    
-    /// Method to log out the user.
-    /// This method removes the cached user from the context and signs off the user.
-    func logout() async {
-        // remove the cached user from the context
-        _ = daVinci.sharedContext.removeValue(forKey: SharedContext.Keys.userKey)
-        // instead of calling `OidcClient.endSession` directly, we call `DaVinci.signOff` to sign off the user
-        _ = await daVinci.signOff()
-    }
-    
-    func token() async -> Result<Token, OidcError> {
-        return await user.token()
-    }
-    
-    func revoke() async {
-        await user.revoke()
-    }
-    
-    func userinfo(cache: Bool) async -> Result<UserInfo, OidcError> {
-        await user.userinfo(cache: cache)
-    }
-    
-    func value() -> String {
-        return session.value()
-    }
+  }
 }

--- a/PingDavinci/PingDavinci/module/Connector.swift
+++ b/PingDavinci/PingDavinci/module/Connector.swift
@@ -1,5 +1,5 @@
 //
-//  DavinciConnector.swift
+//  Connector.swift
 //  PingDavinci
 //
 //  Copyright (c) 2024 Ping Identity. All rights reserved.
@@ -13,33 +13,33 @@ import PingOrchestrate
 /// Extension to get the id of a ContinueNode.
 extension ContinueNode {
     public var id: String {
-        return (self as? DaVinciConnector)?.idValue ?? ""
+        return (self as? Connector)?.idValue ?? ""
     }
     
     public var name: String {
-        return (self as? DaVinciConnector)?.nameValue ?? ""
+        return (self as? Connector)?.nameValue ?? ""
     }
     
     public var description: String {
-        return (self as? DaVinciConnector)?.descriptionValue ?? ""
+        return (self as? Connector)?.descriptionValue ?? ""
     }
     
     public var category: String {
-        return (self as? DaVinciConnector)?.categoryValue ?? ""
+        return (self as? Connector)?.categoryValue ?? ""
     }
     
 }
 
 
-/// Class representing a DaVinciConnector.
+/// Class representing a Connector.
 ///- property context: The FlowContext of the ContinueNode.
-///- property workflow: The Workflow of the ContinueNode.
+///- property davinci: The Davinci Flow of the ContinueNode.
 ///- property input: The input JsonObject of the ContinueNode.
 ///- property collectors: The collectors of the ContinueNode.
-class DaVinciConnector: ContinueNode {
+class Connector: ContinueNode {
     
-    init(context: FlowContext, workflow: Workflow, input: [String: Any], collectors: Collectors) {
-        super.init(context: context, workflow: workflow, input: input, actions: collectors)
+  init(context: FlowContext, davinci: DaVinci, input: [String: Any], collectors: Collectors) {
+    super.init(context: context, workflow: davinci, input: input, actions: collectors)
     }
     
     /// Function to convert the connector to a dictionary.

--- a/PingDavinci/PingDavinci/module/Transform.swift
+++ b/PingDavinci/PingDavinci/module/Transform.swift
@@ -55,7 +55,7 @@ public class NodeTransformModule {
           return FailureNode(cause: ApiError.error(status, json, body))
         }
         
-        return transform(context: flowContext, workflow: setup.workflow, json: json)
+        return transform(context: flowContext, davinci: setup.workflow, json: json)
       }
       
       // 5XX errors are treated as unrecoverable failures
@@ -64,7 +64,7 @@ public class NodeTransformModule {
     
   })
   
-  private static func transform(context: FlowContext, workflow: Workflow, json: [String: Any]) -> Node {
+  private static func transform(context: FlowContext, davinci: DaVinci, json: [String: Any]) -> Node {
     // If authorizeResponse is present, return success
     if let _ = json[Constants.authorizeResponse] as? [String: Any] {
       return SuccessNode(input: json, session: SessionResponse(json: json))
@@ -75,7 +75,7 @@ public class NodeTransformModule {
       collectors.append(contentsOf: Form.parse(json: json))
     }
     
-    return DaVinciConnector(context: context, workflow: workflow, input: json, collectors: collectors)
+    return Connector(context: context, davinci: davinci, input: json, collectors: collectors)
   }
 }
 
@@ -86,10 +86,13 @@ struct SessionResponse: Session {
     self.json = json
   }
   
-  func value() -> String {
-    let authResponse = json[Constants.authorizeResponse] as? [String: Any]
-    return authResponse?[Constants.code] as? String ?? ""
+  var value: String {
+    get {
+      let authResponse = json[Constants.authorizeResponse] as? [String: Any]
+      return authResponse?[Constants.code] as? String ?? ""
+    }
   }
+  
 }
 
 public enum ApiError: Error {

--- a/PingOrchestrate/PingOrchestrate/Node.swift
+++ b/PingOrchestrate/PingOrchestrate/Node.swift
@@ -100,7 +100,7 @@ open class ContinueNode: Node, Closeable {
 /// Protocol for a Session. A Session represents a user's session in the application.
 public protocol Session {
   /// Returns the value of the session as a String.
-  func value() -> String
+  var value: String { get }
 }
 
 
@@ -109,7 +109,6 @@ public struct EmptySession: Session {
   public init() {}
   
   /// The value of the empty session as a String.
-  public func value() -> String {
-    return ""
-  }
+  public var value: String = ""
+ 
 }

--- a/PingOrchestrate/PingOrchestrateTests/SessionTests.swift
+++ b/PingOrchestrate/PingOrchestrateTests/SessionTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 //  SessionTests.swift
 //  PingOrchestrateTests
 //
@@ -14,19 +14,18 @@ import XCTest
 @testable import PingOrchestrate
 
 final class SessionTests: XCTestCase {
-    
-    func testEmptySessionValueShouldReturnEmptyString() {
-        XCTAssertEqual("", EmptySession().value())
-    }
-    
-    func testSessionValueShouldReturnCorrectSessionValue() {
-        let session = MockSession()
-        XCTAssertEqual("session_value", session.value())
-    }
-    
-    class MockSession: Session {
-        func value() -> String {
-            return "session_value"
-        }
-    }
+  
+  func testEmptySessionValueShouldReturnEmptyString() {
+    XCTAssertEqual("", EmptySession().value)
+  }
+  
+  func testSessionValueShouldReturnCorrectSessionValue() {
+    let session = MockSession()
+    XCTAssertEqual("session_value", session.value)
+  }
+  
+  class MockSession: Session {
+    var value: String = "session_value"
+  }
+  
 }


### PR DESCRIPTION
# JIRA Ticket
[SDKS-3505](https://pingidentity.atlassian.net/browse/SDKS-3505) Align with Android Implementation [PR #8](https://github.com/ForgeRock/ping-android-sdk/pull/8)

# Description
- Rename `DaVinciConnector` to `Connector`
- `Session.value()` function to `Session.value` property
- Add DaVinci as alias of Workflow. Modules will use DaVinci instead of Workflow. 

# Checklist:

- [ ] I ran all unit tests and they pass
- [ ] I added test case coverage for my changes
