### PR TITLE
SDKS-4630 Enhance DefaultDeviceIdentifier to Reuse Legacy Device Identifier When Available

### DIFF
--- a/DeviceId/DeviceId.xcodeproj/project.pbxproj
+++ b/DeviceId/DeviceId.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		EC23D5872E2FD12100C43D42 /* PingDeviceId.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC23D57D2E2FD12100C43D42 /* PingDeviceId.framework */; };
+		EC92D44E2F1663900083CCF3 /* LegacyDeviceIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC92D44C2F1663900083CCF3 /* LegacyDeviceIdentifier.swift */; };
+		EC92D4512F1668300083CCF3 /* LegacyDeviceIdentifierMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC92D44F2F1667D70083CCF3 /* LegacyDeviceIdentifierMigrationTests.swift */; };
 		ECCAB3102E393EDF00BA1C73 /* PingLogger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ECCAB30F2E393EDF00BA1C73 /* PingLogger.framework */; };
 		ECCAB3112E393EDF00BA1C73 /* PingLogger.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = ECCAB30F2E393EDF00BA1C73 /* PingLogger.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		ECCAB3142E393F2500BA1C73 /* PingLogger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ECCAB3132E393F2500BA1C73 /* PingLogger.framework */; };
@@ -61,6 +63,8 @@
 /* Begin PBXFileReference section */
 		EC23D57D2E2FD12100C43D42 /* PingDeviceId.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PingDeviceId.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC23D5862E2FD12100C43D42 /* DeviceIdTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DeviceIdTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		EC92D44C2F1663900083CCF3 /* LegacyDeviceIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyDeviceIdentifier.swift; sourceTree = "<group>"; };
+		EC92D44F2F1667D70083CCF3 /* LegacyDeviceIdentifierMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyDeviceIdentifierMigrationTests.swift; sourceTree = "<group>"; };
 		ECCAB30F2E393EDF00BA1C73 /* PingLogger.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingLogger.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ECCAB3132E393F2500BA1C73 /* PingLogger.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingLogger.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ECCAB3172E393F2F00BA1C73 /* PingStorage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingStorage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -126,6 +130,7 @@
 		ECCAB39D2E3B5FBC00BA1C73 /* DeviceId */ = {
 			isa = PBXGroup;
 			children = (
+				EC92D44C2F1663900083CCF3 /* LegacyDeviceIdentifier.swift */,
 				ECCAB39A2E3B5FBC00BA1C73 /* DeviceId.h */,
 				ECCAB39B2E3B5FBC00BA1C73 /* DeviceIdentifier.swift */,
 				ECCAB3AF2E3BA1A000BA1C73 /* DefaultDeviceIdentifier.swift */,
@@ -138,6 +143,7 @@
 		ECCAB3A22E3B5FEB00BA1C73 /* DeviceIdTests */ = {
 			isa = PBXGroup;
 			children = (
+				EC92D44F2F1667D70083CCF3 /* LegacyDeviceIdentifierMigrationTests.swift */,
 				ECCAB3A12E3B5FEB00BA1C73 /* DeviceIdTests.swift */,
 			);
 			path = DeviceIdTests;
@@ -261,6 +267,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ECCAB3B02E3BA1B200BA1C73 /* DefaultDeviceIdentifier.swift in Sources */,
+				EC92D44E2F1663900083CCF3 /* LegacyDeviceIdentifier.swift in Sources */,
 				ECCAB3B22E3BA21300BA1C73 /* UUIDDeviceIdentifier.swift in Sources */,
 				ECCAB39F2E3B5FBC00BA1C73 /* DeviceIdentifier.swift in Sources */,
 			);
@@ -270,6 +277,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EC92D4512F1668300083CCF3 /* LegacyDeviceIdentifierMigrationTests.swift in Sources */,
 				ECCAB3A32E3B5FEB00BA1C73 /* DeviceIdTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -432,7 +440,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0-alpha;
+				MARKETING_VERSION = "2.0.0-alpha";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pingidentity.Device;
@@ -466,7 +474,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0-alpha;
+				MARKETING_VERSION = "2.0.0-alpha";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pingidentity.Device;
@@ -488,7 +496,7 @@
 				DEVELOPMENT_TEAM = 9QSE66762D;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				MARKETING_VERSION = 2.0.0-alpha;
+				MARKETING_VERSION = "2.0.0-alpha";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pingidentity.DeviceTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -506,7 +514,7 @@
 				DEVELOPMENT_TEAM = 9QSE66762D;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				MARKETING_VERSION = 2.0.0-alpha;
+				MARKETING_VERSION = "2.0.0-alpha";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pingidentity.DeviceTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;

--- a/DeviceId/DeviceId/DefaultDeviceIdentifier.swift
+++ b/DeviceId/DeviceId/DefaultDeviceIdentifier.swift
@@ -19,6 +19,32 @@ import PingStorage
 /// ```swift
 /// let deviceId = DefaultDeviceIdentifier()
 /// let identifier = try await deviceId.id
+///
+/// // In case of migration from the FR SDK when using a custom Keychain Access Group use the following
+///
+///
+/// func setupDeviceIdentifierWithMigration() async throws -> String {
+///     // If your legacy FRAuth SDK used a custom keychain access group,
+///     // specify it here to enable migration
+///     let configuration = DeviceIdentifierConfiguration(
+///         keySize: DeviceIdentifierConfiguration.default.keySize,
+///         keychainAccount: DeviceIdentifierConfiguration.default.keychainAccount,
+///         useEncryption: DeviceIdentifierConfiguration.default.useEncryption,
+///         legacyKeychainAccessGroup: "com.test" // Set Legacy Keychain Access Group
+///     )
+///
+///     // Initialize with configuration
+///    let deviceIdentifier = try DefaultDeviceIdentifier(
+///         configuration: configuration,
+///         logger: LogManager.standard  // Optional: for debugging migration
+///     )
+///
+///     // First access will trigger migration if legacy identifier exists
+///     let deviceId = try await deviceIdentifier.id
+///     print("Device ID: \(deviceId)")
+///
+///     return deviceId
+/// }
 /// ```
 public actor DefaultDeviceIdentifier: DeviceIdentifier, Sendable {
     /// Configuration for the device identifier
@@ -213,7 +239,10 @@ public actor DefaultDeviceIdentifier: DeviceIdentifier, Sendable {
     /// Attempts to migrate a legacy device identifier from FRAuth SDK format
     /// - Returns: The legacy identifier if found and successfully migrated, otherwise nil
     private func migrateLegacyIdentifier() async throws -> String? {
-        let legacyIdentifier = LegacyDeviceIdentifier(logger: logger)
+        let legacyIdentifier = LegacyDeviceIdentifier(
+            accessGroup: configuration.legacyKeychainAccessGroup,
+            logger: logger
+        )
         
         // First try direct retrieval of the identifier string
         if let legacyId = try await legacyIdentifier.getLegacyIdentifier() {

--- a/DeviceId/DeviceId/DefaultDeviceIdentifier.swift
+++ b/DeviceId/DeviceId/DefaultDeviceIdentifier.swift
@@ -193,9 +193,9 @@ public actor DefaultDeviceIdentifier: DeviceIdentifier, Sendable {
             logger?.d("No legacy identifier found, will generate new one")
         } catch {
             // Migration found a legacy ID but failed to store it in new format
-            // Log the error but continue - user experience is more important than preserving legacy ID
-            logger?.e("Failed to migrate legacy device identifier. Will generate a new one instead.", error: error)
-            // Fall through to generate a new identifier
+            // Log the error and continue with generating a new identifier
+            logger?.e("Failed to migrate legacy device identifier, will generate new one instead", error: error)
+            // Fall through to generation step below
         }
         
         // 3. Keychain is empty and no legacy identifier, so generate a new key pair
@@ -215,19 +215,20 @@ public actor DefaultDeviceIdentifier: DeviceIdentifier, Sendable {
     private func migrateLegacyIdentifier() async throws -> String? {
         let legacyIdentifier = LegacyDeviceIdentifier(logger: logger)
         
-        // First try direct retrieval using raw keychain queries
+        // First try direct retrieval of the identifier string
         if let legacyId = try await legacyIdentifier.getLegacyIdentifier() {
-            logger?.i("Found legacy identifier via direct keychain query")
-            // Store in new format
-            try await storeLegacyIdentifierInNewFormat(legacyId)
+            logger?.i("Found legacy identifier string via direct keychain query")
+            // Store in new format with empty key pair (identifier only)
+            try await storeLegacyIdentifierInNewFormat(legacyId, keyPair: nil)
             return legacyId
         }
         
-        // If direct retrieval failed, try regenerating from public key
-        if let regeneratedId = try await legacyIdentifier.migrateLegacyIdentifierFromPublicKey() {
-            logger?.i("Regenerated legacy identifier from public key data")
-            try await storeLegacyIdentifierInNewFormat(regeneratedId)
-            return regeneratedId
+        // If direct retrieval failed, try migrating the full key pair from system keychain
+        if let migration = try await legacyIdentifier.migrateLegacyKeyPair() {
+            logger?.i("Successfully migrated legacy key pair from system keychain")
+            // Store both the identifier and the actual key pair data
+            try await storeLegacyIdentifierInNewFormat(migration.identifier, keyPair: migration.keyPair)
+            return migration.identifier
         }
         
         logger?.d("No legacy identifier found to migrate")
@@ -235,13 +236,24 @@ public actor DefaultDeviceIdentifier: DeviceIdentifier, Sendable {
     }
     
     /// Stores the legacy identifier in the new DeviceIdentifierImpl format
-    /// - Parameter legacyId: The legacy identifier to store
-    private func storeLegacyIdentifierInNewFormat(_ legacyId: String) async throws {
+    /// - Parameters:
+    ///   - legacyId: The legacy identifier to store
+    ///   - keyPair: Optional key pair data (if available from system keychain migration)
+    private func storeLegacyIdentifierInNewFormat(_ legacyId: String, keyPair: DeviceIdentifierKeyPair?) async throws {
         logger?.i("Storing migrated legacy identifier in new format")
-        // Create a special DeviceIdentifierImpl that wraps the legacy identifier
-        // We'll use empty key data since the legacy system only stored the final hash
-        let emptyKeyPair = DeviceIdentifierKeyPair(privateKey: Data(), publicKey: Data())
-        let impl = DeviceIdentifierImpl(deviceIdentifierKeyPair: emptyKeyPair, legacyIdentifier: legacyId)
+        
+        let finalKeyPair: DeviceIdentifierKeyPair
+        if let keyPair = keyPair {
+            // We have the actual key pair from legacy system keychain
+            logger?.i("Storing with migrated key pair (public: \(keyPair.publicKey.count) bytes, private: \(keyPair.privateKey?.count ?? 0) bytes)")
+            finalKeyPair = keyPair
+        } else {
+            // We only have the identifier string, use empty key data
+            logger?.i("Storing identifier only (no key pair available)")
+            finalKeyPair = DeviceIdentifierKeyPair(privateKey: Data(), publicKey: Data())
+        }
+        
+        let impl = DeviceIdentifierImpl(deviceIdentifierKeyPair: finalKeyPair, legacyIdentifier: legacyId)
         try await keychainService.save(item: impl)
     }
     

--- a/DeviceId/DeviceId/DefaultDeviceIdentifier.swift
+++ b/DeviceId/DeviceId/DefaultDeviceIdentifier.swift
@@ -2,7 +2,7 @@
 //  DefaultDeviceIdentifier.swift
 //  DeviceId
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -106,6 +106,7 @@ public actor DefaultDeviceIdentifier: DeviceIdentifier, Sendable {
     
     /// Asynchronously regenerates the device identifier by deleting the existing keychain item.
     /// This method cancels any ongoing generation task and clears the cache.
+    /// Also clears any legacy identifier storage to ensure a completely new identifier is generated.
     /// - Throws: `DeviceIdentifierError` if keychain operations fail.
     /// - Returns: The new unique identifier for the device.
     public func regenerateIdentifier() async throws -> String {
@@ -115,7 +116,21 @@ public actor DefaultDeviceIdentifier: DeviceIdentifier, Sendable {
         generationTask = nil
         
         clearCache()
+        
+        // Delete from new storage
         try await keychainService.delete()
+        
+        // Also delete from legacy storage to ensure clean regeneration
+        let legacyStorage = LegacyDeviceIdentifier.createLegacyStorage(logger: logger)
+        try? await legacyStorage.delete()
+        
+        // Delete legacy public key storage as well
+        let legacyPublicKeyStorage = KeychainStorage<Data>(
+            account: "com.forgerock.ios.device-identifier.pubic-key.data",
+            encryptor: NoEncryptor()
+        )
+        try? await legacyPublicKeyStorage.delete()
+        
         return try await self.id
     }
     
@@ -132,16 +147,57 @@ public actor DefaultDeviceIdentifier: DeviceIdentifier, Sendable {
             return id
         }
         
-        // 2. Keychain is empty, so generate a new key pair
+        // 2. Check for legacy device identifier before generating new one
+        logger?.i("Checking for legacy device identifier")
+        if let legacyId = try await migrateLegacyIdentifier() {
+            logger?.i("Successfully migrated legacy device identifier")
+            cachedId = legacyId
+            return legacyId
+        }
+        
+        // 3. Keychain is empty and no legacy identifier, so generate a new key pair
         logger?.i("Generating new device identifier key pair")
         let keyPair = try await generateKeyPair()
         
-        // 3. Persist and cache the new identifier
+        // 4. Persist and cache the new identifier
         let impl = DeviceIdentifierImpl(deviceIdentifierKeyPair: keyPair)
         try await keychainService.save(item: impl)
         let identifier = try await impl.id
         cachedId = identifier // Cache the result
         return identifier
+    }
+    
+    /// Attempts to migrate a legacy device identifier from FRAuth SDK format
+    /// - Returns: The legacy identifier if found and successfully migrated, otherwise nil
+    private func migrateLegacyIdentifier() async throws -> String? {
+        let legacyStorage = LegacyDeviceIdentifier.createLegacyStorage(logger: logger)
+        let legacyIdentifier = LegacyDeviceIdentifier(keychainService: legacyStorage, logger: logger)
+        
+        // First try direct retrieval
+        if let legacyId = try await legacyIdentifier.getLegacyIdentifier() {
+            // Store in new format
+            try await storeLegacyIdentifierInNewFormat(legacyId)
+            return legacyId
+        }
+        
+        // If direct retrieval failed, try regenerating from public key
+        if let regeneratedId = try await legacyIdentifier.migrateLegacyIdentifierFromPublicKey() {
+            try await storeLegacyIdentifierInNewFormat(regeneratedId)
+            return regeneratedId
+        }
+        
+        return nil
+    }
+    
+    /// Stores the legacy identifier in the new DeviceIdentifierImpl format
+    /// - Parameter legacyId: The legacy identifier to store
+    private func storeLegacyIdentifierInNewFormat(_ legacyId: String) async throws {
+        logger?.i("Storing migrated legacy identifier in new format")
+        // Create a special DeviceIdentifierImpl that wraps the legacy identifier
+        // We'll use empty key data since the legacy system only stored the final hash
+        let emptyKeyPair = DeviceIdentifierKeyPair(privateKey: Data(), publicKey: Data())
+        let impl = DeviceIdentifierImpl(deviceIdentifierKeyPair: emptyKeyPair, legacyIdentifier: legacyId)
+        try await keychainService.save(item: impl)
     }
     
     /// Asynchronously generates a key pair on a background task.

--- a/DeviceId/DeviceId/DefaultDeviceIdentifier.swift
+++ b/DeviceId/DeviceId/DefaultDeviceIdentifier.swift
@@ -120,18 +120,52 @@ public actor DefaultDeviceIdentifier: DeviceIdentifier, Sendable {
         // Delete from new storage
         try await keychainService.delete()
         
-        // Also delete from legacy storage to ensure clean regeneration
-        let legacyStorage = LegacyDeviceIdentifier.createLegacyStorage(logger: logger)
-        try? await legacyStorage.delete()
-        
-        // Delete legacy public key storage as well
-        let legacyPublicKeyStorage = KeychainStorage<Data>(
-            account: "com.forgerock.ios.device-identifier.pubic-key.data",
-            encryptor: NoEncryptor()
-        )
-        try? await legacyPublicKeyStorage.delete()
+        // Delete from legacy storage using direct keychain calls
+        await deleteLegacyIdentifiers()
         
         return try await self.id
+    }
+    
+    /// Deletes legacy identifiers from keychain
+    private func deleteLegacyIdentifiers() async {
+        // Delete legacy identifier
+        let identifierQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: LegacyDeviceIdentifier.LegacyKeychainKeys.identifier
+        ]
+        
+        let identifierStatus = SecItemDelete(identifierQuery as CFDictionary)
+        if identifierStatus == errSecSuccess {
+            logger?.i("Deleted legacy identifier")
+        } else if identifierStatus != errSecItemNotFound {
+            logger?.w("Failed to delete legacy identifier. Status: \(identifierStatus)", error: nil)
+        }
+        
+        // Delete legacy public key data
+        let publicKeyQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: LegacyDeviceIdentifier.LegacyKeychainKeys.publicKeyData
+        ]
+        
+        let publicKeyStatus = SecItemDelete(publicKeyQuery as CFDictionary)
+        if publicKeyStatus == errSecSuccess {
+            logger?.i("Deleted legacy public key data")
+        } else if publicKeyStatus != errSecItemNotFound {
+            logger?.w("Failed to delete legacy public key data. Status: \(publicKeyStatus)", error: nil)
+        }
+        
+        // Delete legacy private key data (if it exists)
+        let privateKeyQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: LegacyDeviceIdentifier.LegacyKeychainKeys.privateKeyData
+        ]
+        
+        let privateKeyStatus = SecItemDelete(privateKeyQuery as CFDictionary)
+        if privateKeyStatus == errSecSuccess {
+            logger?.i("Deleted legacy private key data")
+        } else if privateKeyStatus != errSecItemNotFound {
+            logger?.w("Failed to delete legacy private key data. Status: \(privateKeyStatus)", error: nil)
+        }
     }
     
     /// Performs the logic of getting an ID from keychain or generating a new one.
@@ -149,10 +183,19 @@ public actor DefaultDeviceIdentifier: DeviceIdentifier, Sendable {
         
         // 2. Check for legacy device identifier before generating new one
         logger?.i("Checking for legacy device identifier")
-        if let legacyId = try await migrateLegacyIdentifier() {
-            logger?.i("Successfully migrated legacy device identifier")
-            cachedId = legacyId
-            return legacyId
+        do {
+            if let legacyId = try await migrateLegacyIdentifier() {
+                logger?.i("Successfully migrated legacy device identifier")
+                cachedId = legacyId
+                return legacyId
+            }
+            // No legacy identifier found, continue to generation
+            logger?.d("No legacy identifier found, will generate new one")
+        } catch {
+            // Migration found a legacy ID but failed to store it in new format
+            // Log the error but continue - user experience is more important than preserving legacy ID
+            logger?.e("Failed to migrate legacy device identifier. Will generate a new one instead.", error: error)
+            // Fall through to generate a new identifier
         }
         
         // 3. Keychain is empty and no legacy identifier, so generate a new key pair
@@ -170,11 +213,11 @@ public actor DefaultDeviceIdentifier: DeviceIdentifier, Sendable {
     /// Attempts to migrate a legacy device identifier from FRAuth SDK format
     /// - Returns: The legacy identifier if found and successfully migrated, otherwise nil
     private func migrateLegacyIdentifier() async throws -> String? {
-        let legacyStorage = LegacyDeviceIdentifier.createLegacyStorage(logger: logger)
-        let legacyIdentifier = LegacyDeviceIdentifier(keychainService: legacyStorage, logger: logger)
+        let legacyIdentifier = LegacyDeviceIdentifier(logger: logger)
         
-        // First try direct retrieval
+        // First try direct retrieval using raw keychain queries
         if let legacyId = try await legacyIdentifier.getLegacyIdentifier() {
+            logger?.i("Found legacy identifier via direct keychain query")
             // Store in new format
             try await storeLegacyIdentifierInNewFormat(legacyId)
             return legacyId
@@ -182,10 +225,12 @@ public actor DefaultDeviceIdentifier: DeviceIdentifier, Sendable {
         
         // If direct retrieval failed, try regenerating from public key
         if let regeneratedId = try await legacyIdentifier.migrateLegacyIdentifierFromPublicKey() {
+            logger?.i("Regenerated legacy identifier from public key data")
             try await storeLegacyIdentifierInNewFormat(regeneratedId)
             return regeneratedId
         }
         
+        logger?.d("No legacy identifier found to migrate")
         return nil
     }
     

--- a/DeviceId/DeviceId/DeviceIdentifier.swift
+++ b/DeviceId/DeviceId/DeviceIdentifier.swift
@@ -2,7 +2,7 @@
 //  DeviceIdentifier.swift
 //  DeviceId
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -73,17 +73,29 @@ public struct DeviceIdentifierConfiguration : Sendable {
 public final class DeviceIdentifierImpl: DeviceIdentifier, Codable, Sendable {
     /// The key pair used for device identification, containing both private and public keys.
     let deviceIdentifierKeyPair: DeviceIdentifierKeyPair
+    /// An optional legacy identifier, used for migration from older versions.
+    let legacyIdentifier: String?
+    
     /// The unique identifier for the device, computed as a SHA-256 hash of the public key.
     public var id: String {
         get async throws {
+            // If this is a migrated legacy identifier, return it directly
+            if let legacy = legacyIdentifier {
+                return legacy
+            }
             // Hashing is synchronous, so this never actually suspends or throws,
             // but it satisfies the protocol requirement exactly.
-            hashSHA256AndTransformToHex(deviceIdentifierKeyPair.publicKey)
+            return hashSHA256AndTransformToHex(deviceIdentifierKeyPair.publicKey)
         }
     }
+    
     /// Initializes a new instance of `DeviceIdentifierImpl`.
-    public init(deviceIdentifierKeyPair: DeviceIdentifierKeyPair) {
+    /// - Parameters:
+    ///   - deviceIdentifierKeyPair: The key pair for the device identifier.
+    ///   - legacyIdentifier: An optional legacy identifier for migration purposes. Defaults to `nil`.
+    public init(deviceIdentifierKeyPair: DeviceIdentifierKeyPair, legacyIdentifier: String? = nil) {
         self.deviceIdentifierKeyPair = deviceIdentifierKeyPair
+        self.legacyIdentifier = legacyIdentifier
     }
 }
 

--- a/DeviceId/DeviceId/DeviceIdentifier.swift
+++ b/DeviceId/DeviceId/DeviceIdentifier.swift
@@ -47,6 +47,10 @@ public struct DeviceIdentifierConfiguration : Sendable {
     public let keychainAccount: String
     /// Whether to use encryption for keychain storage
     public let useEncryption: Bool
+    /// Optional keychain access group used by the legacy SDK for migration purposes.
+    /// If your app used a custom keychain access group with the legacy FRAuth SDK,
+    /// specify it here to enable migration of the legacy device identifier.
+    public let legacyKeychainAccessGroup: String?
     
     /// Default configuration
     public static let `default` = DeviceIdentifierConfiguration(
@@ -62,10 +66,11 @@ public struct DeviceIdentifierConfiguration : Sendable {
         useEncryption: true
     )
     
-    public init(keySize: Int, keychainAccount: String, useEncryption: Bool = true) {
+    public init(keySize: Int, keychainAccount: String, useEncryption: Bool = true, legacyKeychainAccessGroup: String? = nil) {
         self.keySize = keySize
         self.keychainAccount = keychainAccount
         self.useEncryption = useEncryption
+        self.legacyKeychainAccessGroup = legacyKeychainAccessGroup
     }
 }
 

--- a/DeviceId/DeviceId/LegacyDeviceIdentifier.swift
+++ b/DeviceId/DeviceId/LegacyDeviceIdentifier.swift
@@ -16,42 +16,68 @@ import PingStorage
 /// Legacy device identifier retrieval from FRAuth SDK format.
 /// This class handles migration from the old FRDeviceIdentifier format to the new DeviceId module format.
 internal actor LegacyDeviceIdentifier {
-    /// Legacy keychain key for the identifier
-    private static let legacyIdentifierKey = "com.forgerock.ios.device-identifier.hash-base64-string-identifier"
-    /// Legacy keychain key for public key data
-    private static let legacyPublicKeyDataKey = "com.forgerock.ios.device-identifier.pubic-key.data"
     
-    private let keychainService: any Storage<String>
+    // MARK: - Legacy Keychain Constants
+    
+    /// Legacy keychain keys from FRAuth SDK
+    enum LegacyKeychainKeys {
+        /// Legacy keychain key for the identifier
+        static let identifier = "com.forgerock.ios.device-identifier.hash-base64-string-identifier"
+        /// Legacy keychain key for public key data
+        static let publicKeyData = "com.forgerock.ios.device-identifier.pubic-key.data"
+        /// Legacy keychain key for private key data
+        static let privateKeyData = "com.forgerock.ios.device-identifier.private-key.data"
+    }
+    
     private let logger: Logger?
     
     /// Initializes the legacy device identifier retriever
     /// - Parameters:
-    ///   - keychainService: Storage service to access legacy keychain items
     ///   - logger: Optional logger for diagnostic messages
-    init(keychainService: any Storage<String>, logger: Logger? = nil) {
-        self.keychainService = keychainService
+    init(logger: Logger? = nil) {
         self.logger = logger
     }
     
-    /// Attempts to retrieve the legacy device identifier
+    /// Attempts to retrieve the legacy device identifier directly from keychain
+    /// Uses raw Security framework queries to match FRAuth SDK's KeychainService behavior
     /// - Returns: The legacy identifier if it exists, otherwise nil
     func getLegacyIdentifier() async throws -> String? {
-        logger?.i("Checking for legacy device identifier")
+        logger?.i("Checking for legacy device identifier using direct keychain query")
         
-        // First try to get the stored identifier directly
-        if let identifier = try await keychainService.get() {
-            logger?.i("Found legacy device identifier in keychain")
-            return identifier
-        }
-        
-        logger?.d("No legacy device identifier found")
-        return nil
+        return await Task.detached { () -> String? in
+            // Build query matching FRAuth SDK's KeychainService
+            var query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrAccount as String: LegacyKeychainKeys.identifier,
+                kSecReturnData as String: true,
+                kSecMatchLimit as String: kSecMatchLimitOne
+            ]
+            
+            // Add access group if available (same as FRAuth SDK would use)
+            if let accessGroup = await self.getKeychainAccessGroup() {
+                query[kSecAttrAccessGroup as String] = accessGroup
+            }
+            
+            var result: AnyObject?
+            let status = SecItemCopyMatching(query as CFDictionary, &result)
+            
+            if status == errSecSuccess, let data = result as? Data, let identifier = String(data: data, encoding: .utf8) {
+                self.logger?.i("Found legacy device identifier in keychain")
+                return identifier
+            } else if status == errSecItemNotFound {
+                self.logger?.d("No legacy device identifier found (errSecItemNotFound)")
+                return nil
+            } else {
+                self.logger?.w("Failed to retrieve legacy identifier. Status: \(status)", error: nil)
+                return nil
+            }
+        }.value
     }
     
     /// Creates a legacy keychain storage instance
     /// - Parameter account: Keychain account (typically the legacy identifier key)
     /// - Returns: Storage instance configured for legacy keychain access
-    static func createLegacyStorage(account: String = legacyIdentifierKey, logger: Logger? = nil) -> any Storage<String> {
+    static func createLegacyStorage(account: String = LegacyKeychainKeys.identifier, logger: Logger? = nil) -> any Storage<String> {
         return KeychainStorage<String>(
             account: account,
             encryptor: NoEncryptor()
@@ -64,24 +90,93 @@ internal actor LegacyDeviceIdentifier {
     func migrateLegacyIdentifierFromPublicKey() async throws -> String? {
         logger?.i("Attempting to regenerate legacy identifier from public key data")
         
-        // Create storage for public key data
-        let publicKeyStorage = KeychainStorage<Data>(
-            account: Self.legacyPublicKeyDataKey,
-            encryptor: NoEncryptor()
-        )
-        
-        guard let keyData = try await publicKeyStorage.get() else {
-            logger?.d("No legacy public key data found")
-            return nil
-        }
-        
-        logger?.i("Found legacy public key data, regenerating identifier")
-        let identifier = hashAndBase64Data(keyData)
-        
-        // Store the regenerated identifier for future retrievals
-        try await keychainService.save(item: identifier)
-        
-        return identifier
+        return await Task.detached { () -> String? in
+            // Build query for legacy public key data
+            var query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrAccount as String: LegacyKeychainKeys.publicKeyData,
+                kSecReturnData as String: true,
+                kSecMatchLimit as String: kSecMatchLimitOne
+            ]
+            
+            // Add access group if available
+            if let accessGroup = await self.getKeychainAccessGroup() {
+                query[kSecAttrAccessGroup as String] = accessGroup
+            }
+            
+            var result: AnyObject?
+            let status = SecItemCopyMatching(query as CFDictionary, &result)
+            
+            guard status == errSecSuccess, let keyData = result as? Data else {
+                if status == errSecItemNotFound {
+                    self.logger?.d("No legacy public key data found")
+                } else {
+                    self.logger?.w("Failed to retrieve legacy public key. Status: \(status)", error: nil)
+                }
+                return nil
+            }
+            
+            self.logger?.i("Found legacy public key data, regenerating identifier")
+            let identifier = await self.hashAndBase64Data(keyData)
+            
+            // Store the regenerated identifier using raw keychain for consistency
+            await self.saveLegacyIdentifier(identifier)
+            
+            return identifier
+        }.value
+    }
+    
+    /// Saves the legacy identifier to keychain using direct Security framework calls
+    /// - Parameter identifier: The identifier to save
+    private func saveLegacyIdentifier(_ identifier: String) async {
+        await Task.detached {
+            guard let data = identifier.data(using: .utf8) else {
+                self.logger?.e("Failed to encode identifier as UTF-8", error: nil)
+                return
+            }
+            
+            var query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrAccount as String: LegacyKeychainKeys.identifier,
+                kSecValueData as String: data,
+                kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            ]
+            
+            if let accessGroup = await self.getKeychainAccessGroup() {
+                query[kSecAttrAccessGroup as String] = accessGroup
+            }
+            
+            // Try to add, if it exists, update it
+            var status = SecItemAdd(query as CFDictionary, nil)
+            
+            if status == errSecDuplicateItem {
+                let updateQuery: [String: Any] = [
+                    kSecClass as String: kSecClassGenericPassword,
+                    kSecAttrAccount as String: LegacyKeychainKeys.identifier
+                ]
+                let updateAttributes: [String: Any] = [
+                    kSecValueData as String: data
+                ]
+                status = SecItemUpdate(updateQuery as CFDictionary, updateAttributes as CFDictionary)
+            }
+            
+            if status != errSecSuccess {
+                self.logger?.w("Failed to save regenerated legacy identifier. Status: \(status)", error: nil)
+            } else {
+                self.logger?.i("Successfully saved regenerated legacy identifier")
+            }
+        }.value
+    }
+    
+    /// Gets the keychain access group if configured
+    /// This should match the access group used by FRAuth SDK
+    /// - Returns: Access group string if available
+    private func getKeychainAccessGroup() -> String? {
+        // Check if there's a configured access group in the app's entitlements
+        // FRAuth SDK would use the first access group from keychain-access-groups
+        // For now, return nil to search in the default group
+        // This can be enhanced to read from configuration if needed
+        return nil
     }
     
     /// Hashes given Data using SHA1 and returns hex string
@@ -93,7 +188,6 @@ internal actor LegacyDeviceIdentifier {
         data.withUnsafeBytes {
             _ = CC_SHA1($0.baseAddress, CC_LONG(data.count), &digest)
         }
-        // Inline hex conversion to avoid extension conflicts
         let hashData = Data(bytes: digest, count: digest.count)
         return hashData.toHexString()
     }

--- a/DeviceId/DeviceId/LegacyDeviceIdentifier.swift
+++ b/DeviceId/DeviceId/LegacyDeviceIdentifier.swift
@@ -27,14 +27,21 @@ internal actor LegacyDeviceIdentifier {
         static let publicKeyData = "com.forgerock.ios.device-identifier.pubic-key.data"
         /// Legacy keychain key for private key data
         static let privateKeyData = "com.forgerock.ios.device-identifier.private-key.data"
+        /// Legacy keychain tag for public key in system keychain
+        static let publicKeyTag = "com.forgerock.ios.device-identifier.public-key"
+        /// Legacy keychain tag for private key in system keychain
+        static let privateKeyTag = "com.forgerock.ios.device-identifier.private-key"
     }
     
     private let logger: Logger?
+    private let accessGroup: String?
     
     /// Initializes the legacy device identifier retriever
     /// - Parameters:
+    ///   - accessGroup: Optional keychain access group used by the legacy SDK
     ///   - logger: Optional logger for diagnostic messages
-    init(logger: Logger? = nil) {
+    init(accessGroup: String? = nil, logger: Logger? = nil) {
+        self.accessGroup = accessGroup
         self.logger = logger
     }
     
@@ -44,7 +51,7 @@ internal actor LegacyDeviceIdentifier {
     func getLegacyIdentifier() async throws -> String? {
         logger?.i("Checking for legacy device identifier using direct keychain query")
         
-        return await Task.detached { () -> String? in
+        return await Task.detached { [accessGroup, logger] () -> String? in
             // Build query matching FRAuth SDK's KeychainService
             var query: [String: Any] = [
                 kSecClass as String: kSecClassGenericPassword,
@@ -53,22 +60,23 @@ internal actor LegacyDeviceIdentifier {
                 kSecMatchLimit as String: kSecMatchLimitOne
             ]
             
-            // Add access group if available (same as FRAuth SDK would use)
-            if let accessGroup = await self.getKeychainAccessGroup() {
+            // Add access group if specified
+            if let accessGroup = accessGroup {
                 query[kSecAttrAccessGroup as String] = accessGroup
+                logger?.i("Using legacy keychain access group: \(accessGroup)")
             }
             
             var result: AnyObject?
             let status = SecItemCopyMatching(query as CFDictionary, &result)
             
             if status == errSecSuccess, let data = result as? Data, let identifier = String(data: data, encoding: .utf8) {
-                self.logger?.i("Found legacy device identifier in keychain")
+                logger?.i("Found legacy device identifier in keychain")
                 return identifier
             } else if status == errSecItemNotFound {
-                self.logger?.d("No legacy device identifier found (errSecItemNotFound)")
+                logger?.d("No legacy device identifier found (errSecItemNotFound)")
                 return nil
             } else {
-                self.logger?.w("Failed to retrieve legacy identifier. Status: \(status)", error: nil)
+                logger?.w("Failed to retrieve legacy identifier. Status: \(status)", error: nil)
                 return nil
             }
         }.value
@@ -79,8 +87,8 @@ internal actor LegacyDeviceIdentifier {
     func migrateLegacyKeyPair() async throws -> (identifier: String, keyPair: DeviceIdentifierKeyPair)? {
         logger?.i("Attempting to migrate legacy RSA key pair from system keychain")
         
-        let publicKeyTag = "com.forgerock.ios.device-identifier.public-key".data(using: .utf8)!
-        let privateKeyTag = "com.forgerock.ios.device-identifier.private-key".data(using: .utf8)!
+        let publicKeyTag = LegacyKeychainKeys.publicKeyTag.data(using: .utf8)!
+        let privateKeyTag = LegacyKeychainKeys.privateKeyTag.data(using: .utf8)!
         
         // Query for public key
         let publicKeyQuery: [String: Any] = [
@@ -159,17 +167,6 @@ internal actor LegacyDeviceIdentifier {
         if let migration = try await migrateLegacyKeyPair() {
             return migration.identifier
         }
-        return nil
-    }
-    
-    /// Gets the keychain access group if configured
-    /// This should match the access group used by FRAuth SDK
-    /// - Returns: Access group string if available
-    private func getKeychainAccessGroup() -> String? {
-        // Check if there's a configured access group in the app's entitlements
-        // FRAuth SDK would use the first access group from keychain-access-groups
-        // For now, return nil to search in the default group
-        // This can be enhanced to read from configuration if needed
         return nil
     }
     

--- a/DeviceId/DeviceId/LegacyDeviceIdentifier.swift
+++ b/DeviceId/DeviceId/LegacyDeviceIdentifier.swift
@@ -179,16 +179,16 @@ internal actor LegacyDeviceIdentifier {
         return nil
     }
     
-    /// Hashes given Data using SHA1 and returns hex string
+    /// Hashes given Data using SHA1 and returns base64-encoded string
     /// This matches the legacy FRDeviceIdentifier hashing behavior
     /// - Parameter data: Data to be hashed
-    /// - Returns: Hashed hex string of given Data
+    /// - Returns: Base64-encoded string of the SHA1 hash
     private func hashAndBase64Data(_ data: Data) -> String {
         var digest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
         data.withUnsafeBytes {
             _ = CC_SHA1($0.baseAddress, CC_LONG(data.count), &digest)
         }
         let hashData = Data(bytes: digest, count: digest.count)
-        return hashData.toHexString()
+        return hashData.base64EncodedString()
     }
 }

--- a/DeviceId/DeviceId/LegacyDeviceIdentifier.swift
+++ b/DeviceId/DeviceId/LegacyDeviceIdentifier.swift
@@ -179,16 +179,16 @@ internal actor LegacyDeviceIdentifier {
         return nil
     }
     
-    /// Hashes given Data using SHA1 and returns base64-encoded string
+    /// Hashes given Data using SHA1 and returns hex string
     /// This matches the legacy FRDeviceIdentifier hashing behavior
     /// - Parameter data: Data to be hashed
-    /// - Returns: Base64-encoded string of the SHA1 hash
+    /// - Returns: Hex-encoded string of the SHA1 hash (40 characters)
     private func hashAndBase64Data(_ data: Data) -> String {
         var digest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
         data.withUnsafeBytes {
             _ = CC_SHA1($0.baseAddress, CC_LONG(data.count), &digest)
         }
         let hashData = Data(bytes: digest, count: digest.count)
-        return hashData.base64EncodedString()
+        return hashData.toHexString()
     }
 }

--- a/DeviceId/DeviceId/LegacyDeviceIdentifier.swift
+++ b/DeviceId/DeviceId/LegacyDeviceIdentifier.swift
@@ -74,98 +74,92 @@ internal actor LegacyDeviceIdentifier {
         }.value
     }
     
-    /// Creates a legacy keychain storage instance
-    /// - Parameter account: Keychain account (typically the legacy identifier key)
-    /// - Returns: Storage instance configured for legacy keychain access
-    static func createLegacyStorage(account: String = LegacyKeychainKeys.identifier, logger: Logger? = nil) -> any Storage<String> {
-        return KeychainStorage<String>(
-            account: account,
-            encryptor: NoEncryptor()
-        )
-    }
-    
-    /// Attempts to migrate legacy identifier by regenerating it from public key data if needed
-    /// This handles the case where the identifier exists but may need regeneration
-    /// - Returns: The migrated identifier if successful, otherwise nil
-    func migrateLegacyIdentifierFromPublicKey() async throws -> String? {
-        logger?.i("Attempting to regenerate legacy identifier from public key data")
+    /// Attempts to migrate legacy RSA key pair from system keychain
+    /// - Returns: A tuple containing the legacy identifier and key pair data if found, otherwise nil
+    func migrateLegacyKeyPair() async throws -> (identifier: String, keyPair: DeviceIdentifierKeyPair)? {
+        logger?.i("Attempting to migrate legacy RSA key pair from system keychain")
         
-        return await Task.detached { () -> String? in
-            // Build query for legacy public key data
-            var query: [String: Any] = [
-                kSecClass as String: kSecClassGenericPassword,
-                kSecAttrAccount as String: LegacyKeychainKeys.publicKeyData,
-                kSecReturnData as String: true,
-                kSecMatchLimit as String: kSecMatchLimitOne
-            ]
-            
-            // Add access group if available
-            if let accessGroup = await self.getKeychainAccessGroup() {
-                query[kSecAttrAccessGroup as String] = accessGroup
+        let publicKeyTag = "com.forgerock.ios.device-identifier.public-key".data(using: .utf8)!
+        let privateKeyTag = "com.forgerock.ios.device-identifier.private-key".data(using: .utf8)!
+        
+        // Query for public key
+        let publicKeyQuery: [String: Any] = [
+            kSecClass as String: kSecClassKey,
+            kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
+            kSecAttrApplicationTag as String: publicKeyTag,
+            kSecReturnRef as String: true
+        ]
+        
+        var publicKeyResult: AnyObject?
+        let publicKeyStatus = SecItemCopyMatching(publicKeyQuery as CFDictionary, &publicKeyResult)
+        
+        guard publicKeyStatus == errSecSuccess, let publicSecKey = publicKeyResult as! SecKey? else {
+            if publicKeyStatus == errSecItemNotFound {
+                logger?.d("No legacy public key found in system keychain")
+            } else {
+                logger?.w("Failed to query for legacy public key. Status: \(publicKeyStatus)", error: nil)
             }
+            return nil
+        }
+        
+        logger?.i("Found legacy RSA public key in system keychain")
+        
+        // Export public key
+        var publicError: Unmanaged<CFError>?
+        guard let publicKeyData = SecKeyCopyExternalRepresentation(publicSecKey, &publicError) as Data? else {
+            logger?.e("Could not export legacy public key", error: publicError?.takeRetainedValue())
+            return nil
+        }
+        
+        logger?.i("Exported legacy public key: \(publicKeyData.count) bytes")
+        
+        // Query for private key
+        let privateKeyQuery: [String: Any] = [
+            kSecClass as String: kSecClassKey,
+            kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
+            kSecAttrApplicationTag as String: privateKeyTag,
+            kSecReturnRef as String: true
+        ]
+        
+        var privateKeyResult: AnyObject?
+        let privateKeyStatus = SecItemCopyMatching(privateKeyQuery as CFDictionary, &privateKeyResult)
+        
+        var privateKeyData: Data?
+        if privateKeyStatus == errSecSuccess, let privateSecKey = privateKeyResult as! SecKey? {
+            logger?.i("Found legacy RSA private key in system keychain")
             
-            var result: AnyObject?
-            let status = SecItemCopyMatching(query as CFDictionary, &result)
-            
-            guard status == errSecSuccess, let keyData = result as? Data else {
-                if status == errSecItemNotFound {
-                    self.logger?.d("No legacy public key data found")
-                } else {
-                    self.logger?.w("Failed to retrieve legacy public key. Status: \(status)", error: nil)
-                }
-                return nil
+            var privateError: Unmanaged<CFError>?
+            if let exportedPrivateKey = SecKeyCopyExternalRepresentation(privateSecKey, &privateError) as Data? {
+                privateKeyData = exportedPrivateKey
+                logger?.i("Exported legacy private key: \(exportedPrivateKey.count) bytes")
+            } else {
+                logger?.w("Could not export legacy private key, continuing with public key only", error: privateError?.takeRetainedValue())
             }
-            
-            self.logger?.i("Found legacy public key data, regenerating identifier")
-            let identifier = await self.hashAndBase64Data(keyData)
-            
-            // Store the regenerated identifier using raw keychain for consistency
-            await self.saveLegacyIdentifier(identifier)
-            
-            return identifier
-        }.value
+        } else {
+            logger?.d("No legacy private key found in system keychain (Status: \(privateKeyStatus))")
+        }
+        
+        // Generate identifier from public key (matching FRAuth SDK)
+        let identifier = hashAndBase64Data(publicKeyData)
+        logger?.i("Generated identifier from legacy key: \(identifier)")
+        
+        // Create key pair (private key may be nil/empty)
+        let keyPair = DeviceIdentifierKeyPair(
+            privateKey: privateKeyData,
+            publicKey: publicKeyData
+        )
+        
+        return (identifier: identifier, keyPair: keyPair)
     }
     
-    /// Saves the legacy identifier to keychain using direct Security framework calls
-    /// - Parameter identifier: The identifier to save
-    private func saveLegacyIdentifier(_ identifier: String) async {
-        await Task.detached {
-            guard let data = identifier.data(using: .utf8) else {
-                self.logger?.e("Failed to encode identifier as UTF-8", error: nil)
-                return
-            }
-            
-            var query: [String: Any] = [
-                kSecClass as String: kSecClassGenericPassword,
-                kSecAttrAccount as String: LegacyKeychainKeys.identifier,
-                kSecValueData as String: data,
-                kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
-            ]
-            
-            if let accessGroup = await self.getKeychainAccessGroup() {
-                query[kSecAttrAccessGroup as String] = accessGroup
-            }
-            
-            // Try to add, if it exists, update it
-            var status = SecItemAdd(query as CFDictionary, nil)
-            
-            if status == errSecDuplicateItem {
-                let updateQuery: [String: Any] = [
-                    kSecClass as String: kSecClassGenericPassword,
-                    kSecAttrAccount as String: LegacyKeychainKeys.identifier
-                ]
-                let updateAttributes: [String: Any] = [
-                    kSecValueData as String: data
-                ]
-                status = SecItemUpdate(updateQuery as CFDictionary, updateAttributes as CFDictionary)
-            }
-            
-            if status != errSecSuccess {
-                self.logger?.w("Failed to save regenerated legacy identifier. Status: \(status)", error: nil)
-            } else {
-                self.logger?.i("Successfully saved regenerated legacy identifier")
-            }
-        }.value
+    /// Attempts to regenerate legacy identifier from public key (for backward compatibility)
+    /// - Returns: The legacy identifier if public key is found, otherwise nil
+    func migrateLegacyIdentifierFromPublicKey() async throws -> String? {
+        // Try to migrate the full key pair first
+        if let migration = try await migrateLegacyKeyPair() {
+            return migration.identifier
+        }
+        return nil
     }
     
     /// Gets the keychain access group if configured

--- a/DeviceId/DeviceId/LegacyDeviceIdentifier.swift
+++ b/DeviceId/DeviceId/LegacyDeviceIdentifier.swift
@@ -1,0 +1,100 @@
+//
+//  LegacyDeviceIdentifier.swift
+//  DeviceId
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import Foundation
+import CommonCrypto
+import PingLogger
+import PingStorage
+
+/// Legacy device identifier retrieval from FRAuth SDK format.
+/// This class handles migration from the old FRDeviceIdentifier format to the new DeviceId module format.
+internal actor LegacyDeviceIdentifier {
+    /// Legacy keychain key for the identifier
+    private static let legacyIdentifierKey = "com.forgerock.ios.device-identifier.hash-base64-string-identifier"
+    /// Legacy keychain key for public key data
+    private static let legacyPublicKeyDataKey = "com.forgerock.ios.device-identifier.pubic-key.data"
+    
+    private let keychainService: any Storage<String>
+    private let logger: Logger?
+    
+    /// Initializes the legacy device identifier retriever
+    /// - Parameters:
+    ///   - keychainService: Storage service to access legacy keychain items
+    ///   - logger: Optional logger for diagnostic messages
+    init(keychainService: any Storage<String>, logger: Logger? = nil) {
+        self.keychainService = keychainService
+        self.logger = logger
+    }
+    
+    /// Attempts to retrieve the legacy device identifier
+    /// - Returns: The legacy identifier if it exists, otherwise nil
+    func getLegacyIdentifier() async throws -> String? {
+        logger?.i("Checking for legacy device identifier")
+        
+        // First try to get the stored identifier directly
+        if let identifier = try await keychainService.get() {
+            logger?.i("Found legacy device identifier in keychain")
+            return identifier
+        }
+        
+        logger?.d("No legacy device identifier found")
+        return nil
+    }
+    
+    /// Creates a legacy keychain storage instance
+    /// - Parameter account: Keychain account (typically the legacy identifier key)
+    /// - Returns: Storage instance configured for legacy keychain access
+    static func createLegacyStorage(account: String = legacyIdentifierKey, logger: Logger? = nil) -> any Storage<String> {
+        return KeychainStorage<String>(
+            account: account,
+            encryptor: NoEncryptor()
+        )
+    }
+    
+    /// Attempts to migrate legacy identifier by regenerating it from public key data if needed
+    /// This handles the case where the identifier exists but may need regeneration
+    /// - Returns: The migrated identifier if successful, otherwise nil
+    func migrateLegacyIdentifierFromPublicKey() async throws -> String? {
+        logger?.i("Attempting to regenerate legacy identifier from public key data")
+        
+        // Create storage for public key data
+        let publicKeyStorage = KeychainStorage<Data>(
+            account: Self.legacyPublicKeyDataKey,
+            encryptor: NoEncryptor()
+        )
+        
+        guard let keyData = try await publicKeyStorage.get() else {
+            logger?.d("No legacy public key data found")
+            return nil
+        }
+        
+        logger?.i("Found legacy public key data, regenerating identifier")
+        let identifier = hashAndBase64Data(keyData)
+        
+        // Store the regenerated identifier for future retrievals
+        try await keychainService.save(item: identifier)
+        
+        return identifier
+    }
+    
+    /// Hashes given Data using SHA1 and returns hex string
+    /// This matches the legacy FRDeviceIdentifier hashing behavior
+    /// - Parameter data: Data to be hashed
+    /// - Returns: Hashed hex string of given Data
+    private func hashAndBase64Data(_ data: Data) -> String {
+        var digest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
+        data.withUnsafeBytes {
+            _ = CC_SHA1($0.baseAddress, CC_LONG(data.count), &digest)
+        }
+        // Inline hex conversion to avoid extension conflicts
+        let hashData = Data(bytes: digest, count: digest.count)
+        return hashData.toHexString()
+    }
+}

--- a/DeviceId/DeviceIdTests/DefaultDeviceIdentifierTests.swift
+++ b/DeviceId/DeviceIdTests/DefaultDeviceIdentifierTests.swift
@@ -1,0 +1,236 @@
+//
+//  DefaultDeviceIdentifierTests.swift
+//  DeviceIdTests
+//
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+@testable import PingDeviceId
+@testable import PingStorage
+
+/// Tests for `DefaultDeviceIdentifier` core functionality
+final class DefaultDeviceIdentifierTests: XCTestCase {
+    
+    var deviceIdentifier: DefaultDeviceIdentifier!
+    
+    override func setUp() async throws {
+        try await super.setUp()
+        // Clean up any existing data
+        await cleanupKeychain()
+        
+        // Create a fresh instance for each test
+        deviceIdentifier = try DefaultDeviceIdentifier(configuration: .default)
+    }
+    
+    override func tearDown() async throws {
+        await cleanupKeychain()
+        deviceIdentifier = nil
+        try await super.tearDown()
+    }
+    
+    // MARK: - Helper Methods
+    
+    private func cleanupKeychain() async {
+        // Clean up new storage
+        let storage = KeychainStorage<DeviceIdentifierImpl>(
+            account: Constants.deviceIdentifierKey,
+            encryptor: NoEncryptor()
+        )
+        try? await storage.delete()
+        
+        // Clean up legacy storage
+        let legacyKeys = [
+            LegacyDeviceIdentifier.LegacyKeychainKeys.identifier,
+            LegacyDeviceIdentifier.LegacyKeychainKeys.publicKeyData,
+            LegacyDeviceIdentifier.LegacyKeychainKeys.privateKeyData
+        ]
+        
+        for key in legacyKeys {
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrAccount as String: key
+            ]
+            SecItemDelete(query as CFDictionary)
+        }
+    }
+    
+    // MARK: - Core Functionality Tests
+    
+    func testIdentifierGeneration_CreatesValidIdentifier() async throws {
+        // When
+        let id = try await deviceIdentifier.id
+        
+        // Then: Should be a valid SHA-256 hash (64 hex characters)
+        XCTAssertEqual(id.count, 64, "SHA-256 hash should be 64 hex characters")
+        XCTAssertTrue(id.allSatisfy { $0.isHexDigit }, "Identifier should only contain hex characters")
+    }
+    
+    func testIdentifierConsistency_ReturnsSameValueOnMultipleAccess() async throws {
+        // When
+        let id1 = try await deviceIdentifier.id
+        let id2 = try await deviceIdentifier.id
+        let id3 = try await deviceIdentifier.id
+        
+        // Then
+        XCTAssertEqual(id1, id2, "Identifier should be consistent")
+        XCTAssertEqual(id2, id3, "Identifier should be consistent")
+    }
+    
+    func testIdentifierPersistence_MaintainsAcrossInstances() async throws {
+        // Given
+        let firstId = try await deviceIdentifier.id
+        
+        // When: Creating new instance
+        deviceIdentifier = try DefaultDeviceIdentifier(configuration: .default)
+        let secondId = try await deviceIdentifier.id
+        
+        // Then
+        XCTAssertEqual(firstId, secondId, "Identifier should persist across instances")
+    }
+    
+    func testConcurrentAccess_NoDuplicateGeneration() async throws {
+        // When: Multiple concurrent access attempts
+        async let id1 = deviceIdentifier.id
+        async let id2 = deviceIdentifier.id
+        async let id3 = deviceIdentifier.id
+        async let id4 = deviceIdentifier.id
+        
+        let ids = try await [id1, id2, id3, id4]
+        
+        // Then: All should return the same identifier
+        XCTAssertEqual(Set(ids).count, 1, "Concurrent access should return same ID")
+    }
+    
+    func testClearCache_DoesNotAffectPersistedIdentifier() async throws {
+        // Given
+        let originalId = try await deviceIdentifier.id
+        
+        // When
+        deviceIdentifier.clearCache()
+        let retrievedId = try await deviceIdentifier.id
+        
+        // Then
+        XCTAssertEqual(originalId, retrievedId, "Clearing cache should not change identifier")
+    }
+    
+    func testRegenerateIdentifier_CreatesNewIdentifier() async throws {
+        // Given
+        let firstId = try await deviceIdentifier.id
+        
+        // When
+        let newId = try await deviceIdentifier.regenerateIdentifier()
+        
+        // Then
+        XCTAssertNotEqual(firstId, newId, "Regenerated ID should be different")
+        XCTAssertEqual(newId.count, 64, "New ID should be SHA-256 hash")
+        
+        // And: New ID should be persistent
+        let retrievedId = try await deviceIdentifier.id
+        XCTAssertEqual(newId, retrievedId, "Regenerated ID should be accessible")
+    }
+    
+    func testCustomConfiguration_UsesCorrectSettings() async throws {
+        // Given
+        let customConfig = DeviceIdentifierConfiguration(
+            keySize: 4096,
+            keychainAccount: "com.test.custom",
+            useEncryption: true
+        )
+        
+        // When
+        let customIdentifier = try DefaultDeviceIdentifier(configuration: customConfig)
+        let id = try await customIdentifier.id
+        
+        // Then
+        XCTAssertEqual(id.count, 64, "Should generate valid identifier with custom config")
+        
+        // Verify stored in custom account
+        let customStorage = KeychainStorage<DeviceIdentifierImpl>(
+            account: "com.test.custom",
+            encryptor: NoEncryptor()
+        )
+        let stored = try await customStorage.get()
+        XCTAssertNotNil(stored, "Should store in custom account")
+    }
+    
+    func testHighSecurityConfiguration_UsesLargerKeySize() async throws {
+        // Given
+        let secureIdentifier = try DefaultDeviceIdentifier(configuration: .highSecurity)
+        
+        // When
+        let id = try await secureIdentifier.id
+        
+        // Then
+        XCTAssertEqual(id.count, 64, "Should generate SHA-256 hash")
+        XCTAssertNotNil(id, "Should successfully generate with 4096-bit keys")
+    }
+    
+    func testEncryptionConfiguration_DisabledEncryption() async throws {
+        // Given
+        let config = DeviceIdentifierConfiguration(
+            keySize: 2048,
+            keychainAccount: "com.test.noencryption",
+            useEncryption: false
+        )
+        
+        // When
+        let identifier = try DefaultDeviceIdentifier(configuration: config)
+        let id = try await identifier.id
+        
+        // Then
+        XCTAssertNotNil(id, "Should work without encryption")
+        XCTAssertEqual(id.count, 64)
+    }
+    
+    func testCustomStorage_UsesProvidedStorage() async throws {
+        // Given
+        let mockStorage = MockStorage<DeviceIdentifierImpl>()
+        
+        // When
+        let identifier = try DefaultDeviceIdentifier(
+            configuration: .default,
+            storage: mockStorage
+        )
+        let id = try await identifier.id
+        
+        // Then
+        XCTAssertTrue(mockStorage.saveCalled, "Should use custom storage")
+        XCTAssertEqual(id.count, 64)
+    }
+}
+
+// MARK: - Mock Storage
+
+private actor MockStorage<T: Codable & Sendable>: Storage {
+    var saveCalled = false
+    var getCalled = false
+    var deleteCalled = false
+    private var stored: T?
+    
+    func save(item: T) async throws {
+        saveCalled = true
+        stored = item
+    }
+    
+    func get() async throws -> T? {
+        getCalled = true
+        return stored
+    }
+    
+    func delete() async throws {
+        deleteCalled = true
+        stored = nil
+    }
+}
+
+// MARK: - Character Extension
+
+private extension Character {
+    var isHexDigit: Bool {
+        return self.isNumber || ("a"..."f").contains(self) || ("A"..."F").contains(self)
+    }
+}

--- a/DeviceId/DeviceIdTests/LegacyDeviceIdentifierMigrationTests.swift
+++ b/DeviceId/DeviceIdTests/LegacyDeviceIdentifierMigrationTests.swift
@@ -30,44 +30,101 @@ final class LegacyDeviceIdentifierMigrationTests: XCTestCase {
     }
     
     private func cleanupKeychain() {
-        let group = DispatchGroup()
+        // Bridge async cleanup to synchronous test lifecycle
+        let semaphore = DispatchSemaphore(value: 0)
         
-        // Clean up default configuration
-        group.enter()
         Task {
-            try? await DefaultDeviceIdentifier(configuration: .default).keychainService.delete()
-            group.leave()
+            async let defaultCleanup: Void = {
+                try? await DefaultDeviceIdentifier(configuration: .default).keychainService.delete()
+            }()
+            
+            async let legacyCleanup: Void = {
+                await LegacyDeviceIdentifierMigrationTests.deleteLegacyKeychainItem(account: LegacyDeviceIdentifier.LegacyKeychainKeys.identifier)
+                await LegacyDeviceIdentifierMigrationTests.deleteLegacyKeychainItem(account: LegacyDeviceIdentifier.LegacyKeychainKeys.publicKeyData)
+                await LegacyDeviceIdentifierMigrationTests.deleteLegacyKeychainItem(account: LegacyDeviceIdentifier.LegacyKeychainKeys.privateKeyData)
+            }()
+            
+            await defaultCleanup
+            await legacyCleanup
+            semaphore.signal()
         }
         
-        // Clean up legacy storage locations
-        group.enter()
-        Task {
-            let legacyIdentifierStorage = LegacyDeviceIdentifier.createLegacyStorage()
-            try? await legacyIdentifierStorage.delete()
-            group.leave()
-        }
-        
-        group.enter()
-        Task {
-            let legacyPublicKeyStorage = KeychainStorage<Data>(
-                account: "com.forgerock.ios.device-identifier.pubic-key.data",
-                encryptor: NoEncryptor()
-            )
-            try? await legacyPublicKeyStorage.delete()
-            group.leave()
-        }
-        
-        group.wait()
+        semaphore.wait()
+    }
+    
+    /// Helper to delete legacy keychain items using raw Security framework
+    private static func deleteLegacyKeychainItem(account: String) async {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+    
+    /// Helper to save legacy keychain item using raw Security framework (simulating FRAuth SDK)
+    private func saveLegacyKeychainItem(account: String, value: String) async throws {
+        try await Task.detached {
+            guard let data = value.data(using: .utf8) else {
+                throw NSError(domain: "TestError", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to encode string"])
+            }
+            
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrAccount as String: account,
+                kSecValueData as String: data,
+                kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            ]
+            
+            // Delete first to ensure clean state
+            let deleteQuery: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrAccount as String: account
+            ]
+            SecItemDelete(deleteQuery as CFDictionary)
+            
+            // Add the item
+            let status = SecItemAdd(query as CFDictionary, nil)
+            if status != errSecSuccess {
+                throw NSError(domain: NSOSStatusErrorDomain, code: Int(status), userInfo: [NSLocalizedDescriptionKey: "Failed to save to keychain"])
+            }
+        }.value
+    }
+    
+    /// Helper to save legacy public key data using raw Security framework
+    private func saveLegacyPublicKeyData(_ data: Data) async throws {
+        try await Task.detached {
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrAccount as String: LegacyDeviceIdentifier.LegacyKeychainKeys.publicKeyData,
+                kSecValueData as String: data,
+                kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            ]
+            
+            // Delete first to ensure clean state
+            let deleteQuery: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrAccount as String: LegacyDeviceIdentifier.LegacyKeychainKeys.publicKeyData
+            ]
+            SecItemDelete(deleteQuery as CFDictionary)
+            
+            // Add the item
+            let status = SecItemAdd(query as CFDictionary, nil)
+            if status != errSecSuccess {
+                throw NSError(domain: NSOSStatusErrorDomain, code: Int(status), userInfo: [NSLocalizedDescriptionKey: "Failed to save public key to keychain"])
+            }
+        }.value
     }
     
     // MARK: - Legacy Identifier Migration Tests
     
     /// Test that when a legacy identifier exists, it is retrieved and used instead of generating a new one
     func testLegacyIdentifierIsUsedWhenAvailable() async throws {
-        // GIVEN: A legacy identifier exists in keychain
+        // GIVEN: A legacy identifier exists in keychain (using raw keychain like FRAuth SDK would)
         let expectedLegacyId = "abc123def456legacy789"
-        let legacyStorage = LegacyDeviceIdentifier.createLegacyStorage()
-        try await legacyStorage.save(item: expectedLegacyId)
+        try await saveLegacyKeychainItem(
+            account: LegacyDeviceIdentifier.LegacyKeychainKeys.identifier,
+            value: expectedLegacyId
+        )
         
         // WHEN: Creating a new DefaultDeviceIdentifier
         let deviceIdentifier = try DefaultDeviceIdentifier()
@@ -88,10 +145,12 @@ final class LegacyDeviceIdentifierMigrationTests: XCTestCase {
     
     /// Test that legacy identifier stored in new format persists correctly
     func testLegacyIdentifierPersistedInNewFormat() async throws {
-        // GIVEN: A legacy identifier exists
+        // GIVEN: A legacy identifier exists (using raw keychain like FRAuth SDK would)
         let expectedLegacyId = "legacy_identifier_12345"
-        let legacyStorage = LegacyDeviceIdentifier.createLegacyStorage()
-        try await legacyStorage.save(item: expectedLegacyId)
+        try await saveLegacyKeychainItem(
+            account: LegacyDeviceIdentifier.LegacyKeychainKeys.identifier,
+            value: expectedLegacyId
+        )
         
         // WHEN: First access triggers migration
         let firstIdentifier = try DefaultDeviceIdentifier()
@@ -101,7 +160,7 @@ final class LegacyDeviceIdentifierMigrationTests: XCTestCase {
         XCTAssertEqual(migratedId, expectedLegacyId)
         
         // WHEN: We clear the legacy storage (simulating it being removed)
-        try await legacyStorage.delete()
+        await LegacyDeviceIdentifierMigrationTests.deleteLegacyKeychainItem(account: LegacyDeviceIdentifier.LegacyKeychainKeys.identifier)
         
         // AND: Create a new instance
         let secondIdentifier = try DefaultDeviceIdentifier()
@@ -130,13 +189,9 @@ final class LegacyDeviceIdentifierMigrationTests: XCTestCase {
     
     /// Test migration from public key data when identifier doesn't exist but public key does
     func testMigrationFromLegacyPublicKey() async throws {
-        // GIVEN: Legacy public key data exists but no identifier
+        // GIVEN: Legacy public key data exists but no identifier (using raw keychain like FRAuth SDK would)
         let samplePublicKeyData = Data("sample_public_key_data".utf8)
-        let legacyPublicKeyStorage = KeychainStorage<Data>(
-            account: "com.forgerock.ios.device-identifier.pubic-key.data",
-            encryptor: NoEncryptor()
-        )
-        try await legacyPublicKeyStorage.save(item: samplePublicKeyData)
+        try await saveLegacyPublicKeyData(samplePublicKeyData)
         
         // WHEN: Creating a DefaultDeviceIdentifier
         let deviceIdentifier = try DefaultDeviceIdentifier()
@@ -144,6 +199,8 @@ final class LegacyDeviceIdentifierMigrationTests: XCTestCase {
         
         // THEN: An identifier should be generated from the public key
         XCTAssertFalse(migratedId.isEmpty, "Should generate identifier from legacy public key")
+        // Legacy migration uses SHA-1, which produces 40 character hex strings
+        XCTAssertEqual(migratedId.count, 40, "Legacy identifier from public key should be SHA-1 based (40 chars)")
         
         // AND: The same identifier should be returned on subsequent calls
         let secondCallId = try await deviceIdentifier.id
@@ -157,10 +214,12 @@ final class LegacyDeviceIdentifierMigrationTests: XCTestCase {
     
     /// Test that regenerateIdentifier works correctly even with legacy migration
     func testRegenerateIdentifierAfterLegacyMigration() async throws {
-        // GIVEN: A legacy identifier that has been migrated
+        // GIVEN: A legacy identifier that has been migrated (using raw keychain like FRAuth SDK would)
         let legacyId = "legacy_identifier_xyz"
-        let legacyStorage = LegacyDeviceIdentifier.createLegacyStorage()
-        try await legacyStorage.save(item: legacyId)
+        try await saveLegacyKeychainItem(
+            account: LegacyDeviceIdentifier.LegacyKeychainKeys.identifier,
+            value: legacyId
+        )
         
         let deviceIdentifier = try DefaultDeviceIdentifier()
         let initialId = try await deviceIdentifier.id
@@ -180,10 +239,12 @@ final class LegacyDeviceIdentifierMigrationTests: XCTestCase {
     
     /// Test concurrent access during legacy migration
     func testConcurrentAccessDuringLegacyMigration() async throws {
-        // GIVEN: A legacy identifier exists
+        // GIVEN: A legacy identifier exists (using raw keychain like FRAuth SDK would)
         let legacyId = "concurrent_legacy_test"
-        let legacyStorage = LegacyDeviceIdentifier.createLegacyStorage()
-        try await legacyStorage.save(item: legacyId)
+        try await saveLegacyKeychainItem(
+            account: LegacyDeviceIdentifier.LegacyKeychainKeys.identifier,
+            value: legacyId
+        )
         
         // WHEN: Multiple concurrent requests are made
         let deviceIdentifier = try DefaultDeviceIdentifier()
@@ -207,10 +268,12 @@ final class LegacyDeviceIdentifierMigrationTests: XCTestCase {
     
     /// Test that cache clearing works correctly with legacy identifiers
     func testCacheClearingWithLegacyIdentifier() async throws {
-        // GIVEN: A legacy identifier that has been loaded
+        // GIVEN: A legacy identifier that has been loaded (using raw keychain like FRAuth SDK would)
         let legacyId = "cache_test_legacy_id"
-        let legacyStorage = LegacyDeviceIdentifier.createLegacyStorage()
-        try await legacyStorage.save(item: legacyId)
+        try await saveLegacyKeychainItem(
+            account: LegacyDeviceIdentifier.LegacyKeychainKeys.identifier,
+            value: legacyId
+        )
         
         let deviceIdentifier = try DefaultDeviceIdentifier()
         let firstId = try await deviceIdentifier.id
@@ -287,18 +350,15 @@ final class LegacyDeviceIdentifierMigrationTests: XCTestCase {
     
     /// Test migration priority: direct identifier > public key regeneration > new generation
     func testMigrationPriority() async throws {
-        // GIVEN: Both legacy identifier AND public key exist
+        // GIVEN: Both legacy identifier AND public key exist (using raw keychain like FRAuth SDK would)
         let directLegacyId = "direct_legacy_identifier"
         let publicKeyData = Data("legacy_public_key".utf8)
         
-        let legacyIdentifierStorage = LegacyDeviceIdentifier.createLegacyStorage()
-        try await legacyIdentifierStorage.save(item: directLegacyId)
-        
-        let legacyPublicKeyStorage = KeychainStorage<Data>(
-            account: "com.forgerock.ios.device-identifier.pubic-key.data",
-            encryptor: NoEncryptor()
+        try await saveLegacyKeychainItem(
+            account: LegacyDeviceIdentifier.LegacyKeychainKeys.identifier,
+            value: directLegacyId
         )
-        try await legacyPublicKeyStorage.save(item: publicKeyData)
+        try await saveLegacyPublicKeyData(publicKeyData)
         
         // WHEN: Creating a DefaultDeviceIdentifier
         let deviceIdentifier = try DefaultDeviceIdentifier()

--- a/DeviceId/DeviceIdTests/LegacyDeviceIdentifierMigrationTests.swift
+++ b/DeviceId/DeviceIdTests/LegacyDeviceIdentifierMigrationTests.swift
@@ -30,36 +30,59 @@ final class LegacyDeviceIdentifierMigrationTests: XCTestCase {
     }
     
     private func cleanupKeychain() {
-        let group = DispatchGroup()
+        let semaphore = DispatchSemaphore(value: 0)
         
-        // Clean up default configuration
-        group.enter()
-        Task.detached {
-            try? await DefaultDeviceIdentifier(configuration: .default).keychainService.delete()
-            group.leave()
+        Task {
+            async let defaultCleanup: Void = {
+                try? await DefaultDeviceIdentifier(configuration: .default).keychainService.delete()
+            }()
+            
+            async let legacyCleanup: Void = {
+                await LegacyDeviceIdentifierMigrationTests.deleteLegacyKeychainItem(account: LegacyDeviceIdentifier.LegacyKeychainKeys.identifier)
+                await LegacyDeviceIdentifierMigrationTests.deleteLegacyKeychainItem(account: LegacyDeviceIdentifier.LegacyKeychainKeys.publicKeyData)
+                await LegacyDeviceIdentifierMigrationTests.deleteLegacyKeychainItem(account: LegacyDeviceIdentifier.LegacyKeychainKeys.privateKeyData)
+            }()
+            
+            async let systemKeychainCleanup: Void = {
+                await LegacyDeviceIdentifierMigrationTests.deleteLegacySystemKeychainKeys()
+            }()
+            
+            await defaultCleanup
+            await legacyCleanup
+            await systemKeychainCleanup
+            semaphore.signal()
         }
         
-        // Clean up legacy storage locations using raw keychain access
-        group.enter()
-        Task.detached {
-            await LegacyDeviceIdentifierMigrationTests.deleteLegacyKeychainItem(account: LegacyDeviceIdentifier.LegacyKeychainKeys.identifier)
-            await LegacyDeviceIdentifierMigrationTests.deleteLegacyKeychainItem(account: LegacyDeviceIdentifier.LegacyKeychainKeys.publicKeyData)
-            await LegacyDeviceIdentifierMigrationTests.deleteLegacyKeychainItem(account: LegacyDeviceIdentifier.LegacyKeychainKeys.privateKeyData)
-            group.leave()
-        }
+        semaphore.wait()
+    }
+    
+    /// Helper to delete legacy system keychain keys (RSA keys stored with kSecClassKey)
+    private static func deleteLegacySystemKeychainKeys() async {
+        let publicKeyTag = "com.forgerock.ios.device-identifier.public-key".data(using: .utf8)!
+        let privateKeyTag = "com.forgerock.ios.device-identifier.private-key".data(using: .utf8)!
         
-        group.wait()
+        // Delete public key
+        let publicKeyQuery: [String: Any] = [
+            kSecClass as String: kSecClassKey,
+            kSecAttrApplicationTag as String: publicKeyTag
+        ]
+        SecItemDelete(publicKeyQuery as CFDictionary)
+        
+        // Delete private key
+        let privateKeyQuery: [String: Any] = [
+            kSecClass as String: kSecClassKey,
+            kSecAttrApplicationTag as String: privateKeyTag
+        ]
+        SecItemDelete(privateKeyQuery as CFDictionary)
     }
     
     /// Helper to delete legacy keychain items using raw Security framework
     private static func deleteLegacyKeychainItem(account: String) async {
-        await Task.detached {
-            let query: [String: Any] = [
-                kSecClass as String: kSecClassGenericPassword,
-                kSecAttrAccount as String: account
-            ]
-            SecItemDelete(query as CFDictionary)
-        }.value
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(query as CFDictionary)
     }
     
     /// Helper to save legacy keychain item using raw Security framework (simulating FRAuth SDK)
@@ -188,20 +211,46 @@ final class LegacyDeviceIdentifierMigrationTests: XCTestCase {
         XCTAssertEqual(generatedId, secondCallId)
     }
     
-    /// Test migration from public key data when identifier doesn't exist but public key does
+    /// Test migration from public key when identifier doesn't exist but public key SecKey does
     func testMigrationFromLegacyPublicKey() async throws {
-        // GIVEN: Legacy public key data exists but no identifier (using raw keychain like FRAuth SDK would)
-        let samplePublicKeyData = Data("sample_public_key_data".utf8)
-        try await saveLegacyPublicKeyData(samplePublicKeyData)
+        // GIVEN: A legacy RSA public key exists in system keychain (simulating FRAuth SDK)
+        // We need to create a real RSA key pair and store it with the legacy application tag
+        let publicKeyTag = "com.forgerock.ios.device-identifier.public-key".data(using: .utf8)!
         
-        // WHEN: Creating a DefaultDeviceIdentifier
+        // Clean up any existing key first
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassKey,
+            kSecAttrApplicationTag as String: publicKeyTag
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
+        
+        // Generate a test RSA key pair (matching FRAuth SDK behavior)
+        let attributes: CFDictionary = [
+            kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
+            kSecAttrKeySizeInBits as String: 2048,
+            kSecPublicKeyAttrs as String: [
+                kSecAttrIsPermanent as String: true,
+                kSecAttrApplicationTag as String: publicKeyTag
+            ] as CFDictionary
+        ] as CFDictionary
+        
+        var publicKey: SecKey?
+        var privateKey: SecKey?
+        let status = SecKeyGeneratePair(attributes, &publicKey, &privateKey)
+        
+        guard status == errSecSuccess, let pubKey = publicKey else {
+            XCTFail("Failed to generate test RSA key pair. Status: \(status)")
+            return
+        }
+        
+        // WHEN: Creating a DefaultDeviceIdentifier (should find the legacy key)
         let deviceIdentifier = try DefaultDeviceIdentifier()
         let migratedId = try await deviceIdentifier.id
         
-        // THEN: An identifier should be generated from the public key
+        // THEN: An identifier should be generated from the legacy public key
         XCTAssertFalse(migratedId.isEmpty, "Should generate identifier from legacy public key")
-        // Legacy migration uses SHA-1 hash that is base64-encoded (20 bytes -> ~28 chars base64)
-        XCTAssertTrue(migratedId.count >= 27 && migratedId.count <= 28, "Legacy identifier from public key should be base64-encoded SHA-1 hash (~28 chars), got \(migratedId.count)")
+        // Legacy migration uses SHA-1 hash with hex encoding (40 characters)
+        XCTAssertEqual(migratedId.count, 40, "Legacy identifier from public key should be SHA-1 hex encoded (40 chars)")
         
         // AND: The same identifier should be returned on subsequent calls
         let secondCallId = try await deviceIdentifier.id
@@ -211,6 +260,9 @@ final class LegacyDeviceIdentifierMigrationTests: XCTestCase {
         let newInstance = try DefaultDeviceIdentifier()
         let newInstanceId = try await newInstance.id
         XCTAssertEqual(migratedId, newInstanceId, "Migrated identifier should persist")
+        
+        // Clean up the test key
+        SecItemDelete(deleteQuery as CFDictionary)
     }
     
     /// Test that regenerateIdentifier works correctly even with legacy migration
@@ -388,25 +440,55 @@ final class LegacyDeviceIdentifierMigrationTests: XCTestCase {
         XCTAssertEqual(decodedId, legacyId, "Legacy identifier should survive encoding/decoding")
     }
     
-    /// Test that the hashing format matches FRAuth SDK (SHA-1 + base64, not hex)
-    func testLegacyHashingFormatIsBase64NotHex() async throws {
-        // GIVEN: A known public key data
-        let testData = Data("test_public_key_data".utf8)
-        try await saveLegacyPublicKeyData(testData)
+    /// Test that the hashing format matches FRAuth SDK (SHA-1 + hex encoding)
+    func testLegacyHashingFormatIsHexNotBase64() async throws {
+        // GIVEN: A legacy RSA public key exists in system keychain
+        let publicKeyTag = "com.forgerock.ios.device-identifier.public-key".data(using: .utf8)!
+        
+        // Clean up any existing key first
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassKey,
+            kSecAttrApplicationTag as String: publicKeyTag
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
+        
+        // Generate a test RSA key pair
+        let attributes: CFDictionary = [
+            kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
+            kSecAttrKeySizeInBits as String: 2048,
+            kSecPublicKeyAttrs as String: [
+                kSecAttrIsPermanent as String: true,
+                kSecAttrApplicationTag as String: publicKeyTag
+            ] as CFDictionary
+        ] as CFDictionary
+        
+        var publicKey: SecKey?
+        var privateKey: SecKey?
+        let status = SecKeyGeneratePair(attributes, &publicKey, &privateKey)
+        
+        guard status == errSecSuccess else {
+            XCTFail("Failed to generate test RSA key pair")
+            return
+        }
         
         // WHEN: Migrating the identifier
         let deviceIdentifier = try DefaultDeviceIdentifier()
         let migratedId = try await deviceIdentifier.id
         
-        // THEN: The identifier should be base64-encoded (contains chars like +, /, =)
-        // Base64 uses A-Z, a-z, 0-9, +, /, and =
-        let base64CharSet = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=")
-        let idCharSet = CharacterSet(charactersIn: migratedId)
-        XCTAssertTrue(idCharSet.isSubset(of: base64CharSet), "Legacy identifier should use base64 encoding, not hex")
-        
-        // AND: Should NOT be a hex string (hex only uses 0-9, a-f)
+        // THEN: The identifier should be hex-encoded (only 0-9, a-f)
         let isHexOnly = migratedId.allSatisfy { "0123456789abcdefABCDEF".contains($0) }
-        XCTAssertFalse(isHexOnly || migratedId.count == 40, "Legacy identifier should not be a hex string")
+        XCTAssertTrue(isHexOnly, "Legacy identifier should use hex encoding (only 0-9, a-f)")
+        
+        // AND: Should be 40 characters (SHA-1 hash in hex)
+        XCTAssertEqual(migratedId.count, 40, "Legacy identifier should be SHA-1 hex (40 characters)")
+        
+        // AND: Should NOT contain base64-specific characters like +, /, =
+        XCTAssertFalse(migratedId.contains("+"), "Should not contain base64 character '+'")
+        XCTAssertFalse(migratedId.contains("/"), "Should not contain base64 character '/'")
+        XCTAssertFalse(migratedId.contains("="), "Should not contain base64 character '='")
+        
+        // Clean up
+        SecItemDelete(deleteQuery as CFDictionary)
     }
 }
 

--- a/DeviceId/DeviceIdTests/LegacyDeviceIdentifierMigrationTests.swift
+++ b/DeviceId/DeviceIdTests/LegacyDeviceIdentifierMigrationTests.swift
@@ -1,0 +1,351 @@
+//
+//  LegacyDeviceIdentifierMigrationTests.swift
+//  DeviceIdTests
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+@testable import PingDeviceId
+import PingStorage
+
+/// Tests for legacy device identifier migration functionality.
+/// These tests verify that legacy identifiers from FRAuth SDK are properly detected,
+/// migrated, and used instead of generating new identifiers.
+final class LegacyDeviceIdentifierMigrationTests: XCTestCase {
+    
+    // MARK: - Test Lifecycle
+    
+    override func setUpWithError() throws {
+        // Clean up before each test
+        cleanupKeychain()
+    }
+    
+    override func tearDownWithError() throws {
+        // Clean up after each test
+        cleanupKeychain()
+    }
+    
+    private func cleanupKeychain() {
+        let group = DispatchGroup()
+        
+        // Clean up default configuration
+        group.enter()
+        Task {
+            try? await DefaultDeviceIdentifier(configuration: .default).keychainService.delete()
+            group.leave()
+        }
+        
+        // Clean up legacy storage locations
+        group.enter()
+        Task {
+            let legacyIdentifierStorage = LegacyDeviceIdentifier.createLegacyStorage()
+            try? await legacyIdentifierStorage.delete()
+            group.leave()
+        }
+        
+        group.enter()
+        Task {
+            let legacyPublicKeyStorage = KeychainStorage<Data>(
+                account: "com.forgerock.ios.device-identifier.pubic-key.data",
+                encryptor: NoEncryptor()
+            )
+            try? await legacyPublicKeyStorage.delete()
+            group.leave()
+        }
+        
+        group.wait()
+    }
+    
+    // MARK: - Legacy Identifier Migration Tests
+    
+    /// Test that when a legacy identifier exists, it is retrieved and used instead of generating a new one
+    func testLegacyIdentifierIsUsedWhenAvailable() async throws {
+        // GIVEN: A legacy identifier exists in keychain
+        let expectedLegacyId = "abc123def456legacy789"
+        let legacyStorage = LegacyDeviceIdentifier.createLegacyStorage()
+        try await legacyStorage.save(item: expectedLegacyId)
+        
+        // WHEN: Creating a new DefaultDeviceIdentifier
+        let deviceIdentifier = try DefaultDeviceIdentifier()
+        let actualId = try await deviceIdentifier.id
+        
+        // THEN: The returned identifier should match the legacy one
+        XCTAssertEqual(actualId, expectedLegacyId, "Should use legacy identifier instead of generating new one")
+        
+        // AND: The identifier should be stable across multiple calls
+        let secondCallId = try await deviceIdentifier.id
+        XCTAssertEqual(actualId, secondCallId, "Legacy identifier should be stable")
+        
+        // AND: A new instance should also use the same legacy identifier
+        let newInstance = try DefaultDeviceIdentifier()
+        let newInstanceId = try await newInstance.id
+        XCTAssertEqual(actualId, newInstanceId, "New instance should also use migrated legacy identifier")
+    }
+    
+    /// Test that legacy identifier stored in new format persists correctly
+    func testLegacyIdentifierPersistedInNewFormat() async throws {
+        // GIVEN: A legacy identifier exists
+        let expectedLegacyId = "legacy_identifier_12345"
+        let legacyStorage = LegacyDeviceIdentifier.createLegacyStorage()
+        try await legacyStorage.save(item: expectedLegacyId)
+        
+        // WHEN: First access triggers migration
+        let firstIdentifier = try DefaultDeviceIdentifier()
+        let migratedId = try await firstIdentifier.id
+        
+        // THEN: The migrated ID should match the legacy one
+        XCTAssertEqual(migratedId, expectedLegacyId)
+        
+        // WHEN: We clear the legacy storage (simulating it being removed)
+        try await legacyStorage.delete()
+        
+        // AND: Create a new instance
+        let secondIdentifier = try DefaultDeviceIdentifier()
+        let persistedId = try await secondIdentifier.id
+        
+        // THEN: The identifier should still be the legacy one (now persisted in new format)
+        XCTAssertEqual(persistedId, expectedLegacyId, "Legacy identifier should persist in new format even after legacy storage is cleared")
+    }
+    
+    /// Test that when no legacy identifier exists, a new one is generated
+    func testNewIdentifierGeneratedWhenNoLegacyExists() async throws {
+        // GIVEN: No legacy identifier exists (clean keychain)
+        
+        // WHEN: Creating a new DefaultDeviceIdentifier
+        let deviceIdentifier = try DefaultDeviceIdentifier()
+        let generatedId = try await deviceIdentifier.id
+        
+        // THEN: A new identifier should be generated (SHA-256 hash = 64 chars)
+        XCTAssertEqual(generatedId.count, 64, "Should generate new SHA-256 based identifier")
+        XCTAssertFalse(generatedId.isEmpty)
+        
+        // AND: It should be stable
+        let secondCallId = try await deviceIdentifier.id
+        XCTAssertEqual(generatedId, secondCallId)
+    }
+    
+    /// Test migration from public key data when identifier doesn't exist but public key does
+    func testMigrationFromLegacyPublicKey() async throws {
+        // GIVEN: Legacy public key data exists but no identifier
+        let samplePublicKeyData = Data("sample_public_key_data".utf8)
+        let legacyPublicKeyStorage = KeychainStorage<Data>(
+            account: "com.forgerock.ios.device-identifier.pubic-key.data",
+            encryptor: NoEncryptor()
+        )
+        try await legacyPublicKeyStorage.save(item: samplePublicKeyData)
+        
+        // WHEN: Creating a DefaultDeviceIdentifier
+        let deviceIdentifier = try DefaultDeviceIdentifier()
+        let migratedId = try await deviceIdentifier.id
+        
+        // THEN: An identifier should be generated from the public key
+        XCTAssertFalse(migratedId.isEmpty, "Should generate identifier from legacy public key")
+        
+        // AND: The same identifier should be returned on subsequent calls
+        let secondCallId = try await deviceIdentifier.id
+        XCTAssertEqual(migratedId, secondCallId, "Migrated identifier should be stable")
+        
+        // AND: A new instance should return the same migrated identifier
+        let newInstance = try DefaultDeviceIdentifier()
+        let newInstanceId = try await newInstance.id
+        XCTAssertEqual(migratedId, newInstanceId, "Migrated identifier should persist")
+    }
+    
+    /// Test that regenerateIdentifier works correctly even with legacy migration
+    func testRegenerateIdentifierAfterLegacyMigration() async throws {
+        // GIVEN: A legacy identifier that has been migrated
+        let legacyId = "legacy_identifier_xyz"
+        let legacyStorage = LegacyDeviceIdentifier.createLegacyStorage()
+        try await legacyStorage.save(item: legacyId)
+        
+        let deviceIdentifier = try DefaultDeviceIdentifier()
+        let initialId = try await deviceIdentifier.id
+        XCTAssertEqual(initialId, legacyId)
+        
+        // WHEN: Regenerating the identifier
+        let regeneratedId = try await deviceIdentifier.regenerateIdentifier()
+        
+        // THEN: A new identifier should be generated (different from legacy)
+        XCTAssertNotEqual(regeneratedId, legacyId, "Regenerated identifier should be different from legacy")
+        XCTAssertEqual(regeneratedId.count, 64, "Regenerated identifier should be SHA-256 based")
+        
+        // AND: The new identifier should be stable
+        let afterRegenerationId = try await deviceIdentifier.id
+        XCTAssertEqual(regeneratedId, afterRegenerationId)
+    }
+    
+    /// Test concurrent access during legacy migration
+    func testConcurrentAccessDuringLegacyMigration() async throws {
+        // GIVEN: A legacy identifier exists
+        let legacyId = "concurrent_legacy_test"
+        let legacyStorage = LegacyDeviceIdentifier.createLegacyStorage()
+        try await legacyStorage.save(item: legacyId)
+        
+        // WHEN: Multiple concurrent requests are made
+        let deviceIdentifier = try DefaultDeviceIdentifier()
+        
+        let ids = try await withThrowingTaskGroup(of: String.self) { group in
+            for _ in 0..<10 {
+                group.addTask { try await deviceIdentifier.id }
+            }
+            var results = [String]()
+            for try await id in group {
+                results.append(id)
+            }
+            return results
+        }
+        
+        // THEN: All should return the same legacy identifier
+        let uniqueIds = Set(ids)
+        XCTAssertEqual(uniqueIds.count, 1, "All concurrent calls should return same legacy identifier")
+        XCTAssertEqual(uniqueIds.first, legacyId, "Concurrent calls should all get the legacy identifier")
+    }
+    
+    /// Test that cache clearing works correctly with legacy identifiers
+    func testCacheClearingWithLegacyIdentifier() async throws {
+        // GIVEN: A legacy identifier that has been loaded
+        let legacyId = "cache_test_legacy_id"
+        let legacyStorage = LegacyDeviceIdentifier.createLegacyStorage()
+        try await legacyStorage.save(item: legacyId)
+        
+        let deviceIdentifier = try DefaultDeviceIdentifier()
+        let firstId = try await deviceIdentifier.id
+        XCTAssertEqual(firstId, legacyId)
+        
+        // WHEN: Clearing the cache
+        await deviceIdentifier.clearCache()
+        
+        // THEN: The identifier should still be the same (loaded from storage)
+        let afterClearId = try await deviceIdentifier.id
+        XCTAssertEqual(afterClearId, legacyId, "Should reload legacy identifier from storage after cache clear")
+    }
+    
+    // MARK: - Tests with Mock Storage
+    
+    /// Test legacy migration with custom mock storage
+    func testLegacyMigrationWithMockStorage() async throws {
+        // GIVEN: A mock storage implementation
+        let mockStorage = MockStorage<DeviceIdentifierImpl>()
+        let deviceIdentifier = try DefaultDeviceIdentifier(
+            configuration: .default,
+            storage: mockStorage,
+            logger: nil
+        )
+        
+        // WHEN: Initially there's no data
+        let newId = try await deviceIdentifier.id
+        
+        // THEN: A new identifier is generated
+        XCTAssertEqual(newId.count, 64, "Should generate new identifier with empty mock storage")
+        
+        // WHEN: We manually save a legacy identifier to storage
+        let legacyId = "mock_legacy_identifier"
+        let emptyKeyPair = DeviceIdentifierKeyPair(privateKey: Data(), publicKey: Data())
+        let legacyImpl = DeviceIdentifierImpl(deviceIdentifierKeyPair: emptyKeyPair, legacyIdentifier: legacyId)
+        try await mockStorage.save(item: legacyImpl)
+        
+        // AND: Clear cache and access again
+        await deviceIdentifier.clearCache()
+        let retrievedId = try await deviceIdentifier.id
+        
+        // THEN: The legacy identifier should be returned
+        XCTAssertEqual(retrievedId, legacyId, "Should retrieve legacy identifier from mock storage")
+    }
+    
+    /// Test that DeviceIdentifierImpl correctly returns legacy identifier when present
+    func testDeviceIdentifierImplWithLegacyIdentifier() async throws {
+        // GIVEN: A DeviceIdentifierImpl with a legacy identifier
+        let legacyId = "test_legacy_id_123"
+        let emptyKeyPair = DeviceIdentifierKeyPair(privateKey: Data(), publicKey: Data())
+        let impl = DeviceIdentifierImpl(deviceIdentifierKeyPair: emptyKeyPair, legacyIdentifier: legacyId)
+        
+        // WHEN: Accessing the id
+        let retrievedId = try await impl.id
+        
+        // THEN: The legacy identifier should be returned, not a computed one
+        XCTAssertEqual(retrievedId, legacyId, "DeviceIdentifierImpl should return legacy identifier when present")
+    }
+    
+    /// Test that DeviceIdentifierImpl computes hash when no legacy identifier
+    func testDeviceIdentifierImplWithoutLegacyIdentifier() async throws {
+        // GIVEN: A DeviceIdentifierImpl without a legacy identifier
+        let publicKeyData = Data("sample_public_key".utf8)
+        let keyPair = DeviceIdentifierKeyPair(privateKey: Data(), publicKey: publicKeyData)
+        let impl = DeviceIdentifierImpl(deviceIdentifierKeyPair: keyPair)
+        
+        // WHEN: Accessing the id
+        let retrievedId = try await impl.id
+        
+        // THEN: The identifier should be a SHA-256 hash (64 characters)
+        XCTAssertEqual(retrievedId.count, 64, "Should compute SHA-256 hash when no legacy identifier")
+        XCTAssertFalse(retrievedId.isEmpty)
+    }
+    
+    /// Test migration priority: direct identifier > public key regeneration > new generation
+    func testMigrationPriority() async throws {
+        // GIVEN: Both legacy identifier AND public key exist
+        let directLegacyId = "direct_legacy_identifier"
+        let publicKeyData = Data("legacy_public_key".utf8)
+        
+        let legacyIdentifierStorage = LegacyDeviceIdentifier.createLegacyStorage()
+        try await legacyIdentifierStorage.save(item: directLegacyId)
+        
+        let legacyPublicKeyStorage = KeychainStorage<Data>(
+            account: "com.forgerock.ios.device-identifier.pubic-key.data",
+            encryptor: NoEncryptor()
+        )
+        try await legacyPublicKeyStorage.save(item: publicKeyData)
+        
+        // WHEN: Creating a DefaultDeviceIdentifier
+        let deviceIdentifier = try DefaultDeviceIdentifier()
+        let retrievedId = try await deviceIdentifier.id
+        
+        // THEN: The direct legacy identifier should be used (higher priority)
+        XCTAssertEqual(retrievedId, directLegacyId, "Direct legacy identifier should take priority over public key regeneration")
+    }
+    
+    /// Test that legacy identifier is properly encoded/decoded
+    func testLegacyIdentifierCodable() async throws {
+        // GIVEN: A DeviceIdentifierImpl with legacy identifier
+        let legacyId = "codable_test_legacy"
+        let keyPair = DeviceIdentifierKeyPair(privateKey: Data(), publicKey: Data())
+        let originalImpl = DeviceIdentifierImpl(deviceIdentifierKeyPair: keyPair, legacyIdentifier: legacyId)
+        
+        // WHEN: Encoding and decoding
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        
+        let encoded = try encoder.encode(originalImpl)
+        let decoded = try decoder.decode(DeviceIdentifierImpl.self, from: encoded)
+        
+        // THEN: The legacy identifier should be preserved
+        let decodedId = try await decoded.id
+        XCTAssertEqual(decodedId, legacyId, "Legacy identifier should survive encoding/decoding")
+    }
+}
+
+actor Mock<T: Codable & Sendable>: Storage {
+    private var data: T?
+    
+    public func save(item: T) async throws {
+        data = item
+    }
+    
+    public func get() async throws -> T?  {
+        return data
+    }
+    
+    public func delete() async throws {
+        data = nil
+    }
+}
+
+class MockStorage<T: Codable& Sendable>: StorageDelegate<T>, @unchecked Sendable {
+    public init(cacheable: Bool = false) {
+        super.init(delegate: Mock<T>(), cacheable: cacheable)
+    }
+}

--- a/DeviceId/DeviceIdTests/LegacyDeviceIdentifierMigrationTests.swift
+++ b/DeviceId/DeviceIdTests/LegacyDeviceIdentifierMigrationTests.swift
@@ -30,35 +30,36 @@ final class LegacyDeviceIdentifierMigrationTests: XCTestCase {
     }
     
     private func cleanupKeychain() {
-        // Bridge async cleanup to synchronous test lifecycle
-        let semaphore = DispatchSemaphore(value: 0)
+        let group = DispatchGroup()
         
-        Task {
-            async let defaultCleanup: Void = {
-                try? await DefaultDeviceIdentifier(configuration: .default).keychainService.delete()
-            }()
-            
-            async let legacyCleanup: Void = {
-                await LegacyDeviceIdentifierMigrationTests.deleteLegacyKeychainItem(account: LegacyDeviceIdentifier.LegacyKeychainKeys.identifier)
-                await LegacyDeviceIdentifierMigrationTests.deleteLegacyKeychainItem(account: LegacyDeviceIdentifier.LegacyKeychainKeys.publicKeyData)
-                await LegacyDeviceIdentifierMigrationTests.deleteLegacyKeychainItem(account: LegacyDeviceIdentifier.LegacyKeychainKeys.privateKeyData)
-            }()
-            
-            await defaultCleanup
-            await legacyCleanup
-            semaphore.signal()
+        // Clean up default configuration
+        group.enter()
+        Task.detached {
+            try? await DefaultDeviceIdentifier(configuration: .default).keychainService.delete()
+            group.leave()
         }
         
-        semaphore.wait()
+        // Clean up legacy storage locations using raw keychain access
+        group.enter()
+        Task.detached {
+            await LegacyDeviceIdentifierMigrationTests.deleteLegacyKeychainItem(account: LegacyDeviceIdentifier.LegacyKeychainKeys.identifier)
+            await LegacyDeviceIdentifierMigrationTests.deleteLegacyKeychainItem(account: LegacyDeviceIdentifier.LegacyKeychainKeys.publicKeyData)
+            await LegacyDeviceIdentifierMigrationTests.deleteLegacyKeychainItem(account: LegacyDeviceIdentifier.LegacyKeychainKeys.privateKeyData)
+            group.leave()
+        }
+        
+        group.wait()
     }
     
     /// Helper to delete legacy keychain items using raw Security framework
     private static func deleteLegacyKeychainItem(account: String) async {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: account
-        ]
-        SecItemDelete(query as CFDictionary)
+        await Task.detached {
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrAccount as String: account
+            ]
+            SecItemDelete(query as CFDictionary)
+        }.value
     }
     
     /// Helper to save legacy keychain item using raw Security framework (simulating FRAuth SDK)
@@ -199,8 +200,8 @@ final class LegacyDeviceIdentifierMigrationTests: XCTestCase {
         
         // THEN: An identifier should be generated from the public key
         XCTAssertFalse(migratedId.isEmpty, "Should generate identifier from legacy public key")
-        // Legacy migration uses SHA-1, which produces 40 character hex strings
-        XCTAssertEqual(migratedId.count, 40, "Legacy identifier from public key should be SHA-1 based (40 chars)")
+        // Legacy migration uses SHA-1 hash that is base64-encoded (20 bytes -> ~28 chars base64)
+        XCTAssertTrue(migratedId.count >= 27 && migratedId.count <= 28, "Legacy identifier from public key should be base64-encoded SHA-1 hash (~28 chars), got \(migratedId.count)")
         
         // AND: The same identifier should be returned on subsequent calls
         let secondCallId = try await deviceIdentifier.id
@@ -385,6 +386,27 @@ final class LegacyDeviceIdentifierMigrationTests: XCTestCase {
         // THEN: The legacy identifier should be preserved
         let decodedId = try await decoded.id
         XCTAssertEqual(decodedId, legacyId, "Legacy identifier should survive encoding/decoding")
+    }
+    
+    /// Test that the hashing format matches FRAuth SDK (SHA-1 + base64, not hex)
+    func testLegacyHashingFormatIsBase64NotHex() async throws {
+        // GIVEN: A known public key data
+        let testData = Data("test_public_key_data".utf8)
+        try await saveLegacyPublicKeyData(testData)
+        
+        // WHEN: Migrating the identifier
+        let deviceIdentifier = try DefaultDeviceIdentifier()
+        let migratedId = try await deviceIdentifier.id
+        
+        // THEN: The identifier should be base64-encoded (contains chars like +, /, =)
+        // Base64 uses A-Z, a-z, 0-9, +, /, and =
+        let base64CharSet = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=")
+        let idCharSet = CharacterSet(charactersIn: migratedId)
+        XCTAssertTrue(idCharSet.isSubset(of: base64CharSet), "Legacy identifier should use base64 encoding, not hex")
+        
+        // AND: Should NOT be a hex string (hex only uses 0-9, a-f)
+        let isHexOnly = migratedId.allSatisfy { "0123456789abcdefABCDEF".contains($0) }
+        XCTAssertFalse(isHexOnly || migratedId.count == 40, "Legacy identifier should not be a hex string")
     }
 }
 

--- a/DeviceId/DeviceIdTests/LegacyDeviceIdentifierTests.swift
+++ b/DeviceId/DeviceIdTests/LegacyDeviceIdentifierTests.swift
@@ -1,0 +1,182 @@
+//
+//  LegacyDeviceIdentifierTests.swift
+//  DeviceIdTests
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+import CommonCrypto
+@testable import PingDeviceId
+
+/// Unit tests for LegacyDeviceIdentifier actor
+final class LegacyDeviceIdentifierTests: XCTestCase {
+    
+    override func setUp() async throws {
+        try await super.setUp()
+        await cleanupLegacyKeychain()
+    }
+    
+    override func tearDown() async throws {
+        await cleanupLegacyKeychain()
+        try await super.tearDown()
+    }
+    
+    // MARK: - Helper Methods
+    
+    private func cleanupLegacyKeychain() async {
+        let keys = [
+            LegacyDeviceIdentifier.LegacyKeychainKeys.identifier,
+            LegacyDeviceIdentifier.LegacyKeychainKeys.publicKeyData,
+            LegacyDeviceIdentifier.LegacyKeychainKeys.privateKeyData
+        ]
+        
+        for key in keys {
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrAccount as String: key
+            ]
+            SecItemDelete(query as CFDictionary)
+        }
+    }
+    
+    private func storeLegacyIdentifier(_ identifier: String) {
+        guard let data = identifier.data(using: .utf8) else {
+            XCTFail("Failed to encode identifier")
+            return
+        }
+        
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: LegacyDeviceIdentifier.LegacyKeychainKeys.identifier,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        ]
+        
+        let status = SecItemAdd(query as CFDictionary, nil)
+        XCTAssertEqual(status, errSecSuccess, "Failed to store legacy identifier")
+    }
+    
+    private func storeLegacyPublicKeyData(_ data: Data) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: LegacyDeviceIdentifier.LegacyKeychainKeys.publicKeyData,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        ]
+        
+        let status = SecItemAdd(query as CFDictionary, nil)
+        XCTAssertEqual(status, errSecSuccess, "Failed to store legacy public key data")
+    }
+    
+    private func generateLegacyHash(from data: Data) -> String {
+        var digest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
+        data.withUnsafeBytes {
+            _ = CC_SHA1($0.baseAddress, CC_LONG(data.count), &digest)
+        }
+        return Data(bytes: digest, count: digest.count).toHexString()
+    }
+    
+    // MARK: - Tests
+    
+    func testGetLegacyIdentifier_WhenExists_ReturnsIdentifier() async throws {
+        // Given
+        let expectedIdentifier = "legacy-test-identifier-12345"
+        storeLegacyIdentifier(expectedIdentifier)
+        
+        let legacyIdentifier = LegacyDeviceIdentifier()
+        
+        // When
+        let result = try await legacyIdentifier.getLegacyIdentifier()
+        
+        // Then
+        XCTAssertEqual(result, expectedIdentifier)
+    }
+    
+    func testGetLegacyIdentifier_WhenNotExists_ReturnsNil() async throws {
+        // Given
+        let legacyIdentifier = LegacyDeviceIdentifier()
+        
+        // When
+        let result = try await legacyIdentifier.getLegacyIdentifier()
+        
+        // Then
+        XCTAssertNil(result)
+    }
+    
+    func testMigrateLegacyIdentifierFromPublicKey_WhenPublicKeyExists_RegeneratesIdentifier() async throws {
+        // Given
+        let testData = "test-public-key-data".data(using: .utf8)!
+        storeLegacyPublicKeyData(testData)
+        
+        let expectedHash = generateLegacyHash(from: testData)
+        let legacyIdentifier = LegacyDeviceIdentifier()
+        
+        // When
+        let result = try await legacyIdentifier.migrateLegacyIdentifierFromPublicKey()
+        
+        // Then
+        XCTAssertEqual(result, expectedHash)
+        
+        // Verify it was also saved
+        let savedId = try await legacyIdentifier.getLegacyIdentifier()
+        XCTAssertEqual(savedId, expectedHash)
+    }
+    
+    func testMigrateLegacyIdentifierFromPublicKey_WhenPublicKeyNotExists_ReturnsNil() async throws {
+        // Given
+        let legacyIdentifier = LegacyDeviceIdentifier()
+        
+        // When
+        let result = try await legacyIdentifier.migrateLegacyIdentifierFromPublicKey()
+        
+        // Then
+        XCTAssertNil(result)
+    }
+    
+    func testLegacyKeychainKeys_MatchFRAuthSDK() {
+        // Verify the legacy keys match FRAuth SDK exactly
+        XCTAssertEqual(
+            LegacyDeviceIdentifier.LegacyKeychainKeys.identifier,
+            "com.forgerock.ios.device-identifier.hash-base64-string-identifier"
+        )
+        XCTAssertEqual(
+            LegacyDeviceIdentifier.LegacyKeychainKeys.publicKeyData,
+            "com.forgerock.ios.device-identifier.pubic-key.data"
+        )
+        XCTAssertEqual(
+            LegacyDeviceIdentifier.LegacyKeychainKeys.privateKeyData,
+            "com.forgerock.ios.device-identifier.private-key.data"
+        )
+    }
+    
+    func testHashAlgorithm_MatchesLegacyImplementation() async throws {
+        // Given: Test data
+        let testData = "test-data-for-hashing".data(using: .utf8)!
+        
+        // Expected hash from legacy implementation (SHA-1)
+        var expectedDigest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
+        testData.withUnsafeBytes {
+            _ = CC_SHA1($0.baseAddress, CC_LONG(testData.count), &expectedDigest)
+        }
+        let expectedHash = Data(bytes: expectedDigest, count: expectedDigest.count).toHexString()
+        
+        // When: Using legacy identifier to hash
+        storeLegacyPublicKeyData(testData)
+        let legacyIdentifier = LegacyDeviceIdentifier()
+        let result = try await legacyIdentifier.migrateLegacyIdentifierFromPublicKey()
+        
+        // Then
+        XCTAssertEqual(result, expectedHash)
+        XCTAssertEqual(result?.count, 40, "SHA-1 hash should be 40 hex characters")
+    }
+}
+
+extension Data {
+    func toHexString() -> String {
+        map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/DeviceId/DeviceIdTests/LegacyMigrationTests.swift
+++ b/DeviceId/DeviceIdTests/LegacyMigrationTests.swift
@@ -1,0 +1,287 @@
+//
+//  LegacyMigrationTests.swift
+//  DeviceIdTests
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+import CommonCrypto
+@testable import PingDeviceId
+@testable import PingStorage
+
+/// Comprehensive tests for legacy FRAuth SDK device identifier migration
+final class LegacyMigrationTests: XCTestCase {
+    
+    var deviceIdentifier: DefaultDeviceIdentifier!
+    
+    override func setUp() async throws {
+        try await super.setUp()
+        await cleanupAllKeychain()
+    }
+    
+    override func tearDown() async throws {
+        await cleanupAllKeychain()
+        deviceIdentifier = nil
+        try await super.tearDown()
+    }
+    
+    // MARK: - Helper Methods
+    
+    private func cleanupAllKeychain() async {
+        // Clean up new storage
+        let newStorage = KeychainStorage<DeviceIdentifierImpl>(
+            account: Constants.deviceIdentifierKey,
+            encryptor: NoEncryptor()
+        )
+        try? await newStorage.delete()
+        
+        // Clean up legacy storage
+        let legacyKeys = [
+            LegacyDeviceIdentifier.LegacyKeychainKeys.identifier,
+            LegacyDeviceIdentifier.LegacyKeychainKeys.publicKeyData,
+            LegacyDeviceIdentifier.LegacyKeychainKeys.privateKeyData
+        ]
+        
+        for key in legacyKeys {
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrAccount as String: key
+            ]
+            SecItemDelete(query as CFDictionary)
+        }
+    }
+    
+    private func storeLegacyIdentifier(_ identifier: String) {
+        guard let data = identifier.data(using: .utf8) else {
+            XCTFail("Failed to encode identifier")
+            return
+        }
+        
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: LegacyDeviceIdentifier.LegacyKeychainKeys.identifier,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        ]
+        
+        let status = SecItemAdd(query as CFDictionary, nil)
+        XCTAssertEqual(status, errSecSuccess, "Failed to store legacy identifier")
+    }
+    
+    private func storeLegacyPublicKeyData(_ data: Data) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: LegacyDeviceIdentifier.LegacyKeychainKeys.publicKeyData,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        ]
+        
+        let status = SecItemAdd(query as CFDictionary, nil)
+        XCTAssertEqual(status, errSecSuccess, "Failed to store legacy public key data")
+    }
+    
+    private func generateLegacyHash(from data: Data) -> String {
+        var digest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
+        data.withUnsafeBytes {
+            _ = CC_SHA1($0.baseAddress, CC_LONG(data.count), &digest)
+        }
+        return Data(bytes: digest, count: digest.count).toHexString()
+    }
+    
+    private func verifyIdentifierInNewStorage(_ expectedId: String) async throws {
+        let storage = KeychainStorage<DeviceIdentifierImpl>(
+            account: Constants.deviceIdentifierKey,
+            encryptor: NoEncryptor()
+        )
+        
+        let stored = try await storage.get()
+        XCTAssertNotNil(stored, "Identifier should be stored in new format")
+        
+        let id = try await stored?.id
+        XCTAssertEqual(id, expectedId, "Migrated identifier should match")
+    }
+    
+    // MARK: - Migration Tests
+    
+    func testMigration_WithLegacyIdentifier_MigratesSuccessfully() async throws {
+        // Given
+        let legacyId = "abc123def456legacy"
+        storeLegacyIdentifier(legacyId)
+        
+        // When
+        deviceIdentifier = try DefaultDeviceIdentifier()
+        let retrievedId = try await deviceIdentifier.id
+        
+        // Then
+        XCTAssertEqual(retrievedId, legacyId, "Should return migrated legacy identifier")
+        try await verifyIdentifierInNewStorage(legacyId)
+    }
+    
+    func testMigration_WithPublicKeyOnly_RegeneratesIdentifier() async throws {
+        // Given
+        let testKeyData = "test-public-key-data".data(using: .utf8)!
+        storeLegacyPublicKeyData(testKeyData)
+        let expectedHash = generateLegacyHash(from: testKeyData)
+        
+        // When
+        deviceIdentifier = try DefaultDeviceIdentifier()
+        let retrievedId = try await deviceIdentifier.id
+        
+        // Then
+        XCTAssertEqual(retrievedId, expectedHash, "Should regenerate identifier from public key")
+        try await verifyIdentifierInNewStorage(expectedHash)
+    }
+    
+    func testMigration_NoLegacyData_GeneratesNewIdentifier() async throws {
+        // When
+        deviceIdentifier = try DefaultDeviceIdentifier()
+        let firstId = try await deviceIdentifier.id
+        
+        // Then
+        XCTAssertFalse(firstId.isEmpty, "Should generate new identifier")
+        XCTAssertEqual(firstId.count, 64, "New identifiers should use SHA-256 (64 hex chars)")
+        
+        let secondId = try await deviceIdentifier.id
+        XCTAssertEqual(firstId, secondId, "Identifier should be consistent")
+    }
+    
+    func testMigration_LegacyIdentifierPersistsAcrossRestart() async throws {
+        // Given
+        let legacyId = "persistent-legacy-id"
+        storeLegacyIdentifier(legacyId)
+        
+        deviceIdentifier = try DefaultDeviceIdentifier()
+        let firstRetrievedId = try await deviceIdentifier.id
+        XCTAssertEqual(firstRetrievedId, legacyId)
+        
+        // When: "App restarts"
+        deviceIdentifier = try DefaultDeviceIdentifier()
+        let secondRetrievedId = try await deviceIdentifier.id
+        
+        // Then
+        XCTAssertEqual(secondRetrievedId, legacyId, "Migrated identifier should persist")
+    }
+    
+    func testMigration_RegenerateAfterMigration_CreatesNewIdentifier() async throws {
+        // Given
+        let legacyId = "legacy-to-regenerate"
+        storeLegacyIdentifier(legacyId)
+        
+        deviceIdentifier = try DefaultDeviceIdentifier()
+        let migratedId = try await deviceIdentifier.id
+        XCTAssertEqual(migratedId, legacyId)
+        
+        // When
+        let newId = try await deviceIdentifier.regenerateIdentifier()
+        
+        // Then
+        XCTAssertNotEqual(newId, legacyId, "Regenerated ID should be different from legacy")
+        XCTAssertEqual(newId.count, 64, "New ID should use SHA-256")
+        
+        // Verify legacy storage is cleared
+        let legacyQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: LegacyDeviceIdentifier.LegacyKeychainKeys.identifier,
+            kSecReturnData as String: true
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(legacyQuery as CFDictionary, &result)
+        XCTAssertEqual(status, errSecItemNotFound, "Legacy identifier should be deleted")
+    }
+    
+    func testMigration_ConcurrentAccess_NoDuplicateMigration() async throws {
+        // Given
+        let legacyId = "concurrent-legacy-id"
+        storeLegacyIdentifier(legacyId)
+        
+        deviceIdentifier = try DefaultDeviceIdentifier()
+        
+        // When
+        async let id1 = deviceIdentifier.id
+        async let id2 = deviceIdentifier.id
+        async let id3 = deviceIdentifier.id
+        
+        let ids = try await [id1, id2, id3]
+        
+        // Then
+        XCTAssertEqual(Set(ids).count, 1, "All concurrent accesses should return same ID")
+        XCTAssertEqual(ids.first, legacyId, "Should return migrated legacy ID")
+    }
+    
+    func testMigration_LegacyUsingSHA1_NewUsesSHA256() async throws {
+        // Given: Legacy identifier (SHA-1 based, 40 hex chars)
+        let legacyId = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2" // 40 chars
+        storeLegacyIdentifier(legacyId)
+        
+        deviceIdentifier = try DefaultDeviceIdentifier()
+        let migratedId = try await deviceIdentifier.id
+        
+        // Then: Legacy ID preserved as-is
+        XCTAssertEqual(migratedId.count, 40, "Legacy SHA-1 hash should be 40 chars")
+        XCTAssertEqual(migratedId, legacyId)
+        
+        // When: Regenerating
+        let newId = try await deviceIdentifier.regenerateIdentifier()
+        
+        // Then: New ID uses SHA-256
+        XCTAssertEqual(newId.count, 64, "New SHA-256 hash should be 64 chars")
+        XCTAssertNotEqual(newId, legacyId)
+    }
+    
+    func testMigration_WithEncryptionEnabled_MigratesSuccessfully() async throws {
+        // Given
+        let legacyId = "encrypted-legacy-id"
+        storeLegacyIdentifier(legacyId)
+        
+        let config = DeviceIdentifierConfiguration(
+            keySize: 2048,
+            keychainAccount: Constants.deviceIdentifierKey,
+            useEncryption: true
+        )
+        
+        // When
+        deviceIdentifier = try DefaultDeviceIdentifier(configuration: config)
+        let retrievedId = try await deviceIdentifier.id
+        
+        // Then
+        XCTAssertEqual(retrievedId, legacyId, "Should migrate even with encryption enabled")
+    }
+    
+    func testMigration_CustomConfiguration_FindsLegacyIdentifier() async throws {
+        // Given
+        let customAccount = "com.test.custom.deviceid"
+        let config = DeviceIdentifierConfiguration(
+            keySize: 2048,
+            keychainAccount: customAccount,
+            useEncryption: false
+        )
+        
+        let legacyId = "legacy-id-different-account"
+        storeLegacyIdentifier(legacyId)
+        
+        // When
+        deviceIdentifier = try DefaultDeviceIdentifier(configuration: config)
+        let retrievedId = try await deviceIdentifier.id
+        
+        // Then
+        XCTAssertEqual(retrievedId, legacyId, "Should find legacy identifier regardless of config")
+        
+        // Verify stored in custom account
+        let customStorage = KeychainStorage<DeviceIdentifierImpl>(
+            account: customAccount,
+            encryptor: NoEncryptor()
+        )
+        let stored = try await customStorage.get()
+        XCTAssertNotNil(stored, "Should store in custom location")
+    }
+}
+
+extension Data {
+    func toHexString() -> String {
+        map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/DeviceId/README.md
+++ b/DeviceId/README.md
@@ -1,4 +1,3 @@
-
 <p align="center">
   <a href="https://github.com/ForgeRock/ping-ios-sdk">
     <img src="https://www.pingidentity.com/content/dam/picr/nav/Ping-Logo-2.svg" alt="Logo">
@@ -22,16 +21,17 @@ The core implementation, `DefaultDeviceIdentifier`, is built as a Swift `actor` 
 - **⚙️ Configurable**: Allows customization of the Keychain account name, key size, and optional data encryption.
 - **⚡️ Asynchronous API**: Fully embraces modern Swift concurrency with an `async/await` interface.
 - **🧩 Extensible**: Define your own identifier strategy by conforming to the `DeviceIdentifier` protocol.
+- **🔄 Legacy Migration**: Automatically migrates device identifiers from FRAuth SDK format, ensuring seamless transition for existing users.
 
 ***
 
 ## Installation
 
 Add dependency to your project
-To integrate Journey into your iOS project, add the following dependency to your Podfile or Package.swift file:
+To integrate the DeviceId module into your iOS project, add the following dependency to your Podfile or Package.swift file:
 
 ```
-pod 'PingJourney', '<version>'
+pod 'PingDeviceId', '<version>'
 ```
 or for Swift Package Manager:
 
@@ -39,9 +39,9 @@ or for Swift Package Manager:
 .package(url: "https://github.com/ForgeRock/ping-ios-sdk.git", from: "<version>")
 ```
 
-Replace <version> with the latest version of the Journey SDK.
+Replace `<version>` with the latest version of the SDK.
 
-Select the `DeviceId` library from the list of package products.
+Select the `PingDeviceId` library from the list of package products.
 
 ***
 
@@ -51,7 +51,7 @@ Select the `DeviceId` library from the list of package products.
 
 Instantiate `DefaultDeviceIdentifier` and access the `id` property. The identifier is generated on its first use and subsequently retrieved from the cache or Keychain.
 
-The `id` is a SHA-256 hash of the public key, providing a stable and unique representation of the device's identity key.
+For newly generated identifiers, the `id` is a SHA-256 hash of the RSA public key, providing a stable and unique representation of the device's identity key.
 
 ```swift
 import PingDeviceId
@@ -67,11 +67,11 @@ Task {
         print("Error retrieving device ID: \(error)")
     }
 }
-````
+```
 
 ### Usage with Configuration
 
-You can customize the behavior, such as specifying a Keychain account name or disabling encryption (not recommended for production).
+You can customize the behavior, such as specifying a Keychain account name, key size, or encryption settings.
 
 ```swift
 import PingDeviceId
@@ -92,9 +92,26 @@ do {
 }
 ```
 
+#### Predefined Configurations
+
+The module provides two predefined configurations for common use cases:
+
+```swift
+// Default configuration with 2048-bit RSA keys and encryption enabled
+let defaultIdentifier = try DefaultDeviceIdentifier(configuration: .default)
+
+// High security configuration with 4096-bit RSA keys and encryption enabled
+let secureIdentifier = try DefaultDeviceIdentifier(configuration: .highSecurity)
+```
+
+**Configuration Options:**
+- `keySize`: RSA key size in bits (2048 for `.default`, 4096 for `.highSecurity`)
+- `keychainAccount`: Custom keychain account identifier for storage isolation
+- `useEncryption`: Whether to encrypt the stored key pair (recommended: `true`)
+
 ### Regenerating the Identifier
 
-If needed, you can explicitly delete the existing key pair from the Keychain and generate a new one.
+If needed, you can explicitly delete the existing key pair from the Keychain and generate a new one. This also clears any legacy identifier storage to ensure a completely fresh identifier is generated.
 
 ```swift
 // In an async context
@@ -105,6 +122,63 @@ do {
     print("Error regenerating ID: \(error)")
 }
 ```
+
+**Note:** Regenerating the identifier will:
+- Clear the in-memory cache
+- Delete the current identifier from keychain storage
+- Delete any legacy FRAuth SDK identifier storage
+- Generate a completely new RSA key pair and identifier
+
+-----
+
+## Legacy Migration
+
+The module automatically handles migration from the legacy FRAuth SDK device identifier format. When retrieving a device identifier for the first time, the system will:
+
+1. **Check for existing identifier** in the new PingDeviceId format
+2. **Search for legacy identifier** from FRAuth SDK if not found
+3. **Migrate the legacy identifier** to the new storage format while preserving the original value
+4. **Generate a new identifier** only if no legacy identifier exists
+
+This ensures that existing users maintain the same device identifier when transitioning from FRAuth to PingDeviceId, providing continuity across SDK versions.
+
+### How Legacy Migration Works
+
+The legacy FRAuth SDK stored device identifiers using:
+- **Hashing Algorithm**: SHA-1 hash of the RSA public key as the identifier
+- **Keychain Storage**: 
+  - Identifier stored at account `com.forgerock.ios.device-identifier.hash-base64-string-identifier`
+  - Public key data stored separately at account `com.forgerock.ios.device-identifier.pubic-key.data`
+- **No Encryption**: Keys and identifiers stored in plain format
+
+The new PingDeviceId module:
+- **Hashing Algorithm**: SHA-256 hash of the RSA public key for newly generated identifiers
+- **Legacy Preservation**: Preserves legacy SHA-1 identifiers when migrating (no re-hashing)
+- **Unified Storage**: Stores both the identifier and key pair in a single structured format
+- **Optional Encryption**: Supports encryption for enhanced security (enabled by default)
+- **Graceful Fallback**: Attempts to regenerate legacy identifier from public key if main identifier is missing
+
+### Migration Example
+
+```swift
+import PingDeviceId
+
+// On first access after upgrading from FRAuth SDK
+let deviceIdentifier = try DefaultDeviceIdentifier()
+
+Task {
+    // This will automatically detect and migrate the legacy identifier
+    let id = try await deviceIdentifier.id
+    print("Device ID: \(id)")
+    // Output will be the same identifier as in FRAuth SDK
+}
+```
+
+**Important Notes:**
+- Legacy identifiers are preserved exactly as they were in FRAuth SDK (SHA-1 hashed)
+- Only newly generated identifiers use the improved SHA-256 hashing algorithm
+- Migration happens transparently on first access - no manual intervention required
+- After migration, the identifier is stored in the new encrypted format (if encryption is enabled)
 
 -----
 
@@ -119,11 +193,21 @@ The identifier's behavior is determined by its storage in the iOS Keychain.
 | **Device Backup & Restore** | The identifier **persists** if the device is restored from an encrypted iCloud or local backup, as these backups include Keychain data. |
 | **Factory Reset** | The identifier is **permanently deleted** as the entire device storage, including the Keychain, is wiped. |
 | **Sharing Across Apps** | The identifier can be shared across apps from the same developer by using the same **Keychain Access Group** in the configuration. |
+| **Migration from FRAuth** | Legacy identifiers are **automatically migrated** and preserved, ensuring continuity for existing users. The original SHA-1 hash is maintained. |
+| **Regeneration** | Calling `regenerateIdentifier()` **deletes both new and legacy** storage, generating a completely fresh identifier with a new key pair. |
+
+### Hashing Algorithms
+
+| Identifier Type | Hashing Algorithm | When Used |
+| :--- | :--- | :--- |
+| **Legacy (FRAuth SDK)** | SHA-1 | Migrated identifiers from FRAuth SDK (preserved as-is) |
+| **New (PingDeviceId)** | SHA-256 | Newly generated identifiers in PingDeviceId module |
 
 -----
-## Fallback to a simple UUIDDeviceIDentifier
 
-In case of errors or if it required to create a simpler less secure DeviceIdentifier the provided `UUIDDeviceIdentifier` can be used.
+## Fallback to a simple UUIDDeviceIdentifier
+
+In case of errors or if a simpler, less secure DeviceIdentifier is required, the provided `UUIDDeviceIdentifier` can be used.
 
 ```swift
 import PingDeviceId
@@ -139,7 +223,11 @@ Task {
         print("Error retrieving device ID: \(error)")
     }
 }
-````
+```
+
+**Note**: `UUIDDeviceIdentifier` generates a random UUID-based identifier that persists in the keychain. While simpler, it offers less cryptographic strength than the RSA-based approach and does not support legacy migration.
+
+-----
 
 ## Custom Implementation
 
@@ -152,12 +240,93 @@ public protocol DeviceIdentifier: Sendable {
     var id: String { get async throws }
 }
 
-// Example: A custom identifier that uses UUID
-struct CustomDeviceIdentifier: DeviceIdentifier {
+// Example: A custom identifier that uses a timestamp-based UUID
+actor CustomDeviceIdentifier: DeviceIdentifier {
+    private let storage: KeychainStorage<String>
+    
+    init() {
+        self.storage = KeychainStorage<String>(
+            account: "com.mycompany.custom.deviceid",
+            encryptor: NoEncryptor()
+        )
+    }
+    
     var id: String {
-        // This is a simple example; for persistence, you would need
-        // to save and retrieve the UUID from a storage mechanism.
-        return UUID().uuidString
+        get async throws {
+            if let stored = try await storage.get() {
+                return stored
+            }
+            
+            // Generate custom identifier
+            let customId = "\(Date().timeIntervalSince1970)-\(UUID().uuidString)"
+            try await storage.save(item: customId)
+            return customId
+        }
     }
 }
 ```
+
+-----
+
+## Error Handling
+
+The module defines specific error cases for various failure scenarios:
+
+```swift
+public enum DeviceIdentifierError: Error {
+    case encryptionInitializationFailed  // Encryption setup failed
+    case keyGenerationFailed(Error)      // RSA key generation failed
+    case publicKeyExtractionFailed       // Could not extract public key
+    case externalRepresentationFailed(Error)  // Key export failed
+    case keychainItemNotFound            // Item not in keychain
+    case keychainUnexpectedData          // Keychain data malformed
+    case keychainUnexpectedStatus(OSStatus)  // Unexpected keychain status
+}
+```
+
+Example error handling:
+
+```swift
+do {
+    let id = try await deviceIdentifier.id
+    print("Device ID: \(id)")
+} catch DeviceIdentifierError.encryptionInitializationFailed {
+    print("Failed to initialize encryption - consider using unencrypted storage")
+} catch DeviceIdentifierError.keyGenerationFailed(let error) {
+    print("Key generation failed: \(error)")
+} catch {
+    print("Unexpected error: \(error)")
+}
+```
+
+-----
+
+## Thread Safety
+
+`DefaultDeviceIdentifier` is implemented as a Swift `actor`, providing the following guarantees:
+
+- **Race Condition Prevention**: Multiple concurrent calls to `id` will not trigger duplicate key generation
+- **Task Deduplication**: If key generation is in progress, subsequent callers await the same result
+- **Cache Coherency**: In-memory cache is protected from concurrent access issues
+
+This makes it safe to use from multiple parts of your application without additional synchronization.
+
+-----
+
+## Performance Considerations
+
+- **First Access**: Initial identifier generation involves RSA key pair creation, which may take 100-500ms depending on key size
+- **Subsequent Access**: Cached in memory after first retrieval - sub-millisecond performance
+- **Background Generation**: Key generation runs on a background task to avoid blocking the main thread
+- **Encryption Overhead**: When encryption is enabled, there's minimal overhead for keychain operations (typically <10ms)
+
+**Recommendations:**
+- Access the identifier early in app lifecycle to warm the cache
+- Use `.default` configuration (2048-bit keys) for most applications
+- Reserve `.highSecurity` configuration (4096-bit keys) for high-security requirements
+
+-----
+
+## License
+
+This software may be modified and distributed under the terms of the MIT license. See the LICENSE file for details.


### PR DESCRIPTION
Adding automatic migration of Legacy identifiers. Preserving old identifier and adding ability to regenerate with new SDK (SHA-256 if regenerated).

**Summary of Changes**
This PR introduces a Legacy Migration mechanism to the DeviceId library. The goal is to ensure that users upgrading from the previous FRAuth SDK to the new PingDeviceId library retain their existing device identifiers, rather than generating new ones upon upgrade.

**Key implementations:**

Legacy Detection: Added logic to check the Keychain for data stored by the old SDK (specifically looking for SHA-1 based identifiers).

**Migration Strategy:**

- If a legacy identifier string exists, it is adopted.
 
- If only the legacy public key exists, the identifier is re-calculated using the legacy algorithm (SHA-1) and adopted.
 
- Once found, the legacy ID is wrapped in the new DeviceIdentifierImpl format and stored, so future lookups are fast.
 
- Logic Updates: Modified DefaultDeviceIdentifier to check for legacy data before generating a new RSA key pair.
 
- Cleanup: Updated regenerateIdentifier to ensure it wipes both the new storage and the old legacy storage to guarantee a fresh start.

# JIRA Ticket

[JIRA](https://bugster.forgerock.org/jira/browse/SDKS-4630) "Enhance DefaultDeviceIdentifier to Reuse Legacy Device Identifier When Available"

# Description

Briefly describe the change and any information that would help speedup the review and testing process.

# Checklist:

- [X] I ran all unit tests and they pass
- [X] I added test case coverage for my changes
