### PR TITLE
SDKS-4713 Fixing issues found during sample app implementation

### DIFF
--- a/Oath/Oath/Core/OathService.swift
+++ b/Oath/Oath/Core/OathService.swift
@@ -2,7 +2,7 @@
 //  OathService.swift
 //  PingOath
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Oath/Oath/Core/OathService.swift
+++ b/Oath/Oath/Core/OathService.swift
@@ -118,10 +118,28 @@ actor OathService {
     /// Add and store a new credential.
     /// - Parameter credential: The credential to add.
     /// - Returns: The stored credential with any updates.
+    /// - Throws: `OathError.duplicateCredential` if a credential with the same issuer and account name already exists.
     /// - Throws: `OathError.policyViolation` if policies are not met.
     /// - Throws: `OathStorageError` if storage operations fail.
     func addCredential(_ credential: OathCredential) async throws -> OathCredential {
         logger.d("Adding new OATH credential: \(credential.id)")
+        
+        // Check for duplicate credential by issuer and account name
+        let existingCredential = try await storage.getCredentialByIssuerAndAccount(
+            issuer: credential.issuer,
+            accountName: credential.accountName
+        )
+        
+        // Only throw duplicate exception if the existing credential has a different ID
+        // (same ID means we're updating, not creating a duplicate)
+        if let existing = existingCredential, existing.id != credential.id {
+            logger.w("Credential already exists for issuer '\(credential.issuer)' and account '\(credential.accountName)'", error: nil)
+            throw OathError.duplicateCredential(
+                issuer: credential.issuer,
+                accountName: credential.accountName
+            )
+        }
+        
         // Validate credential
         try credential.validate()
 

--- a/Oath/Oath/OathError.swift
+++ b/Oath/Oath/OathError.swift
@@ -2,7 +2,7 @@
 //  OathError.swift
 //  PingOath
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Oath/Oath/OathError.swift
+++ b/Oath/Oath/OathError.swift
@@ -66,8 +66,8 @@ public enum OathError: LocalizedError, Sendable {
     /// The credential is locked and cannot be used.
     case credentialLocked(String)
 
-    /// A credential with the same ID already exists.
-    case duplicateCredential(String)
+    /// A credential with the same issuer and account name already exists.
+    case duplicateCredential(issuer: String, accountName: String)
 
     
     // MARK: - URI Parsing Errors
@@ -123,8 +123,8 @@ public enum OathError: LocalizedError, Sendable {
             return "Credential with ID '\(id)' was not found"
         case .credentialLocked(let id):
             return "Credential with ID '\(id)' is locked and cannot be used"
-        case .duplicateCredential(let id):
-            return "A credential with ID '\(id)' already exists"
+        case .duplicateCredential(let issuer, let accountName):
+            return "A credential for issuer '\(issuer)' and account '\(accountName)' already exists"
         case .invalidUri(let message):
             return "Invalid URI: \(message)"
         case .missingRequiredParameter(let message):
@@ -156,8 +156,8 @@ public enum OathError: LocalizedError, Sendable {
             return "The requested credential does not exist in storage"
         case .credentialLocked(_):
             return "The credential is locked by a policy and cannot generate codes"
-        case .duplicateCredential(_):
-            return "Cannot store credential because one with the same ID already exists"
+        case .duplicateCredential(_, _):
+            return "Cannot store credential because one with the same issuer and account name already exists"
         case .invalidUri(_):
             return "The URI format is not valid or is not supported"
         case .missingRequiredParameter(_):

--- a/Oath/Oath/Storage/OathKeychainStorage.swift
+++ b/Oath/Oath/Storage/OathKeychainStorage.swift
@@ -2,7 +2,7 @@
 //  OathKeychainStorage.swift
 //  PingOath
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Oath/Oath/Storage/OathKeychainStorage.swift
+++ b/Oath/Oath/Storage/OathKeychainStorage.swift
@@ -308,6 +308,65 @@ public final class OathKeychainStorage: OathStorage, @unchecked Sendable {
         }
     }
 
+    /// Retrieve an OATH credential by issuer and account name.
+    /// - Parameters:
+    ///   - issuer: The issuer of the credential.
+    ///   - accountName: The account name of the credential.
+    /// - Returns: The credential if found, nil otherwise.
+    /// - Throws: `OathStorageError.storageFailure` if keychain operations fail.
+    public func getCredentialByIssuerAndAccount(issuer: String, accountName: String) async throws -> OathCredential? {
+        logger?.d("Checking for credential with issuer: \(issuer), account: \(accountName)")
+
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<OathCredential?, Error>) in
+            keychainQueue.async { [weak self] in
+                do {
+                    guard let self = self else {
+                        continuation.resume(throwing: OathStorageError.storageFailure("Storage instance deallocated"))
+                        return
+                    }
+
+                    let allItems = try self.loadAllKeychainItems(service: self.keychainService)
+
+                    for (account, data) in allItems {
+                        do {
+                            // Decode credential metadata
+                            let credentialWithoutSecret = try JSONDecoder().decode(OathCredential.self, from: data)
+
+                            // Check if issuer and accountName match (case-sensitive)
+                            if credentialWithoutSecret.issuer == issuer &&
+                               credentialWithoutSecret.accountName == accountName {
+                                // Retrieve and attach secret
+                                if let secretData = try self.loadKeychainItem(
+                                    service: self.keychainSecretService,
+                                    account: account
+                                ) {
+                                    let secret = String(data: secretData, encoding: .utf8) ?? ""
+                                    let credential = OathCredential.withSecret(credentialWithoutSecret, secretKey: secret)
+                                    self.logger?.d("Found credential with issuer: \(issuer), account: \(accountName)")
+                                    continuation.resume(returning: credential)
+                                    return
+                                }
+                            }
+                        } catch {
+                            self.logger?.w("Failed to decode credential \(account), skipping: \(error)", error: error)
+                        }
+                    }
+
+                    // No matching credential found
+                    self.logger?.d("No credential found with issuer: \(issuer), account: \(accountName)")
+                    continuation.resume(returning: nil)
+                } catch {
+                    self?.logger?.e("Failed to retrieve credential by issuer and account: \(error)", error: error)
+                    if let storageError = error as? OathStorageError {
+                        continuation.resume(throwing: storageError)
+                    } else {
+                        continuation.resume(throwing: OathStorageError.storageFailure("Failed to retrieve credential", error))
+                    }
+                }
+            }
+        }
+    }
+
     
     // MARK: - Private Keychain Operations
 

--- a/Oath/Oath/Storage/OathStorage.swift
+++ b/Oath/Oath/Storage/OathStorage.swift
@@ -2,7 +2,7 @@
 //  OathStorage.swift
 //  PingOath
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Oath/Oath/Storage/OathStorage.swift
+++ b/Oath/Oath/Storage/OathStorage.swift
@@ -39,6 +39,15 @@ public protocol OathStorage: Sendable {
     /// - Throws: `OathStorageError.storageFailure` if the credential cannot be removed.
     func removeOathCredential(credentialId: String) async throws -> Bool
 
+    /// Retrieve an OATH credential by issuer and account name.
+    /// Used for duplicate detection during credential registration.
+    /// - Parameters:
+    ///   - issuer: The issuer of the credential.
+    ///   - accountName: The account name of the credential.
+    /// - Returns: The OATH credential if found, nil otherwise.
+    /// - Throws: `OathStorageError.storageFailure` if the credential cannot be retrieved.
+    func getCredentialByIssuerAndAccount(issuer: String, accountName: String) async throws -> OathCredential?
+
     /// Clear all OATH credentials from the storage.
     /// - Throws: `OathStorageError.storageFailure` if the credentials cannot be cleared.
     func clearOathCredentials() async throws

--- a/Oath/OathTests/OathServiceTests.swift
+++ b/Oath/OathTests/OathServiceTests.swift
@@ -161,6 +161,52 @@ final class OathServiceTests: XCTestCase {
         XCTAssertEqual(credentialCount, 1)
     }
     
+    func testAddCredentialWithDuplicateIssuerAndAccount() async throws {
+        guard let service = oathService else {
+            XCTFail("OathService not initialized")
+            return
+        }
+        
+        // Add first credential
+        let credential1 = OathCredential(
+            issuer: "ForgeRock",
+            accountName: "rodrigo1@forgerock.com",
+            oathType: .totp,
+            secretKey: "JBSWY3DPEHPK3PXP"
+        )
+        let stored1 = try await service.addCredential(credential1)
+        XCTAssertNotNil(stored1)
+        
+        // Try to add second credential with same issuer+accountName but different ID
+        let credential2 = OathCredential(
+            id: "different-id",
+            issuer: "ForgeRock",
+            accountName: "rodrigo1@forgerock.com",
+            oathType: .totp,
+            secretKey: "JBSWY3DPEHPK3PXQ"
+        )
+        
+        // Should throw duplicate credential error
+        do {
+            _ = try await service.addCredential(credential2)
+            XCTFail("Expected duplicateCredential error")
+        } catch let error as OathError {
+            switch error {
+            case .duplicateCredential(let issuer, let accountName):
+                XCTAssertEqual(issuer, "ForgeRock")
+                XCTAssertEqual(accountName, "rodrigo1@forgerock.com")
+            default:
+                XCTFail("Expected duplicateCredential error, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected OathError, got \(error)")
+        }
+        
+        // Should still only have one credential
+        let credentialCount = await inMemoryStorage.credentialCount
+        XCTAssertEqual(credentialCount, 1)
+    }
+    
     func testParseUriWithPolicyViolationBlocks() async {
         // Create a mock policy that always fails
         let failingPolicy = MockFailingPolicy()

--- a/Oath/OathTests/Utilities/OathInMemoryStorage.swift
+++ b/Oath/OathTests/Utilities/OathInMemoryStorage.swift
@@ -44,6 +44,12 @@ actor OathInMemoryStorage: OathStorage {
         credentials.removeAll()
     }
 
+    func getCredentialByIssuerAndAccount(issuer: String, accountName: String) async throws -> OathCredential? {
+        credentials.values.first { credential in
+            credential.issuer == issuer && credential.accountName == accountName
+        }
+    }
+
     // MARK: - Test Utilities
 
     /// Get the count of stored credentials (for testing).

--- a/Push/Push/Core/PingAMPushResponder.swift
+++ b/Push/Push/Core/PingAMPushResponder.swift
@@ -245,7 +245,7 @@ public final class PingAMPushResponder: @unchecked Sendable {
             claims: claims
         )
 
-        var requestBody: [String: Any] = [
+        let requestBody: [String: Any] = [
             Keys.mechanismUID: credential.id,
             Keys.jwt: jwt,
             Keys.username: userId

--- a/Push/Push/Core/PingAMPushResponder.swift
+++ b/Push/Push/Core/PingAMPushResponder.swift
@@ -90,7 +90,7 @@ public final class PingAMPushResponder: @unchecked Sendable {
         ]
 
         if let userId = credential.userId, !userId.isEmpty {
-            requestBody[Keys.userId] = userId
+            requestBody[Keys.username] = userId
         }
 
         // Configure HTTP request
@@ -169,7 +169,7 @@ public final class PingAMPushResponder: @unchecked Sendable {
         ]
 
         if let userId = credential.userId, !userId.isEmpty {
-            requestBody[Keys.userId] = userId
+            requestBody[Keys.username] = userId
         }
 
         let request = httpClient.request()
@@ -222,6 +222,13 @@ public final class PingAMPushResponder: @unchecked Sendable {
             throw PushError.invalidParameterValue("Device token cannot be empty")
         }
 
+        guard let userId = credential.userId, !userId.isEmpty else {
+            logger?.e("Device token update requires userId but credential \(credential.id) has none", error: nil)
+            throw PushError.invalidParameterValue(
+                "Device token update requires a credential with userId. Credential '\(credential.id)' does not have a userId."
+            )
+        }
+
         let resolvedName = deviceName?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .nonEmpty ?? Constants.defaultDeviceName
@@ -240,12 +247,9 @@ public final class PingAMPushResponder: @unchecked Sendable {
 
         var requestBody: [String: Any] = [
             Keys.mechanismUID: credential.id,
-            Keys.jwt: jwt
+            Keys.jwt: jwt,
+            Keys.username: userId
         ]
-
-        if let userId = credential.userId, !userId.isEmpty {
-            requestBody[Keys.userId] = userId
-        }
 
         let request = httpClient.request()
         request.url = credential.updateEndpoint
@@ -465,7 +469,7 @@ public final class PingAMPushResponder: @unchecked Sendable {
         static let amlbCookie = "amlbCookie"
         static let challenge = "challenge"
         static let jwt = "jwt"
-        static let userId = "userId"
+        static let username = "username"
     }
 
     private enum Constants {

--- a/Push/Push/Core/PushService.swift
+++ b/Push/Push/Core/PushService.swift
@@ -237,11 +237,28 @@ actor PushService {
     ///
     /// - Parameter credential: The credential to persist.
     /// - Returns: The stored credential (potentially locked).
+    /// - Throws: `PushError.duplicateCredential` if a credential with the same issuer and account name already exists.
     /// - Throws: `PushError.storageFailure` when persistence fails.
     func addCredential(_ credential: PushCredential) async throws -> PushCredential {
         logger?.d("Adding Push credential \(credential.id)")
 
         do {
+            // Check for duplicate credential by issuer and account name
+            let existingCredential = try await storage.getCredentialByIssuerAndAccount(
+                issuer: credential.issuer,
+                accountName: credential.accountName
+            )
+            
+            // Only throw duplicate exception if the existing credential has a different ID
+            // (same ID means we're updating, not creating a duplicate)
+            if let existing = existingCredential, existing.id != credential.id {
+                logger?.w("Credential already exists for issuer '\(credential.issuer)' and account '\(credential.accountName)'", error: nil)
+                throw PushError.duplicateCredential(
+                    issuer: credential.issuer,
+                    accountName: credential.accountName
+                )
+            }
+            
             var updatedCredential = credential
             try await evaluateAndUpdateCredentialPolicies(&updatedCredential, store: false)
 
@@ -352,6 +369,12 @@ actor PushService {
             let removed = try await storage.removePushCredential(credentialId: credentialId)
             if removed {
                 logger?.d("Removed Push credential \(credentialId)")
+                
+                // Remove associated push notifications for this credential
+                let notificationsRemoved = try await storage.removePushNotificationsForCredential(credentialId: credentialId)
+                if notificationsRemoved > 0 {
+                    logger?.d("Removed \(notificationsRemoved) associated push notification(s) for credential \(credentialId)")
+                }
             } else {
                 logger?.d("No Push credential found for removal: \(credentialId)")
             }
@@ -377,21 +400,21 @@ actor PushService {
         _ deviceToken: String,
         credentialId: String? = nil
     ) async throws -> Bool {
-        let trimmedToken = deviceToken.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedToken.isEmpty else {
+        guard !deviceToken.isEmpty else {
             logger?.w("setDeviceToken called with an empty token", error: nil)
             throw PushError.invalidParameterValue("Device token cannot be empty")
         }
 
         do {
-            let tokenChanged = try await deviceTokenManager.hasTokenChanged(trimmedToken)
+            let tokenChanged = try await deviceTokenManager.hasTokenChanged(deviceToken)
 
             if !tokenChanged {
-                logger?.d("Device token unchanged; skipping update")
+                logger?.d("Device token unchanged; skipping server update")
                 return true
             }
 
-            try await deviceTokenManager.storeDeviceToken(trimmedToken)
+            logger?.i("Device token changed; updating on server for \(credentialId != nil ? "credential \(credentialId!)" : "all credentials")")
+            try await deviceTokenManager.storeDeviceToken(deviceToken)
         } catch let error as PushError {
             throw error
         } catch {
@@ -400,7 +423,7 @@ actor PushService {
         }
 
         return try await updateDeviceTokensOnServer(
-            deviceToken: trimmedToken,
+            deviceToken: deviceToken,
             credentialId: credentialId
         )
     }
@@ -1076,6 +1099,7 @@ actor PushService {
                 }
 
                 do {
+                    logger?.d("Updating device token for credential \(credential.id) (platform: \(platformId))")
                     let success = try await handler.setDeviceToken(
                         credential: credential,
                         deviceToken: deviceToken,
@@ -1085,10 +1109,12 @@ actor PushService {
                     if !success {
                         allSucceeded = false
                         logger?.w("Handler reported failure updating device token for credential \(credential.id)", error: nil)
+                    } else {
+                        logger?.i("Successfully updated device token for credential \(credential.id)")
                     }
                 } catch let error as PushError {
                     allSucceeded = false
-                    logger?.e("Handler threw PushError while updating credential \(credential.id)", error: error)
+                    logger?.e("Handler threw PushError while updating credential \(credential.id): \(error)", error: error)
                 } catch {
                     allSucceeded = false
                     logger?.e("Unexpected error updating credential \(credential.id)", error: error)

--- a/Push/Push/PushError.swift
+++ b/Push/Push/PushError.swift
@@ -2,7 +2,7 @@
 //  PushError.swift
 //  PingPush
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Push/Push/PushError.swift
+++ b/Push/Push/PushError.swift
@@ -106,6 +106,9 @@ public enum PushError: Error, LocalizedError, Sendable {
     /// The credential is locked due to policy violation.
     case credentialLocked(String)
     
+    /// A credential with the same issuer and account name already exists.
+    case duplicateCredential(issuer: String, accountName: String)
+    
     // MARK: - Notification Errors
     
     /// The specified notification was not found.
@@ -177,6 +180,9 @@ public enum PushError: Error, LocalizedError, Sendable {
             
         case .credentialLocked(let id):
             return "Credential is locked: \(id)"
+            
+        case .duplicateCredential(let issuer, let accountName):
+            return "A credential for issuer '\(issuer)' and account '\(accountName)' already exists"
             
         case .notificationNotFound(let id):
             return "Notification not found: \(id)"

--- a/Push/Push/Storage/PushKeychainStorage.swift
+++ b/Push/Push/Storage/PushKeychainStorage.swift
@@ -196,6 +196,43 @@ public final class PushKeychainStorage: PushStorage, @unchecked Sendable {
         }
     }
 
+    /// Retrieve a push credential by issuer and account name.
+    /// - Parameters:
+    ///   - issuer: The issuer of the credential.
+    ///   - accountName: The account name of the credential.
+    /// - Returns: The credential if found, nil otherwise.
+    /// - Throws: `PushStorageError.storageFailure` if keychain operations fail.
+   public func getCredentialByIssuerAndAccount(issuer: String, accountName: String) async throws -> PushCredential? {
+        logger?.i("Checking for credential with issuer: \(issuer), account: \(accountName)")
+        
+        do {
+            let items = try loadAllKeychainItems(service: credentialService)
+            
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            
+            for (_, data) in items {
+                do {
+                    let credential = try decoder.decode(PushCredential.self, from: data)
+                    // Check if issuer and accountName match (case-sensitive)
+                    if credential.issuer == issuer && credential.accountName == accountName {
+                        logger?.i("Found credential with issuer: \(issuer), account: \(accountName)")
+                        return credential
+                    }
+                } catch {
+                    logger?.w("Failed to decode credential, skipping", error: error)
+                }
+            }
+            
+            // No matching credential found
+            logger?.i("No credential found with issuer: \(issuer), account: \(accountName)")
+            return nil
+        } catch {
+            logger?.e("Failed to retrieve credential by issuer and account", error: error)
+            throw PushStorageError.storageFailure("Failed to retrieve credential", error)
+        }
+    }
+
     /// Store a push notification.
     ///
     /// - Parameter notification: The push notification to store.

--- a/Push/Push/Storage/PushKeychainStorage.swift
+++ b/Push/Push/Storage/PushKeychainStorage.swift
@@ -2,7 +2,7 @@
 //  PushKeychainStorage.swift
 //  PingPush
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Push/Push/Storage/PushStorage.swift
+++ b/Push/Push/Storage/PushStorage.swift
@@ -45,6 +45,15 @@ public protocol PushStorage: Sendable {
     /// - Throws: `PushStorageError.storageFailure` if the credentials cannot be cleared.
     func clearPushCredentials() async throws
 
+    /// Retrieve a push credential by issuer and account name.
+    /// Used for duplicate detection during credential registration.
+    /// - Parameters:
+    ///   - issuer: The issuer of the credential.
+    ///   - accountName: The account name of the credential.
+    /// - Returns: The Push credential if found, nil otherwise.
+    /// - Throws: `PushStorageError.storageFailure` if the credential cannot be retrieved.
+    func getCredentialByIssuerAndAccount(issuer: String, accountName: String) async throws -> PushCredential?
+
     // MARK: - Notification Operations
 
     /// Store a push notification.

--- a/Push/Push/Storage/PushStorage.swift
+++ b/Push/Push/Storage/PushStorage.swift
@@ -2,7 +2,7 @@
 //  PushStorage.swift
 //  PingPush
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Push/PushTests/PingAMPushResponderTests.swift
+++ b/Push/PushTests/PingAMPushResponderTests.swift
@@ -561,7 +561,7 @@ final class PingAMPushResponderTests: XCTestCase {
         let bodyData = try XCTUnwrap(URLProtocolMock.lastRequestBody)
         let requestJson = try JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
         XCTAssertEqual(requestJson?[PingAMPushResponder.Keys.mechanismUID] as? String, credential.id)
-        XCTAssertEqual(requestJson?[PingAMPushResponder.Keys.userId] as? String, credential.userId)
+        XCTAssertEqual(requestJson?[PingAMPushResponder.Keys.username] as? String, credential.userId)
 
         let jwt = try extractJwt(from: bodyData)
         let payload = try Self.decodeJwtPayload(jwt)
@@ -644,6 +644,31 @@ final class PingAMPushResponderTests: XCTestCase {
         }
     }
 
+    func testUpdateDeviceTokenWithoutUserIdThrows() async {
+        // No mock handler needed since validation occurs before network request
+        URLProtocolMock.requestHandler = { _ in
+            XCTFail("Should not make network request when userId is missing")
+            fatalError("Should not reach here")
+        }
+        
+        let mockResponder = PingAMPushResponder(httpClient: makeMockHttpClient(), logger: nil)
+        let credential = makeCredential(userId: nil)
+
+        do {
+            _ = try await mockResponder.updateDeviceToken(
+                credential: credential,
+                deviceToken: TestValues.deviceId,
+                deviceName: TestValues.deviceName
+            )
+            XCTFail("Expected invalidParameterValue error for missing userId")
+        } catch PushError.invalidParameterValue(let message) {
+            XCTAssertTrue(message.localizedCaseInsensitiveContains("userId"))
+            XCTAssertTrue(message.contains(credential.id))
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
 
     // MARK: - Helpers
 
@@ -669,10 +694,10 @@ final class PingAMPushResponderTests: XCTestCase {
         return try XCTUnwrap(JSONSerialization.jsonObject(with: payloadData) as? [String: Any])
     }
 
-    private func makeCredential() -> PushCredential {
-        PushCredential(
+    private func makeCredential(userId: String? = "user-123") -> PushCredential {
+        var credential = PushCredential(
             id: "credential-id",
-            userId: "user-123",
+            userId: userId,
             resourceId: "credential-id",
             issuer: "Ping Identity",
             displayIssuer: "Ping Identity",
@@ -683,6 +708,7 @@ final class PingAMPushResponderTests: XCTestCase {
             createdAt: Date(),
             platform: .pingAM
         )
+        return credential
     }
 
     private func makeMockHttpClient() -> HttpClientProtocol {

--- a/Push/PushTests/PingAMPushResponderTests.swift
+++ b/Push/PushTests/PingAMPushResponderTests.swift
@@ -695,7 +695,7 @@ final class PingAMPushResponderTests: XCTestCase {
     }
 
     private func makeCredential(userId: String? = "user-123") -> PushCredential {
-        var credential = PushCredential(
+        let credential = PushCredential(
             id: "credential-id",
             userId: userId,
             resourceId: "credential-id",

--- a/Push/PushTests/PushServiceTests.swift
+++ b/Push/PushTests/PushServiceTests.swift
@@ -159,6 +159,49 @@ final class PushServiceTests: XCTestCase {
        XCTAssertEqual(persisted?.isLocked, true)
     }
 
+    func testAddCredentialRejectsDuplicateIssuerAndAccount() async throws {
+        let service = makeService(handler: StubPushHandler())
+
+        // Add first credential
+        let credential1 = PushCredential(
+            issuer: "ForgeRock",
+            accountName: "rodrigo1@forgerock.com",
+            serverEndpoint: "https://am.example.com/push",
+            sharedSecret: "secret123"
+        )
+        let stored1 = try await service.addCredential(credential1)
+        XCTAssertNotNil(stored1)
+
+        // Try to add second credential with same issuer+accountName but different ID
+        let credential2 = PushCredential(
+            id: "different-id",
+            issuer: "ForgeRock",
+            accountName: "rodrigo1@forgerock.com",
+            serverEndpoint: "https://am.example.com/push",
+            sharedSecret: "secret456"
+        )
+
+        // Should throw duplicate credential error
+        do {
+            _ = try await service.addCredential(credential2)
+            XCTFail("Expected duplicateCredential error")
+        } catch let error as PushError {
+            switch error {
+            case .duplicateCredential(let issuer, let accountName):
+                XCTAssertEqual(issuer, "ForgeRock")
+                XCTAssertEqual(accountName, "rodrigo1@forgerock.com")
+            default:
+                XCTFail("Expected duplicateCredential error, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected PushError, got \(error)")
+        }
+
+        // Should still only have one credential
+        let allCredentials = try await storage.getAllPushCredentials()
+        XCTAssertEqual(allCredentials.count, 1)
+    }
+
     func testSetDeviceTokenSkipsUpdateWhenUnchanged() async throws {
         let stubHandler = StubPushHandler()
         let tokenManager = PushDeviceTokenManager(storage: storage, logger: nil)

--- a/Push/PushTests/TestInMemoryPushStorage.swift
+++ b/Push/PushTests/TestInMemoryPushStorage.swift
@@ -2,7 +2,7 @@
 //  TestInMemoryPushStorage.swift
 //  PushTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Push/PushTests/TestInMemoryPushStorage.swift
+++ b/Push/PushTests/TestInMemoryPushStorage.swift
@@ -45,6 +45,12 @@ actor TestInMemoryPushStorage: PushStorage {
         credentials.removeAll()
     }
 
+    func getCredentialByIssuerAndAccount(issuer: String, accountName: String) async throws -> PushCredential? {
+        credentials.values.first { credential in
+            credential.issuer == issuer && credential.accountName == accountName
+        }
+    }
+
     // MARK: - Notification Operations
 
     func storePushNotification(_ notification: PushNotification) async throws {

--- a/SampleApps/PingExample/PingExample/AppDelegate.swift
+++ b/SampleApps/PingExample/PingExample/AppDelegate.swift
@@ -2,7 +2,7 @@
 //  AppDelegate.swift
 //  PingExample
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/SampleApps/PingExample/PingExample/AppDelegate.swift
+++ b/SampleApps/PingExample/PingExample/AppDelegate.swift
@@ -75,16 +75,22 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
         let tokenString = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
-        print("APNs Device Token: \(tokenString)")
+        print("Received device token: \(tokenString)")
 
         // Store device token in PushClient
         Task {
             do {
                 let client = try await getInitializedPushClient()
-                _ = try await client.setDeviceToken(tokenString)
-                print("Device token registered with PushClient")
+                let success = try await client.setDeviceToken(tokenString)
+                if success {
+                    print("Device token update completed successfully")
+                } else {
+                    print("Device token update completed with some failures - check logs for details")
+                }
+            } catch let error as NSError where error.domain == "AppDelegate" {
+                print("Failed to update device token: PushClient not yet initialized. Will retry when client is ready.")
             } catch {
-                print("Failed to register device token: \(error.localizedDescription)")
+                print("Failed to update device token: \(error.localizedDescription)")
             }
         }
     }


### PR DESCRIPTION
# JIRA Ticket

[SDKS-4713 ](https://pingidentity.atlassian.net/browse/SDKS-4713) Create MFA sample app for the Unified SDK

# Description

Bug fixes and improvements to the `PingPush` and `PingOath` modules discovered while implementing the SwiftUI MFA sample app:

- Added `getCredentialByIssuerAndAccount(issuer:accountName:)` to `PushStorage` and `OathStorage` protocols.
- Implemented the method in `PushKeychainStorage` and `OathKeychainStorage` to search persisted credentials by issuer and account name.
- `PushService.addCredential` and `OathService.addCredential` now check for an existing credential with the same issuer+account pair before storing. An update to the same credential ID is still allowed.
- Added `PushError.duplicateCredential(issuer:accountName:)` and updated `OathError.duplicateCredential` to use `(issuer:accountName:)` parameters (previously keyed on ID).
- When a push credential is removed via `PushService.removeCredential`, its associated notifications are now also deleted from storage via `PushStorage.removePushNotificationsForCredential(credentialId:)`.
- Renamed the request body key for the user identifier from `userId` to `username` to align with the PingAM API.
- `setDeviceToken` now validates that the credential has a `userId` before sending the update request, throwing `PushError.invalidParameterValue` when it is absent.
- All existing unit tests updated.
- New test cases added for duplicate credential detection (both modules) and the `username` key fix in the push responder.
- Build validated with `swift build` and `xcodebuild`.

# Checklist:

- [x] I ran all unit tests and they pass
- [x] I added test case coverage for my changes
