### PR TITLE
SDKS-3771 Setup Mend SAST scan

### DIFF
--- a/.github/workflows/mend-cli-scan.yaml
+++ b/.github/workflows/mend-cli-scan.yaml
@@ -14,7 +14,7 @@ on:
       
 jobs:
   mend-cli-scan:
-    runs-on: macos-15
+    runs-on: ubuntu-latest
 
     steps:
       # Clone the repo
@@ -24,11 +24,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
-
-      # Set target Xcode version. For more details and options see:
-      # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md
-      - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_16.1.0.app && /usr/bin/xcodebuild -version
 
       # Setup Mend CLI
       - name: Download and cache the Mend CLI executable
@@ -46,45 +41,119 @@ jobs:
       - if: ${{ steps.cache-mend.outputs.cache-hit != 'true' }}
         name: Download Mend CLI executable (cache miss...)
         continue-on-error: true
+        shell: bash
         run: |
           echo "Download Mend CLI executable (cache miss...)"
-          curl https://downloads.mend.io/cli/darwin_amd64/mend -o /usr/local/bin/mend && chmod +x /usr/local/bin/mend
+          curl https://downloads.mend.io/cli/linux_amd64/mend -o /usr/local/bin/mend && chmod +x /usr/local/bin/mend
 
-      # Execute the Mend CLI scan
-      - name: Mend CLI Scan
+      ########################################
+      #       Execute Mend SCA scan          #
+      ########################################
+      - name: Mend SCA scan
         env:
-          MEND_EMAIL: ${{secrets.MEND_EMAIL}}
-          MEND_USER_KEY: ${{secrets.MEND_USER_KEY}}
+          MEND_EMAIL: ${{ secrets.MEND_EMAIL }}
+          MEND_USER_KEY: ${{ secrets.MEND_USER_KEY }}
           MEND_URL: ${{ vars.MEND_SERVER_URL }}
+        shell: bash
         run: |
-            mend dep --no-color -s ${{ vars.MEND_PRODUCT_NAME }}//${{ vars.MEND_PROJECT_NAME }} -u > mend-scan-result.txt
-            echo "MEND_SCAN_URL=$(cat mend-scan-result.txt | grep -Eo '(http|https)://[a-zA-Z0-9./?!=_%:-\#]*')" >> $GITHUB_ENV
-            echo "MEND_SCAN_SUMMARY=$(cat mend-scan-result.txt | grep -Eoiw '(Detected [0-9]* vulnerabilities.*)')" >> $GITHUB_ENV
-            echo "MEND_CRITICAL_COUNT=$(cat mend-scan-result.txt | grep -Eoiw '(Detected [0-9]* vulnerabilities.*)' | grep -oi '[0-9]* Critical' | grep -o [0-9]*)" >> $GITHUB_ENV
-            echo "MEND_HIGH_COUNT=$(cat mend-scan-result.txt | grep -Eoiw '(Detected [0-9]* vulnerabilities.*)' | grep -oi '[0-9]* High' | grep -o [0-9]*)" >> $GITHUB_ENV
+          mend dep --no-color -s ${{ vars.MEND_PRODUCT_NAME }}//${{ vars.MEND_PROJECT_NAME }} -u > mend-sca-scan-result.txt
 
-      # Check for failures and set the outcome of the workflow
-      - name: Parse the result and set job status
-        if: always()
+          export MEND_SCA_SCAN_URL=$(grep -Eo '(http|https)://[^ ]+' mend-sca-scan-result.txt)
+          export MEND_SCA_SCAN_SUMMARY=$(grep -Eo 'Detected [0-9]+ vulnerabilities.*' mend-sca-scan-result.txt)
+          export MEND_SCA_CRITICAL_COUNT=$(grep -Eo '[0-9]+ Critical' mend-sca-scan-result.txt | grep -Eo '[0-9]+')
+          export MEND_SCA_HIGH_COUNT=$(grep -Eo '[0-9]+ High' mend-sca-scan-result.txt | grep -Eo '[0-9]+')
+          export MEND_SCA_MEDIUM_COUNT=$(grep -Eo '[0-9]+ Medium' mend-sca-scan-result.txt | grep -Eo '[0-9]+')
+          export MEND_SCA_LOW_COUNT=$(grep -Eo '[0-9]+ Low' mend-sca-scan-result.txt | grep -Eo '[0-9]+')
+
+          echo "MEND_SCA_SCAN_URL=$MEND_SCA_SCAN_URL" >> $GITHUB_ENV
+          echo "MEND_SCA_SCAN_SUMMARY=$MEND_SCA_SCAN_SUMMARY" >> $GITHUB_ENV
+          echo "MEND_SCA_CRITICAL_COUNT=$MEND_SCA_CRITICAL_COUNT" >> $GITHUB_ENV
+          echo "MEND_SCA_HIGH_COUNT=$MEND_SCA_HIGH_COUNT" >> $GITHUB_ENV
+          echo "MEND_SCA_MEDIUM_COUNT=$MEND_SCA_MEDIUM_COUNT" >> $GITHUB_ENV
+          echo "MEND_SCA_LOW_COUNT=$MEND_SCA_LOW_COUNT" >> $GITHUB_ENV
+
+      # Check for failures in SCA scan and set the outcome of the workflow
+      - name: Fail if Critical or High SCA vulnerabilities are found
+        shell: bash
         run: |
