### PR TITLE
SDKS-4534-Updates for bugs SDKS-4538, SDKS-4535, SDKS-4534

### DIFF
--- a/Fido/Fido/Davinci/AbstractFidoCollector.swift
+++ b/Fido/Fido/Davinci/AbstractFidoCollector.swift
@@ -12,6 +12,7 @@ import Foundation
 import PingDavinci
 import PingLogger
 import PingOrchestrate
+import AuthenticationServices
 
 /// An abstract base class for Fido collectors in a DaVinci flow.
 public class AbstractFidoCollector: FieldCollector<[String: Any]>, DaVinciAware, Submittable, @unchecked Sendable {    
@@ -55,6 +56,70 @@ public class AbstractFidoCollector: FieldCollector<[String: Any]>, DaVinciAware,
             return FidoAuthenticationCollector(with: json)
         default:
             throw FidoError.unsupportedAction(action)
+        }
+    }
+    
+    /// Handles errors that occur during FIDO operations and transforms them into WebAuthn-spec-compliant errors.
+    ///
+    /// This method converts `ASAuthorizationError` codes and `FidoError` types into human-readable error information
+    /// based on the WebAuthn specification. The transformed error is returned to the caller.
+    ///
+    /// - Parameter error: The error to handle and transform.
+    /// - Returns: A transformed `FidoError` that is more human-readable and spec-compliant.
+    public func handleError(error: Error) -> FidoError {
+        logger?.e("Handling FIDO error: \(error.localizedDescription)", error: error)
+        
+        // Check if it's a FidoError first
+        if let fidoError = error as? FidoError {
+            switch fidoError {
+            case .timeout:
+                logger?.d("FIDO operation timed out")
+                return .timeout
+            case .unsupportedAction(let message):
+                logger?.d("FIDO ERROR NOT SUPPORTED: \(message)")
+                return .unsupportedAction(message)
+            case .invalidResponse:
+                logger?.d("FIDO invalid response")
+                return .invalidResponse
+            case .invalidChallenge:
+                logger?.d("FIDO invalid challenge")
+                return .invalidChallenge
+            case .invalidWindow:
+                logger?.d("FIDO invalid window")
+                return .invalidWindow
+            case .invalidAction:
+                logger?.d("FIDO invalid action")
+                return .invalidAction
+            case .missingParameters(let message):
+                logger?.d("FIDO missing parameters: \(message)")
+                return .missingParameters(message)
+            }
+        }
+        
+        let nsError = error as NSError
+        
+        switch nsError.domain {
+        case ASAuthorizationError.errorDomain:
+            switch nsError.code {
+            case ASAuthorizationError.canceled.rawValue:
+                logger?.d("Credential operation cancelled")
+                return .unsupportedAction(FidoConstants.ERROR_NOT_ALLOWED_MESSAGE)
+            case ASAuthorizationError.invalidResponse.rawValue:
+                logger?.d("DOM exception occurred: InvalidStateError")
+                return .invalidResponse
+            case ASAuthorizationError.notHandled.rawValue:
+                logger?.d("DOM exception occurred: NotSupportedError")
+                return .unsupportedAction("Operation not supported")
+            case ASAuthorizationError.unknown.rawValue:
+                logger?.d("Unknown error occurred")
+                return .unsupportedAction("Unknown error: \(error.localizedDescription)")
+            default:
+                logger?.d("Unknown authorization error occurred")
+                return .unsupportedAction("Unknown error: \(error.localizedDescription)")
+            }
+        default:
+            logger?.d("Unknown error occurred")
+            return .unsupportedAction("Unknown error: \(error.localizedDescription)")
         }
     }
 }

--- a/Fido/Fido/Davinci/FidoRegistrationCollector.swift
+++ b/Fido/Fido/Davinci/FidoRegistrationCollector.swift
@@ -82,10 +82,10 @@ public class FidoRegistrationCollector: AbstractFidoCollector, @unchecked Sendab
                   let clientDataJSONData = response[FidoConstants.FIELD_CLIENT_DATA_JSON] as? Data,
                   let attestationObjectData = response[FidoConstants.FIELD_ATTESTATION_OBJECT] as? Data else {
                 
-                let error = FidoError.invalidResponse // Define your error type
+                let error = FidoError.invalidResponse
                 logger?.e(error.localizedDescription, error: error)
-                // Note: No call to self.handleError here as it's specific to the callback context
-                return .failure(error) // Return failure
+                let transformedError = self.handleError(error: error)
+                return .failure(transformedError) // Return failure with transformed error
             }
             
             // 3. Construct the attestationValue payload
