### PR TITLE
SDKS-4717 - Fixing Browser close and reset logic

### DIFF
--- a/Browser/Browser/BrowserLauncher.swift
+++ b/Browser/Browser/BrowserLauncher.swift
@@ -302,8 +302,8 @@ public final class BrowserLauncher: NSObject, BrowserLauncherProtocol {
                     self.state = .closing
                     
                     // Close the UI
-                    safariVC.dismiss(animated: true) {
-                        self.cleanup()
+                    safariVC.dismiss(animated: true) { [weak self] in
+                        self?.cleanup()
                     }
                 }
         }

--- a/Browser/Browser/BrowserLauncher.swift
+++ b/Browser/Browser/BrowserLauncher.swift
@@ -69,7 +69,7 @@ public final class BrowserLauncher: NSObject, BrowserLauncherProtocol {
     // MARK: Properties
     
     /// Static shared instance
-    public static let currentBrowser: BrowserLauncherProtocol = BrowserLauncher()
+    public static var currentBrowser: BrowserLauncherProtocol = BrowserLauncher()
     
     public var isInProgress: Bool {
         if case .idle = state { return false }

--- a/Browser/Browser/BrowserLauncher.swift
+++ b/Browser/Browser/BrowserLauncher.swift
@@ -127,15 +127,24 @@ public final class BrowserLauncher: NSObject, BrowserLauncherProtocol {
         
         state = .closing
         
-        if let session = session as? SFSafariViewController {
-            session.dismiss(animated: false) {
+        // Resume continuation with cancellation error
+        loginContinuation?.resume(throwing: BrowserError.externalUserAgentCancelled)
+        
+        // Handle cleanup based on session type
+        if let sfViewController = session as? SFSafariViewController {
+            logger.i("Resetting SFSafariViewController session")
+            sfViewController.dismiss(animated: false) {
                 self.cleanup()
             }
+        } else if let asAuthSession = session as? ASWebAuthenticationSession {
+            logger.i("Resetting ASWebAuthenticationSession")
+            asAuthSession.cancel()
+            cleanup()
         } else {
+            // Native browser or unknown session type
+            logger.i("Resetting non-UI session")
             cleanup()
         }
-        
-        loginContinuation?.resume(throwing: BrowserError.externalUserAgentCancelled)
     }
     
     /// Launches external user-agent for web requests
@@ -298,17 +307,18 @@ public final class BrowserLauncher: NSObject, BrowserLauncherProtocol {
     private func asWebAuthenticationSession(url: URL, callbackURLScheme: String,
                                             prefersEphemeralWebBrowserSession: Bool) async throws -> URL {
         return try await withCheckedThrowingContinuation { continuation in
+            self.loginContinuation = continuation
             let authSession = ASWebAuthenticationSession(url: url, callbackURLScheme: callbackURLScheme) { [weak self] (url, error) in
                 guard let self = self else { return }
                 
                 self.state = .closing
                 
                 if let error = error {
-                    continuation.resume(throwing: error)
+                    self.loginContinuation?.resume(throwing: error)
                 } else if let url = url {
-                    continuation.resume(returning: url)
+                    self.loginContinuation?.resume(returning: url)
                 } else {
-                    continuation.resume(throwing: BrowserError.externalUserAgentFailure)
+                    self.loginContinuation?.resume(throwing: BrowserError.externalUserAgentFailure)
                 }
                 self.cleanup()
             }
@@ -319,30 +329,12 @@ public final class BrowserLauncher: NSObject, BrowserLauncherProtocol {
             
             if !authSession.start() {
                 self.state = .closing
-                continuation.resume(throwing: BrowserError.externalUserAgentFailure)
+                self.loginContinuation?.resume(throwing: BrowserError.externalUserAgentFailure)
                 self.cleanup()
             }
         }
     }
-    
-    /// Closes currently presenting ViewController
-    private func close() async {
-        guard case .authenticating(let session) = state else {
-            return
-        }
-        
-        if let sfViewController = session as? SFSafariViewController {
-            self.logger.i("Close called with SFSafariViewController: \(String(describing: self.currentSession))")
-            sfViewController.dismiss(animated: true)
-        }
-        
-        if let asAuthSession = session as? ASWebAuthenticationSession {
-            self.logger.i("Close called with ASWebAuthenticationSession: \(String(describing: self.currentSession))")
-            asAuthSession.cancel()
-        }
-        
-        reset()
-    }
+
 }
 
 // MARK: ASWebAuthenticationPresentationContextProviding

--- a/Browser/Browser/BrowserLauncher.swift
+++ b/Browser/Browser/BrowserLauncher.swift
@@ -2,7 +2,7 @@
 //  Browser.swift
 //  Browser
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -15,6 +15,7 @@ import SafariServices
 import Combine
 import UIKit
 
+// MARK: - Enums
 /// BrowserType enum to specify the type of external user-agent;
 /// ASWebAuthenticationSession, Native Browser App,  SFSafariViewController,
 /// or ASWebAuthenticationSession with prefersEphemeralWebBrowserSession set to true
@@ -32,16 +33,16 @@ public enum BrowserError: Error, Sendable {
     case externalUserAgentCancelled
 }
 
-/// BrowserMode enum to specify the mode of the browser; login, logout, or custom
+/// BrowserMode enum to specify the mode of the browser
 public enum BrowserMode: Sendable {
     case login
     case logout
     case custom
 }
 
+// MARK: - Protocol
 /// A protocol to abstract the BrowserLauncher functionality (if not already provided).
 /// (If your project already has a protocol that BrowserLauncher conforms to, you can use it.)
-
 @MainActor
 public protocol BrowserLauncherProtocol: Sendable {
     var isInProgress: Bool { get }
@@ -51,97 +52,88 @@ public protocol BrowserLauncherProtocol: Sendable {
     func handleAppActivation()
 }
 
+// MARK: - BrowserLauncher
+
 /// BrowserLauncher class to launch external user-agent for web requests
 @MainActor
 public final class BrowserLauncher: NSObject, BrowserLauncherProtocol {
     
+    // MARK: Internal State
     private enum State {
         case idle
         case launching
-        case authenticating(session: Any)
+        case authenticating(session: Any) // Holds ASWebAuthenticationSession or SFSafariViewController
         case closing
     }
     
     // MARK: Properties
     
-    /// Static shared instance of current Browser object
-    public static var currentBrowser: BrowserLauncherProtocol = BrowserLauncher()
+    /// Static shared instance
+    public static let currentBrowser: BrowserLauncherProtocol = BrowserLauncher()
     
-    /// Boolean indicator whether or not current Browser object is in progress
     public var isInProgress: Bool {
-        if case .idle = state {
-            return false
-        }
+        if case .idle = state { return false }
         return true
     }
     
-    /// Custom URL query parameter for /authorize request
-    private var customParams: [String: String] = [:]
-    
-    /// Type of external user-agent; Authentication Service, Native Browser App, or SFSafariViewController
+    private var state: State = .idle
     private var browserType: BrowserType = .authSession
-    
-    /// Current external user-agent instance
-    private var currentSession: Any? {
-        if case .authenticating(let session) = state {
-            return session
-        }
-        return nil
-    }
-    
-    /// Browser mode (either login, logout or custom)
     private var browserMode: BrowserMode = .login
+    private var logger: Logger = LogManager.logger
     
-    /// Continuation to be used by the delegate or the sink
+    // Concurrency & Combine
     private var loginContinuation: CheckedContinuation<URL, Error>?
-    
-    /// Cancellable for Combine subscription
     private var cancellable: AnyCancellable?
     
-    /// Logger instance
-    var logger: Logger = LogManager.logger
-    
-    private var state: State = .idle
-    
-    // MARK: Public Methods
+    // MARK: - Public Methods
     
     /// Handles app activation event
-    /// - Note: If the app becomes active during native browser authentication, the authentication will be cancelled.
     public func handleAppActivation() {
-        if case .authenticating(let session) = state, session is String {
+        // If we are using the Native Browser (jumping out of app), and the app comes back
+        // to foreground without a URL callback, we assume the user cancelled/switched back manually.
+        if case .authenticating(let session) = state, session is String { // "String" marker used for Native Browser
             logger.i("App became active during native browser authentication. Cancelling.")
-            loginContinuation?.resume(throwing: BrowserError.externalUserAgentCancelled)
-            cleanup()
+            reset()
         }
     }
     
-    /// Resets the browser state and dismisses any presented view controllers.
-    /// - Note: If the browser is not in an authenticating state, this method will log a warning and return without making any changes.
+    /// Resets the browser state, cancels continuations, and dismisses controllers.
     public func reset() {
-        logger.i("Resetting the browser")
+        logger.i("Resetting the browser. Current state: \(state)")
         
         guard case .authenticating(let session) = state else {
-            logger.w("Browser is not in a state that can be reset.", error: nil)
+            // If we are launching or closing, we still might need to clean up continuation
+            if loginContinuation != nil {
+                forceCancelContinuation()
+                cleanup()
+            } else {
+                logger.w("Browser is not in a state that requires reset.", error: nil)
+            }
             return
         }
         
         state = .closing
         
-        // Resume continuation with cancellation error
-        loginContinuation?.resume(throwing: BrowserError.externalUserAgentCancelled)
+        // 1. Capture and Nil the continuation to prevent double-resume
+        let pendingContinuation = self.loginContinuation
+        self.loginContinuation = nil
         
-        // Handle cleanup based on session type
+        // 2. Resume with cancellation error immediately
+        pendingContinuation?.resume(throwing: BrowserError.externalUserAgentCancelled)
+        
+        // 3. Handle Session Cleanup
         if let sfViewController = session as? SFSafariViewController {
-            logger.i("Resetting SFSafariViewController session")
-            sfViewController.dismiss(animated: false) {
-                self.cleanup()
+            logger.i("Dismissing SFSafariViewController")
+            sfViewController.dismiss(animated: false) { [weak self] in
+                self?.cleanup()
             }
         } else if let asAuthSession = session as? ASWebAuthenticationSession {
-            logger.i("Resetting ASWebAuthenticationSession")
+            logger.i("Cancelling ASWebAuthenticationSession")
+            // This triggers the completion handler, but we nilled the continuation above, so it's safe.
             asAuthSession.cancel()
             cleanup()
         } else {
-            // Native browser or unknown session type
+            // Native browser or unknown
             logger.i("Resetting non-UI session")
             cleanup()
         }
@@ -156,68 +148,48 @@ public final class BrowserLauncher: NSObject, BrowserLauncherProtocol {
     ///   - callbackURLScheme: The callbackURLScheme to be used for returning to the app. Used in ASWebAuthenticationSession modes
     ///   - Returns: URL of the external user-agent
     ///   - Throws: BrowserError
-    public func launch(url: URL, customParams: [String: String]? = nil,
-                       browserType: BrowserType = .authSession, browserMode: BrowserMode = .login, callbackURLScheme: String) async throws -> URL {
+    public func launch(url: URL,
+                       customParams: [String: String]? = nil,
+                       browserType: BrowserType = .authSession,
+                       browserMode: BrowserMode = .login,
+                       callbackURLScheme: String) async throws -> URL {
+        
+        // Refresh logger
         logger = LogManager.logger
         
         guard case .idle = state else {
+            logger.e("Attempted to launch browser while another session is in progress", error: nil)
             throw BrowserError.externalUserAgentAuthenticationInProgress
         }
         
         state = .launching
+        self.browserType = browserType
+        self.browserMode = browserMode
         
-        var finalUrl = url
-        if let params = customParams, !params.isEmpty {
-            var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true)
-            
-            let queryItems = params.map { URLQueryItem(name: $0.key, value: $0.value) }
-            
-            if var existingItems = urlComponents?.queryItems {
-                existingItems.append(contentsOf: queryItems)
-                urlComponents?.queryItems = existingItems
-            } else {
-                urlComponents?.queryItems = queryItems
-            }
-            
-            if let updatedUrl = urlComponents?.url {
-                finalUrl = updatedUrl
-            } else {
-                logger.i("Failed to append custom parameters to URL, using original URL")
-            }
-        }
+        // Prepare URL
+        let finalUrl = appendCustomParams(to: url, params: customParams)
+        
+        logger.i("Launching browser type: \(browserType) for URL: \(finalUrl.absoluteString)")
         
         return try await performLaunch(url: finalUrl, browserType: browserType, callbackURLScheme: callbackURLScheme)
     }
     
-    // MARK: Private Methods
-    /// Performs authentication through /authorize endpoint using SFSafariViewController
-    /// - Parameters:
-    ///   - url: URL of /authorize including all URL query parameter
-    /// - Returns: URL after authentication is complete
-    /// - Throws: BrowserError if the view controller cannot be presented
-    private func loginWithNativeBrowser(url: URL, callbackURLScheme: String ) async throws -> URL {
-        let opened = await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
-            UIApplication.shared.open(url, options: [:]) { success in
-                cont.resume(returning: success)
-            }
-        }
-        guard opened else {
-            throw BrowserError.externalUserAgentFailure
+    // MARK: - Private Helpers
+    
+    private func appendCustomParams(to url: URL, params: [String: String]?) -> URL {
+        guard let params = params, !params.isEmpty else { return url }
+        
+        var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true)
+        let queryItems = params.map { URLQueryItem(name: $0.key, value: $0.value) }
+        
+        if var existingItems = urlComponents?.queryItems {
+            existingItems.append(contentsOf: queryItems)
+            urlComponents?.queryItems = existingItems
+        } else {
+            urlComponents?.queryItems = queryItems
         }
         
-        state = .authenticating(session: "Native Browser")
-        
-        return try await withCheckedThrowingContinuation { continuation in
-            self.loginContinuation = continuation
-            
-            self.cancellable = OpenURLMonitor.shared.urlPublisher
-                .filter { $0.scheme == callbackURLScheme }
-                .first()
-                .sink { [weak self] url in
-                    self?.loginContinuation?.resume(returning: url)
-                    self?.cleanup()
-                }
-        }
+        return urlComponents?.url ?? url
     }
     
     /// Performs the launch based on the specified browser type
@@ -231,13 +203,10 @@ public final class BrowserLauncher: NSObject, BrowserLauncherProtocol {
         switch browserType {
         case .nativeBrowserApp:
             return try await loginWithNativeBrowser(url: url, callbackURLScheme: callbackURLScheme)
-            
         case .sfViewController:
             return try await loginWithSFViewController(url: url, callbackURLScheme: callbackURLScheme)
-            
         case .authSession:
             return try await asWebAuthenticationSession(url: url, callbackURLScheme: callbackURLScheme, prefersEphemeralWebBrowserSession: false)
-            
         case .ephemeralAuthSession:
             return try await asWebAuthenticationSession(url: url, callbackURLScheme: callbackURLScheme, prefersEphemeralWebBrowserSession: true)
         }
@@ -248,53 +217,96 @@ public final class BrowserLauncher: NSObject, BrowserLauncherProtocol {
     ///   - url: URL of /authorize including all URL query parameter
     /// - Returns: URL after authentication is complete
     /// - Throws: BrowserError if the view controller cannot be presented
-    private func loginWithSFViewController(url: URL, callbackURLScheme: String ) async throws -> URL {
-        let safariVC = SFSafariViewController(url: url)
-        safariVC.delegate = self
-        safariVC.modalPresentationStyle = .fullScreen
-        state = .authenticating(session: safariVC)
+    private func forceCancelContinuation() {
+        if let continuation = loginContinuation {
+            continuation.resume(throwing: BrowserError.externalUserAgentCancelled)
+            loginContinuation = nil
+        }
+    }
+    
+    // Cleans up the cancelables and continuations
+    private func cleanup() {
+        cancellable?.cancel()
+        cancellable = nil
+        loginContinuation = nil // Ensure nil
+        state = .idle
+        logger.i("Browser session cleaned up.")
+    }
+    
+    // MARK: - Specific Browser Implementations
+    
+    /// Performs authentication through /authorize endpoint using Native Browser
+    /// - Parameters:
+    ///   - url: URL of /authorize including all URL query parameter
+    ///   - callbackURLScheme: Callback URL Scheme to return to the app
+    /// - Returns: URL after authentication is complete
+    /// - Throws: BrowserError if authentication fails
+    private func loginWithNativeBrowser(url: URL, callbackURLScheme: String) async throws -> URL {
+        let opened = await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
+            UIApplication.shared.open(url, options: [:]) { success in
+                cont.resume(returning: success)
+            }
+        }
         
-        guard
-            let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-            let presentingVC = windowScene.windows.first(where: { $0.isKeyWindow })?.rootViewController
-        else {
-            logger.e("Fail to launch SFSafariViewController; missing presenting ViewController", error: nil)
+        guard opened else {
+            state = .idle
             throw BrowserError.externalUserAgentFailure
         }
         
+        state = .authenticating(session: "Native Browser")
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            self.loginContinuation = continuation
+            self.observeCallback(scheme: callbackURLScheme)
+        }
+    }
+    
+    /// Performs authentication through /authorize endpoint using SFViewController
+    /// - Parameters:
+    ///   - url: URL of /authorize including all URL query parameter
+    ///   - callbackURLScheme: Callback URL Scheme to return to the app
+    /// - Returns: URL after authentication is complete
+    /// - Throws: BrowserError if authentication fails
+    private func loginWithSFViewController(url: URL, callbackURLScheme: String) async throws -> URL {
+        let safariVC = SFSafariViewController(url: url)
+        safariVC.delegate = self
+        safariVC.modalPresentationStyle = .fullScreen
+        
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let presentingVC = windowScene.windows.first(where: { $0.isKeyWindow })?.rootViewController else {
+            logger.e("Fail to launch SFSafariViewController; missing presenting ViewController", error: nil)
+            state = .idle
+            throw BrowserError.externalUserAgentFailure
+        }
+        
+        // We set state BEFORE presenting to prevent race conditions
+        state = .authenticating(session: safariVC)
         presentingVC.present(safariVC, animated: true)
         
         return try await withCheckedThrowingContinuation { continuation in
             self.loginContinuation = continuation
             
+            // For SFVC, we also listen for the URL callback via the Monitor
             self.cancellable = OpenURLMonitor.shared.urlPublisher
                 .filter { $0.scheme == callbackURLScheme }
                 .first()
                 .sink { [weak self] url in
                     guard let self = self else { return }
                     
-                    if case .authenticating(let session) = self.state {
-                        self.state = .closing
-                        self.loginContinuation?.resume(returning: url)
-                        if let sfViewController = session as? SFSafariViewController {
-                            sfViewController.dismiss(animated: true) {
-                                self.cleanup()
-                            }
-                        } else {
-                            self.cleanup()
-                        }
+                    // SFVC flow successful
+                    if let activeContinuation = self.loginContinuation {
+                        activeContinuation.resume(returning: url)
+                        self.loginContinuation = nil // Consumed
+                    }
+                    
+                    self.state = .closing
+                    
+                    // Close the UI
+                    safariVC.dismiss(animated: true) {
+                        self.cleanup()
                     }
                 }
         }
-    }
-    
-    /// Clean up subscription and reset state
-    private func cleanup() {
-        cancellable?.cancel()
-        cancellable = nil
-        loginContinuation = nil
-        state = .idle
-        logger.i("Browser session cleaned up and state reset.")
     }
     
     /// Performs authentication through /authorize endpoint using ASWebAuthenticationSession
@@ -306,49 +318,98 @@ public final class BrowserLauncher: NSObject, BrowserLauncherProtocol {
     /// - Throws: BrowserError if authentication fails
     private func asWebAuthenticationSession(url: URL, callbackURLScheme: String,
                                             prefersEphemeralWebBrowserSession: Bool) async throws -> URL {
-        return try await withCheckedThrowingContinuation { continuation in
+        
+        return try await withCheckedThrowingContinuation { [weak self] continuation in
+            guard let self = self else {
+                continuation.resume(throwing: BrowserError.externalUserAgentFailure)
+                return
+            }
+            
             self.loginContinuation = continuation
-            let authSession = ASWebAuthenticationSession(url: url, callbackURLScheme: callbackURLScheme) { [weak self] (url, error) in
+            
+            let authSession = ASWebAuthenticationSession(url: url, callbackURLScheme: callbackURLScheme) { [weak self] (callbackURL, error) in
                 guard let self = self else { return }
                 
+                self.logger.i("ASWebAuthenticationSession callback received")
+                
+                // CRITICAL: Check if continuation is still valid (not nilled by reset())
+                guard let activeContinuation = self.loginContinuation else {
+                    self.logger.i("Continuation already consumed or cancelled. Ignoring Session callback.")
+                    return
+                }
+                
+                self.loginContinuation = nil // Consume it
                 self.state = .closing
                 
                 if let error = error {
-                    self.loginContinuation?.resume(throwing: error)
-                } else if let url = url {
-                    self.loginContinuation?.resume(returning: url)
+                    // Check for User Cancel
+                    let nsError = error as NSError
+                    if nsError.domain == ASWebAuthenticationSessionError.errorDomain,
+                       nsError.code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
+                        activeContinuation.resume(throwing: BrowserError.externalUserAgentCancelled)
+                    } else {
+                        activeContinuation.resume(throwing: error)
+                    }
+                } else if let url = callbackURL {
+                    activeContinuation.resume(returning: url)
                 } else {
-                    self.loginContinuation?.resume(throwing: BrowserError.externalUserAgentFailure)
+                    activeContinuation.resume(throwing: BrowserError.externalUserAgentFailure)
                 }
+                
                 self.cleanup()
             }
             
             authSession.presentationContextProvider = self
             authSession.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession
+            
             self.state = .authenticating(session: authSession)
             
             if !authSession.start() {
+                self.logger.e("Failed to start ASWebAuthenticationSession", error: nil)
                 self.state = .closing
+                // Resume immediately on failure
                 self.loginContinuation?.resume(throwing: BrowserError.externalUserAgentFailure)
+                self.loginContinuation = nil
                 self.cleanup()
             }
         }
     }
-
-}
-
-// MARK: ASWebAuthenticationPresentationContextProviding
-extension BrowserLauncher: ASWebAuthenticationPresentationContextProviding {
-    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        return ASPresentationAnchor()
+    
+    private func observeCallback(scheme: String) {
+        // Used for Native Browser mode
+        self.cancellable = OpenURLMonitor.shared.urlPublisher
+            .filter { $0.scheme == scheme }
+            .first()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] url in
+                guard let self = self, let continuation = self.loginContinuation else { return }
+                continuation.resume(returning: url)
+                self.loginContinuation = nil
+                self.cleanup()
+            }
     }
 }
 
-// MARK: SFSafariViewControllerDelegate
+// MARK: - ASWebAuthenticationPresentationContextProviding
+
+extension BrowserLauncher: ASWebAuthenticationPresentationContextProviding {
+    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        // Fix: Return the actual window, not a new instance
+        let window = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
+        
+        return window ?? ASPresentationAnchor()
+    }
+}
+
+// MARK: - SFSafariViewControllerDelegate
+
 extension BrowserLauncher: SFSafariViewControllerDelegate {
     nonisolated public func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
         Task { @MainActor [weak self] in
-            self?.logger.i("User cancelled the authorization process by closing the window")
+            self?.logger.i("User cancelled SFSafariViewController by closing the window")
             self?.reset()
         }
     }
@@ -356,27 +417,23 @@ extension BrowserLauncher: SFSafariViewControllerDelegate {
     nonisolated public func safariViewController(_ controller: SFSafariViewController, initialLoadDidRedirectTo URL: URL) {}
 }
 
+// MARK: - OpenURLMonitor
+
 /// A singleton that publishes all URLs your app is asked to open.
 @MainActor
 public final class OpenURLMonitor: NSObject {
     
-    /// Shared singleton instance
     public static let shared = OpenURLMonitor()
     
-    /// Any subscriber can listen to this to be notified of incoming URLs
     public let urlPublisher = PassthroughSubject<URL, Never>()
     
     private override init() {
         super.init()
     }
     
-    /// Call this from your AppDelegate/SceneDelegate when the app is asked to open a URL.
-    /// - Returns: You can return the Bool back to the system if you want.
     @discardableResult
     public func handleOpenURL(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        // Broadcast the URL
         urlPublisher.send(url)
-        // Return true to indicate you handled it
         return true
     }
 }


### PR DESCRIPTION
# JIRA Ticket

[JIRA](https://bugster.forgerock.org/jira/browse/SDKS-4717) "Close External Browser (External IdP Authentication) if user doesn't respond in specified time"

# Description

**Summary of Changes**
The diff represents a refactor of the BrowserLauncher class, specifically focusing on how web authentication sessions are managed and cancelled.

**Consolidated Cancellation Logic**: The private close() method has been removed. Its logic (handling specific session types like SFSafariViewController and ASWebAuthenticationSession) has been moved into the reset() method (inferred name based on context/code structure).

**Fixed Continuation Leak**: In asWebAuthenticationSession, the code now captures the continuation into the instance property self.loginContinuation immediately. Previously, the continuation was only local to the closure, making it impossible for external methods (like a cancel button) to fail the specific active await call.

**Explicit Session Handling**: The reset logic now explicitly checks for ASWebAuthenticationSession to call .cancel(), whereas previously it only specialized for SFSafariViewController and treated everything else generically.

**Logging**: Added info logs (logger.i) to track which type of session is being reset.

# Checklist:

- [X] I ran all unit tests and they pass
- [] I added test case coverage for my changes