-          if [ '${{ env.MEND_CRITICAL_COUNT }}' -gt '0' ] || [ '${{ env.MEND_HIGH_COUNT }}' -gt '0' ]; then
+          if [ "$MEND_SCA_CRITICAL_COUNT" -gt 0 ] || [ "$MEND_SCA_HIGH_COUNT" -gt 0 ]; then
+            echo "❌ SCA scan detected critical/high vulnerabilities."
             exit 1
           else
-            exit 0
+            echo "✅ No critical/high SCA vulnerabilities."
           fi
 
-      # Publish the result
-      - name: Mend Scan Result
+      # Publish the Mend SCA scan result
+      - name: Mend SCA Scan Result
         uses: LouisBrunner/checks-action@v1.6.1
         if: always()
         with:
-          name: "Mend Scan Result"
+          name: "Mend SCA Scan Result"
           token: ${{ secrets.GITHUB_TOKEN }}
           conclusion: ${{ job.status }}
-          output_text_description_file: mend-scan-result.txt
+          output_text_description_file: mend-sca-scan-result.txt
           output: |
-            {"title":"Mend Scan Result", "summary":"${{ job.status }}"}
+            {"title":"Mend SCA Scan Result", "summary":"${{ job.status }}"}
 
+      ########################################
+      #       Execute Mend SAST scan         #
+      ########################################
+      - name: Mend SAST scan
+        env:
+          MEND_EMAIL: ${{ secrets.MEND_EMAIL }}
+          MEND_USER_KEY: ${{ secrets.MEND_USER_KEY }}
+          MEND_URL: ${{ vars.MEND_SERVER_URL }}
+          MEND_SAST_PATH_EXCLUSIONS: ${{ vars.MEND_SAST_PATH_EXCLUSIONS }}
+        shell: bash
+        run: |
+          mend code --report --filename ${{ vars.MEND_SAST_REPORT_NAME }} --formats json,pdf --non-interactive --scope ${{ vars.MEND_PRODUCT_NAME }}//${{ vars.MEND_PROJECT_NAME }} > mend-sast-scan-result.txt
+
+          export MEND_SAST_TOTAL_VULNERABILITIES_COUNT=$(jq '.[0].stats.totalVulnerabilities' ${{ vars.MEND_SAST_REPORT_NAME }}.json)
+          export MEND_SAST_CRITICAL_COUNT=$(jq '.[0].stats.critical' ${{ vars.MEND_SAST_REPORT_NAME }}.json)
+          export MEND_SAST_HIGH_COUNT=$(jq '.[0].stats.high' ${{ vars.MEND_SAST_REPORT_NAME }}.json)
+          export MEND_SAST_MEDIUM_COUNT=$(jq '.[0].stats.medium' ${{ vars.MEND_SAST_REPORT_NAME }}.json)
+          export MEND_SAST_LOW_COUNT=$(jq '.[0].stats.low' ${{ vars.MEND_SAST_REPORT_NAME }}.json)
+          export MEND_SAST_SCAN_URL=$(grep -Eo '(http|https)://[^ ]+' mend-sast-scan-result.txt)
+
+          echo "MEND_SAST_TOTAL_VULNERABILITIES_COUNT=$MEND_SAST_TOTAL_VULNERABILITIES_COUNT" >> $GITHUB_ENV
+          echo "MEND_SAST_CRITICAL_COUNT=$MEND_SAST_CRITICAL_COUNT" >> $GITHUB_ENV
+          echo "MEND_SAST_HIGH_COUNT=$MEND_SAST_HIGH_COUNT" >> $GITHUB_ENV
+          echo "MEND_SAST_MEDIUM_COUNT=$MEND_SAST_MEDIUM_COUNT" >> $GITHUB_ENV
+          echo "MEND_SAST_LOW_COUNT=$MEND_SAST_LOW_COUNT" >> $GITHUB_ENV
+          echo "MEND_SAST_SCAN_URL=$MEND_SAST_SCAN_URL" >> $GITHUB_ENV
+
+      # Check for failures in SAST scan and set the outcome of the workflow
+      - name: Fail if Critical or High SAST vulnerabilities are found
+        shell: bash
+        run: |
+          if [ "$MEND_SAST_CRITICAL_COUNT" -gt 0 ] || [ "$MEND_SAST_HIGH_COUNT" -gt 0 ]; then
+            echo "❌ SAST scan detected critical/high vulnerabilities."
+            exit 1
+          else
+            echo "✅ No critical/high SAST vulnerabilities."
+          fi
+
+      # Publish the Mend SAST scan result (raw output)
+      - name: Mend SAST Scan Result
+        uses: LouisBrunner/checks-action@v1.6.1
+        if: always()
+        with:
+          name: "Mend SAST Scan Result"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          conclusion: ${{ job.status }}
+          output_text_description_file: mend-sast-scan-result.txt
+          output: |
+            {"title":"Mend SAST Scan Result", "summary":"${{ job.status }}"}
+
+      # Publish the Mend SAST scan result (PDF report)
+      - name: Publish${{ vars.MEND_SAST_REPORT_NAME }}.pdf
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ${{ vars.MEND_SAST_REPORT_NAME }}.pdf
+          path: ${{ vars.MEND_SAST_REPORT_NAME }}.pdf
+
+      
       # Send slack notification with result status
       - name: Send slack notification
         uses: 8398a7/action-slack@v3