@@ -110,8 +110,8 @@ public class FidoRegistrationCollector: AbstractFidoCollector, @unchecked Sendab
         } catch {
             // 5. Handle any error caught from the continuation
             logger?.e("FIDO registration failed", error: error)
-            // Note: No call to self.handleError here
-            return .failure(error) // Return failure
+            let transformedError = self.handleError(error: error)
+            return .failure(transformedError) // Return failure with transformed error
         }
     }
     
@@ -140,6 +140,13 @@ public class FidoRegistrationCollector: AbstractFidoCollector, @unchecked Sendab
             logger?.d("Challenge: \(challenge)")
             let data = Data(challenge.map { UInt8(bitPattern: Int8($0)) })
             output[FidoConstants.FIELD_CHALLENGE] = data.base64EncodedString()
+        }
+        
+        // Handle timeout field - use default if not provided
+        if let timeout = output[FidoConstants.FIELD_TIMEOUT] as? Int {
+            output[FidoConstants.FIELD_TIMEOUT] = timeout
+        } else {
+            output[FidoConstants.FIELD_TIMEOUT] = FidoConstants.DEFAULT_TIMEOUT
         }
         
         if let excludeCredentials = output[FidoConstants.FIELD_EXCLUDE_CREDENTIALS] as? [[String: Any]] {

--- a/Fido/Fido/Davinci/FidoRegistrationCollector.swift
+++ b/Fido/Fido/Davinci/FidoRegistrationCollector.swift
@@ -89,7 +89,7 @@ public class FidoRegistrationCollector: AbstractFidoCollector, @unchecked Sendab
             }
             
             // 3. Construct the attestationValue payload
