### PR TITLE
Add missing refreshThreshold to update method in OidcClientConfig

### DIFF
--- a/Oidc/Oidc/OidcClientConfig.swift
+++ b/Oidc/Oidc/OidcClientConfig.swift
@@ -92,6 +92,7 @@ public class OidcClientConfig {
     
     func update(with other: OidcClientConfig) {
         self.openId = other.openId
+        self.refreshThreshold = other.refreshThreshold
         self.agent = other.agent
         self.logger = other.logger
         self.storage = other.storage

--- a/Oidc/OidcTests/OidcClientConfigTests.swift
+++ b/Oidc/OidcTests/OidcClientConfigTests.swift
@@ -100,6 +100,7 @@ final class OidcClientConfigTests: XCTestCase {
     }
     
     func testClone() {
+        oidcClientConfig.refreshThreshold = 100
         oidcClientConfig.agent = AgentDelegate(agent: MockAgent(), agentConfig: (), oidcClientConfig: oidcClientConfig)
         oidcClientConfig.logger = LogManager.standard
         oidcClientConfig.storage = MockStorage<Token>()
@@ -119,6 +120,7 @@ final class OidcClientConfigTests: XCTestCase {
         let clonedConfig = oidcClientConfig.clone()
         
         XCTAssertEqual(oidcClientConfig.openId.debugDescription, clonedConfig.openId.debugDescription)
+        XCTAssertEqual(oidcClientConfig.refreshThreshold, clonedConfig.refreshThreshold)
         XCTAssertEqual(oidcClientConfig.agent.debugDescription, clonedConfig.agent.debugDescription)
         XCTAssertEqual(oidcClientConfig.discoveryEndpoint, clonedConfig.discoveryEndpoint)
         XCTAssertEqual(oidcClientConfig.clientId, clonedConfig.clientId)


### PR DESCRIPTION
[SDKS-3611](https://pingidentity.atlassian.net/browse/SDKS-3611)

[iOS][Ping SDK] refreshThreshold configuration in the OIDC module doesn't work as expected