@@ -93,11 +162,24 @@ jobs:
           fields: all
           custom_payload: |
             {
-              attachments: [{
-                title: 'ForgeRock iOS SDK Mend Scan',
-                color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
-                text: `\nStatus: ${{ job.status }}\nWorkflow: ${process.env.AS_WORKFLOW} -> ${process.env.AS_JOB}\nSummary: ${{ env.MEND_SCAN_SUMMARY }}\nScan URL: ${{ env.MEND_SCAN_URL }}`, 
-              }]
+              "text": "*Mend Security Scan Results*",
+              "attachments": [
+                {
+                  "color": "${{ job.status == 'success' && 'good' || 'danger' }}",
+                  "fields": [
+                    {
+                      "title": "SCA scan",
+                      "value": "${{ env.MEND_SCA_SCAN_SUMMARY }}\n<${{ env.MEND_SCA_SCAN_URL }}|View full SCA report>",
+                      "short": false
+                    },
+                    {
+                      "title": "SAST scan",
+                      "value": "Total: ${{ env.MEND_SAST_TOTAL_VULNERABILITIES_COUNT }} | Critical: ${{ env.MEND_SAST_CRITICAL_COUNT }} | High: ${{ env.MEND_SAST_HIGH_COUNT }} | Medium: ${{ env.MEND_SAST_MEDIUM_COUNT }} | Low: ${{ env.MEND_SAST_LOW_COUNT }}\n<${{ env.MEND_SAST_SCAN_URL }}|View full SAST report>",
+                      "short": false
+                    }
+                  ]
+                }
+              ]
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
# JIRA Ticket

[SDKS-3771](https://pingidentity.atlassian.net/browse/SDKS-3771) Setup Mends SAST scan

# Description

Setup Mend SAST scan.
A few notes:

- Currently, the pipeline will fail if some **Critical** or **High** vulnerabilities are found! Mediums and Lows won't fail the pipeline! We can change that easily if needed...
- Currently the `.build` directory is excluded from the scans. This is controlled by the `MEND_SAST_PATH_EXCLUSIONS` env variable. To modify the list we can simply change the github action variable `MEND_SAST_PATH_EXCLUSIONS` [here](https://github.com/ForgeRock/ping-ios-sdk/settings/variables/actions)...
- The pipeline attaches/publishes the SAST scan results as an attachment to the pipeline execution run
- The results are pushed to our Mend project - direct URL is available through the attached results and also in the slack message.