-            let authenticatorAttachment = "platform"
+            let authenticatorAttachment = response[FidoConstants.FIELD_AUTHENTICATOR_ATTACHMENT] as? String ?? FidoConstants.FIELD_AUTHENTICATOR_ATTACHMENT_PLATFORM
             let newAttestationValue: [String: Any] = [
                 FidoConstants.FIELD_ID: rawIdData.base64urlEncodedString(),
                 FidoConstants.FIELD_TYPE: FidoConstants.FIELD_PUB_KEY,

--- a/Fido/Fido/FidoConstants.swift
+++ b/Fido/Fido/FidoConstants.swift
@@ -80,6 +80,10 @@ public struct FidoConstants {
     public static let FIELD_DISPLAY_NAME = "displayName"
     /// The key for the authenticator attachment type.
     public static let FIELD_AUTHENTICATOR_ATTACHMENT = "authenticatorAttachment"
+    /// The key for the authenticator attachment type platform.
+    public static let FIELD_AUTHENTICATOR_ATTACHMENT_PLATFORM = "platform"
+    /// The key for the authenticator attachment type cross-platform.
+    public static let FIELD_AUTHENTICATOR_ATTACHMENT_CROSS_PLATFORM = "cross-platform"
     /// The key for the resident key requirement.
     public static let FIELD_REQUIRE_RESIDENT_KEY = "requireResidentKey"
     /// The key for the resident key preference.
@@ -164,11 +168,6 @@ public struct FidoConstants {
     public static let ERROR_NOT_SUPPORTED = "NotSupportedError"
     /// The prefix for error messages.
     public static let ERROR_PREFIX = "ERROR::"
-
-    // MARK: - Authenticator Types
-    
-    /// The platform authenticator type.
-    public static let AUTHENTICATOR_PLATFORM = "platform"
 
     // MARK: - FIDO JSON Response Keys
     

--- a/Fido/Fido/Journey/FidoAuthenticationCallback.swift
+++ b/Fido/Fido/Journey/FidoAuthenticationCallback.swift
@@ -83,9 +83,10 @@ public class FidoAuthenticationCallback: FidoCallback, @unchecked Sendable {
             ].joined(separator: FidoConstants.DATA_SEPARATOR)
             
             let callbackValue: String
+            let authenticatorAttachment = response[FidoConstants.FIELD_AUTHENTICATOR_ATTACHMENT] as? String ?? FidoConstants.FIELD_AUTHENTICATOR_ATTACHMENT_PLATFORM
             if self.supportsJsonResponse {
                 let jsonResponse: [String: Any] = [
-                    FidoConstants.FIELD_AUTHENTICATOR_ATTACHMENT: FidoConstants.AUTHENTICATOR_PLATFORM,
+                    FidoConstants.FIELD_AUTHENTICATOR_ATTACHMENT: authenticatorAttachment,
                     FidoConstants.FIELD_LEGACY_DATA: legacyData
                 ]
                 // Safely create JSON string

--- a/Fido/Fido/Journey/FidoRegistrationCallback.swift
+++ b/Fido/Fido/Journey/FidoRegistrationCallback.swift
@@ -83,11 +83,11 @@ public class FidoRegistrationCallback: FidoCallback, @unchecked Sendable {
             if let deviceName = deviceName, !deviceName.isEmpty { // Only add if deviceName has content
                 finalData += "\(FidoConstants.DATA_SEPARATOR)\(deviceName)"
             }
-            
+            let authenticatorAttachment = response[FidoConstants.FIELD_AUTHENTICATOR_ATTACHMENT] as? String ?? FidoConstants.FIELD_AUTHENTICATOR_ATTACHMENT_PLATFORM
             let callbackValue: String
             if self.supportsJsonResponse {
                 let jsonResponse: [String: Any] = [
-                    FidoConstants.FIELD_AUTHENTICATOR_ATTACHMENT: FidoConstants.AUTHENTICATOR_PLATFORM,
+                    FidoConstants.FIELD_AUTHENTICATOR_ATTACHMENT: authenticatorAttachment,
                     FidoConstants.FIELD_LEGACY_DATA: finalData
                 ]
                 // Safely create JSON string

--- a/SampleApps/PingExample/PingExample/Collectors/FidoAuthenticationCollectorView.swift
+++ b/SampleApps/PingExample/PingExample/Collectors/FidoAuthenticationCollectorView.swift
@@ -47,7 +47,11 @@ struct FidoAuthenticationCollectorView: View {
                     }
                 }
             }) {
-                Text("Authenticate with FIDO")
+                if collector.label.isEmpty {
+                    Text("Authenticate with FIDO")
+                } else {
+                    Text(collector.label)
+                }
             }
         }
     }

--- a/SampleApps/PingExample/PingExample/Collectors/FidoRegistrationCollectorView.swift
+++ b/SampleApps/PingExample/PingExample/Collectors/FidoRegistrationCollectorView.swift
@@ -57,7 +57,11 @@ struct FidoRegistrationCollectorView: View {
                     }
                 }
             }) {
-                Text("Register with FIDO")
+                if collector.label.isEmpty {
+                    Text("Register with FIDO")
+                } else {
+                    Text(collector.label)
+                }
             }
         }
     }

--- a/SampleApps/PingExample/PingExample/DavinciViewModel.swift
+++ b/SampleApps/PingExample/PingExample/DavinciViewModel.swift
@@ -32,7 +32,7 @@ public let davinci = DaVinci.createDaVinci { config in
         oidcValue.scopes = Set<String>(currentConfig?.scopes ?? [])
         oidcValue.redirectUri = currentConfig?.redirectUri ?? ""
         oidcValue.discoveryEndpoint = currentConfig?.discoveryEndpoint ?? ""
-        oidcValue.acrValues = "9da1b93991bcd577947da228ad4c741f" //update with actual ACR values if needed or remove
+        oidcValue.acrValues = "" //update with actual ACR values if needed or remove
     }
 }
 


### PR DESCRIPTION
# JIRA Tickets

- [SDKS-4534](https://bugster.forgerock.org/jira/browse/SDKS-4534) FIDO registration and authentication does not timeout (DaVinci)
- [SDKS-4538](https://bugster.forgerock.org/jira/browse/SDKS-4538) Use the configured button label in PingOne "Fido Registration/Authentication" form
- [SDKS-4535](https://bugster.forgerock.org/jira/browse/SDKS-4535) Provide clear error messages for the Fido client errors in the DaVinci module
- [SDKS-4541](https://pingidentity.atlassian.net/browse/SDKS-4535) Wrong `authenticatorAttachment` value set when registering external (cross-platform) key

# Description

Briefly describe the change and any information that would help speedup the review and testing process.

# Checklist:

- [X] I ran all unit tests and they pass
- [X] I added test case coverage for my changes
