### PR TITLE
SDKS-4817-Adding localized error and sendable compliance

### DIFF
--- a/Binding/Binding/Errors/DeviceBindingError.swift
+++ b/Binding/Binding/Errors/DeviceBindingError.swift
@@ -2,7 +2,7 @@
 //  DeviceBindingError.swift
 //  PingBinding
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Binding/Binding/Errors/DeviceBindingError.swift
+++ b/Binding/Binding/Errors/DeviceBindingError.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 /// An enum representing the possible errors that can occur during the device binding and signing process.
-public enum DeviceBindingError: Error, Equatable {
+public enum DeviceBindingError: Error, LocalizedError, Equatable, Sendable {
     /// Authentication with the user failed.
     case authenticationFailed
     /// The device does not support the required authentication method (e.g., biometrics).
@@ -31,6 +31,29 @@ public enum DeviceBindingError: Error, Equatable {
     /// An unsupported error.
     case unsupported(errorMessage: String)
     
+    public var errorDescription: String? {
+        switch self {
+        case .authenticationFailed:
+            return "Authentication with the user failed."
+        case .deviceNotSupported:
+            return "The device does not support the required authentication method."
+        case .deviceNotRegistered:
+            return "No key was found for the user. The device is not registered."
+        case .invalidClaim:
+            return "A custom claim conflicts with a reserved JWT claim."
+        case .biometricError(let error):
+            return "Biometric authentication error: \(error.localizedDescription)"
+        case .userCanceled:
+            return "The operation was cancelled by the user."
+        case .timeout:
+            return "The operation timed out."
+        case .unknown:
+            return "An unknown or unexpected error occurred."
+        case .unsupported(let errorMessage):
+            return "Unsupported: \(errorMessage)"
+        }
+    }
+
     public func toClientError() -> String {
         switch self {
         case .deviceNotRegistered:

--- a/Binding/Binding/Errors/DeviceBindingStatus.swift
+++ b/Binding/Binding/Errors/DeviceBindingStatus.swift
@@ -2,7 +2,7 @@
 //  DeviceBindingStatus.swift
 //  PingBinding
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Binding/Binding/Errors/DeviceBindingStatus.swift
+++ b/Binding/Binding/Errors/DeviceBindingStatus.swift
@@ -19,7 +19,7 @@ struct BindingStatusConstants {
 }
 
 /// An enum representing the status of a device binding operation, which can be used to convey more specific information about the outcome of a binding or signing attempt.
-public enum DeviceBindingStatus: Error {
+public enum DeviceBindingStatus: Error, LocalizedError, Sendable {
     /// The operation timed out.
     case timeout
     /// The user aborted the operation.
@@ -33,6 +33,9 @@ public enum DeviceBindingStatus: Error {
     /// The custom claims are invalid.
     case invalidCustomClaims
     
+    /// A localized description of the error.
+    public var errorDescription: String? { errorMessage }
+
     /// A client error string that can be sent to the server.
     public var clientError: String {
         switch self {

--- a/Binding/Binding/Migration/MigrationError.swift
+++ b/Binding/Binding/Migration/MigrationError.swift
@@ -2,7 +2,7 @@
 //  MigrationError.swift
 //  PingBinding
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Binding/Binding/Migration/MigrationError.swift
+++ b/Binding/Binding/Migration/MigrationError.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 /// Errors that can occur during device binding migration.
-public enum MigrationError: LocalizedError {
+public enum MigrationError: LocalizedError, Sendable {
     /// Failed to read legacy user keys from keychain
     case failedToReadLegacyKeys(Error)
     

--- a/Browser/Browser/BrowserLauncher.swift
+++ b/Browser/Browser/BrowserLauncher.swift
@@ -57,7 +57,7 @@ public enum BrowserMode: Sendable {
 public protocol BrowserLauncherProtocol: Sendable {
     var isInProgress: Bool { get }
     func launch(url: URL, customParams: [String: String]?,
-                browserType: BrowserType, browserMode: BrowserMode, callbackURLScheme: String) async throws -> URL
+                browserType: BrowserType, browserMode: BrowserMode, callbackURLScheme: String, logger: Logger) async throws -> URL
     func reset()
     func handleAppActivation()
 }
@@ -159,8 +159,8 @@ public final class BrowserLauncher: NSObject, BrowserLauncherProtocol {
     ///   - Returns: URL of the external user-agent
     ///   - Throws: BrowserError
     public func launch(url: URL, customParams: [String: String]? = nil,
-                       browserType: BrowserType = .authSession, browserMode: BrowserMode = .login, callbackURLScheme: String) async throws -> URL {
-        logger = LogManager.logger
+                       browserType: BrowserType = .authSession, browserMode: BrowserMode = .login, callbackURLScheme: String, logger: Logger = LogManager.logger) async throws -> URL {
+        self.logger = logger
         
         guard case .idle = state else {
             throw BrowserError.externalUserAgentAuthenticationInProgress

--- a/Browser/Browser/BrowserLauncher.swift
+++ b/Browser/Browser/BrowserLauncher.swift
@@ -2,7 +2,7 @@
 //  Browser.swift
 //  Browser
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Browser/Browser/BrowserLauncher.swift
+++ b/Browser/Browser/BrowserLauncher.swift
@@ -26,10 +26,21 @@ public enum BrowserType: Int, Sendable {
 }
 
 /// BrowserError enum to specify the error that may occur during external user-agent process
-public enum BrowserError: Error, Sendable {
+public enum BrowserError: Error, LocalizedError, Sendable {
     case externalUserAgentFailure
     case externalUserAgentAuthenticationInProgress
     case externalUserAgentCancelled
+
+    public var errorDescription: String? {
+        switch self {
+        case .externalUserAgentFailure:
+            return "The external user agent failed to launch or complete authentication."
+        case .externalUserAgentAuthenticationInProgress:
+            return "An authentication session is already in progress."
+        case .externalUserAgentCancelled:
+            return "The authentication was cancelled by the user."
+        }
+    }
 }
 
 /// BrowserMode enum to specify the mode of the browser; login, logout, or custom

--- a/Browser/PingBrowserTests/PingBrowserTests.swift
+++ b/Browser/PingBrowserTests/PingBrowserTests.swift
@@ -13,7 +13,7 @@ import XCTest
 @testable import PingExternalIdP
 @testable import PingOrchestrate
 @testable import PingNetwork
-
+@testable import PingLogger
 // MARK: - BrowserType Tests
 
 @MainActor
@@ -314,7 +314,7 @@ class MockBrowserLauncher: BrowserLauncherProtocol {
     /// A closure that will be called when `launch` is invoked.
     var launchHandler: ((URL, BrowserType, String) async throws -> URL)?
     
-    func launch(url: URL, customParams: [String : String]?, browserType: PingBrowser.BrowserType, browserMode: PingBrowser.BrowserMode, callbackURLScheme: String) async throws -> URL {
+    func launch(url: URL, customParams: [String : String]?, browserType: PingBrowser.BrowserType, browserMode: PingBrowser.BrowserMode, callbackURLScheme: String, logger: Logger = LogManager.logger) async throws -> URL {
         if let handler = launchHandler {
             return try await handler(url, browserType, callbackURLScheme)
         }

--- a/Commons/Commons/Util/CompactJwt.swift
+++ b/Commons/Commons/Util/CompactJwt.swift
@@ -2,7 +2,7 @@
 //  JwtUtils.swift
 //  PingCommons
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Commons/Commons/Util/CompactJwt.swift
+++ b/Commons/Commons/Util/CompactJwt.swift
@@ -14,7 +14,7 @@ import Security
 
 // MARK: - SecKey to JWK Conversion
 
-enum SecKeyToJWKError: Error, LocalizedError {
+enum SecKeyToJWKError: Error, LocalizedError, Sendable {
     case notECKey
     case externalRepresentationFailed
     case invalidECKeyDataFormat
@@ -42,10 +42,18 @@ public final class CompactJwt: Sendable {
 
     // MARK: - ASN.1 Parsing Helpers
 
-    enum ASN1Error: Error {
+    enum ASN1Error: Error, LocalizedError, Sendable {
         case invalidFormat
         case unexpectedTag
         case lengthMismatch
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidFormat: return "ASN.1 data has an invalid format."
+            case .unexpectedTag: return "ASN.1 parser encountered an unexpected tag."
+            case .lengthMismatch: return "ASN.1 length field does not match available data."
+            }
+        }
     }
 
     struct ASN1 {

--- a/Davinci/Davinci/User.swift
+++ b/Davinci/Davinci/User.swift
@@ -2,7 +2,7 @@
 //  User.swift
 //  PingDavinci
 //
-//  Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Davinci/Davinci/module/ErrorNode.swift
+++ b/Davinci/Davinci/module/ErrorNode.swift
@@ -2,7 +2,7 @@
 //  ErrorNode.swift
 //  Davinci
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Davinci/Davinci/module/ErrorNode.swift
+++ b/Davinci/Davinci/module/ErrorNode.swift
@@ -142,7 +142,14 @@ public struct InnerError: Codable, Sendable {
 }
 
 /// Represents errors that occur during serialization.
-public enum SerializationError: Error {
+public enum SerializationError: Error, LocalizedError, Sendable {
     /// Indicates that the provided data has an invalid format.
     case invalidFormat
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidFormat:
+            return "The response data has an invalid format."
+        }
+    }
 }

--- a/Davinci/Davinci/module/Transform.swift
+++ b/Davinci/Davinci/module/Transform.swift
@@ -116,11 +116,23 @@ public struct SessionResponse: Session, @unchecked Sendable {
 
 
 /// Represents API errors that occur during response transformation.
-public enum ApiError: Error, @unchecked Sendable {
+///
+/// `@unchecked Sendable` is used here because the associated `[String: Any]` JSON dictionary
+/// does not conform to `Sendable` in Swift's type system. However, this is safe in practice
+/// because the dictionary is populated once at the call site during response parsing and is
+/// never mutated after the error value is constructed. All access is read-only.
+public enum ApiError: Error, LocalizedError, @unchecked Sendable {
     /// An error containing an HTTP status code, a JSON object, and a descriptive message.
     /// - Parameters:
     ///   - status: The HTTP status code of the error.
     ///   - json: The JSON data associated with the error.
     ///   - message: A descriptive message explaining the error.
     case error(Int, [String: Any], String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .error(let status, _, let message):
+            return "API error (HTTP \(status)): \(message)"
+        }
+    }
 }

--- a/DavinciPlugin/DavinciPlugin/ValidationError.swift
+++ b/DavinciPlugin/DavinciPlugin/ValidationError.swift
@@ -2,7 +2,7 @@
 //  ValidationError.swift
 //  PingDavinci
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/DavinciPlugin/DavinciPlugin/ValidationError.swift
+++ b/DavinciPlugin/DavinciPlugin/ValidationError.swift
@@ -12,7 +12,7 @@
 import Foundation
 
 /// An error type that represents validation errors.
-public enum ValidationError: Error, Identifiable, Equatable {
+public enum ValidationError: Error, LocalizedError, Identifiable, Equatable, Sendable {
     /// A unique identifier for the error.
     public var id: UUID { UUID() }
     
@@ -23,6 +23,9 @@ public enum ValidationError: Error, Identifiable, Equatable {
     case maxRepeat(max: Int)
     case minCharacters(character: String, min: Int)
     
+    /// A localized description of the error.
+    public var errorDescription: String? { errorMessage }
+
     /// The error message for the validation error.
     public var errorMessage: String {
         switch self {

--- a/DeviceId/DeviceId/DeviceIdentifier.swift
+++ b/DeviceId/DeviceId/DeviceIdentifier.swift
@@ -129,7 +129,7 @@ enum Constants {
 /// - keychainItemNotFound: Indicates that the keychain item was not found.
 /// - keychainUnexpectedData: Indicates that the data retrieved from the keychain was not as expected.
 /// - keychainUnexpectedStatus: Indicates an unexpected status code from the keychain operation, with the associated `OSStatus` code.
-public enum DeviceIdentifierError: Error {
+public enum DeviceIdentifierError: Error, LocalizedError, Sendable {
     case encryptionInitializationFailed
     case keyGenerationFailed(Error)
     case publicKeyExtractionFailed
@@ -137,4 +137,23 @@ public enum DeviceIdentifierError: Error {
     case keychainItemNotFound
     case keychainUnexpectedData
     case keychainUnexpectedStatus(OSStatus)
+
+    public var errorDescription: String? {
+        switch self {
+        case .encryptionInitializationFailed:
+            return "Encryption initialization failed."
+        case .keyGenerationFailed(let error):
+            return "Key generation failed: \(error.localizedDescription)"
+        case .publicKeyExtractionFailed:
+            return "Failed to extract the public key."
+        case .externalRepresentationFailed(let error):
+            return "Failed to export key to external representation: \(error.localizedDescription)"
+        case .keychainItemNotFound:
+            return "Keychain item not found."
+        case .keychainUnexpectedData:
+            return "Unexpected data format in keychain."
+        case .keychainUnexpectedStatus(let status):
+            return "Unexpected keychain status code: \(status)."
+        }
+    }
 }

--- a/DeviceProfile/DeviceProfile/DeviceProfileCallback.swift
+++ b/DeviceProfile/DeviceProfile/DeviceProfileCallback.swift
@@ -225,7 +225,7 @@ public final class DeviceProfileConfig: @unchecked Sendable {
 // MARK: - Error Types
 
 /// Errors that can occur during device profile collection
-public enum DeviceProfileError: Error, LocalizedError {
+public enum DeviceProfileError: Error, LocalizedError, Sendable {
     case collectionFailed
     case serializationFailed
     

--- a/DeviceProfile/DeviceProfile/DeviceProfileCallback.swift
+++ b/DeviceProfile/DeviceProfile/DeviceProfileCallback.swift
@@ -187,7 +187,7 @@ public final class DeviceProfileConfig: @unchecked Sendable {
     public var location: Bool = false
     
     /// Logger instance for recording collection events
-    public var logger: Logger = LogManager.warning
+    public var logger: Logger = LogManager.logger
     
     /// Device identifier generator for unique device identification.
     /// Default value is `DefaultDeviceIdentifier()`

--- a/ExternalIdP/ExternalIdP.xcodeproj/project.pbxproj
+++ b/ExternalIdP/ExternalIdP.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		EC0815E92D4939EB00F1AD02 /* IdpHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0815E82D4939E400F1AD02 /* IdpHandler.swift */; };
 		EC0815ED2D493A1F00F1AD02 /* IdpResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0815EC2D493A1E00F1AD02 /* IdpResult.swift */; };
 		EC0815EF2D493DC900F1AD02 /* IdpExceptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0815EE2D493DC900F1AD02 /* IdpExceptions.swift */; };
+		EC3F70462F61B38700E7ABFA /* PingLogger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC3F70452F61B38700E7ABFA /* PingLogger.framework */; };
+		EC3F70472F61B38700E7ABFA /* PingLogger.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EC3F70452F61B38700E7ABFA /* PingLogger.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		EC5C81CC2ECF8CC300C91570 /* PingDavinciPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC5C81CB2ECF8CC300C91570 /* PingDavinciPlugin.framework */; };
 		EC5C81CD2ECF8CC300C91570 /* PingDavinciPlugin.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EC5C81CB2ECF8CC300C91570 /* PingDavinciPlugin.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		EC8025C52F0D34C60046C961 /* SelectIdpCallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8025C42F0D34C60046C961 /* SelectIdpCallbackTests.swift */; };
@@ -50,6 +52,7 @@
 			files = (
 				A552A7CE2F1699EE003CA76C /* PingJourneyPlugin.framework in Embed Frameworks */,
 				EC5C81CD2ECF8CC300C91570 /* PingDavinciPlugin.framework in Embed Frameworks */,
+				EC3F70472F61B38700E7ABFA /* PingLogger.framework in Embed Frameworks */,
 				ECA53F912D635C53002B35D4 /* PingBrowser.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -67,6 +70,7 @@
 		EC0815E82D4939E400F1AD02 /* IdpHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdpHandler.swift; sourceTree = "<group>"; };
 		EC0815EC2D493A1E00F1AD02 /* IdpResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdpResult.swift; sourceTree = "<group>"; };
 		EC0815EE2D493DC900F1AD02 /* IdpExceptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdpExceptions.swift; sourceTree = "<group>"; };
+		EC3F70452F61B38700E7ABFA /* PingLogger.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingLogger.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC5016152E437052006D8C3A /* PingJourney.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingJourney.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC5C81CB2ECF8CC300C91570 /* PingDavinciPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingDavinciPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC8025C32F0D34C60046C961 /* IdpCallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdpCallbackTests.swift; sourceTree = "<group>"; };
@@ -92,6 +96,7 @@
 			files = (
 				A552A7CD2F1699EE003CA76C /* PingJourneyPlugin.framework in Frameworks */,
 				EC5C81CC2ECF8CC300C91570 /* PingDavinciPlugin.framework in Frameworks */,
+				EC3F70462F61B38700E7ABFA /* PingLogger.framework in Frameworks */,
 				ECA53F902D635C53002B35D4 /* PingBrowser.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -167,6 +172,7 @@
 		ECBF06432D50EBF60066A3BD /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				EC3F70452F61B38700E7ABFA /* PingLogger.framework */,
 				A552A7CC2F1699EE003CA76C /* PingJourneyPlugin.framework */,
 				A5AB9FFF2EF0BBE6000E42B7 /* Network.framework */,
 				EC5C81CB2ECF8CC300C91570 /* PingDavinciPlugin.framework */,

--- a/ExternalIdP/ExternalIdP/Handlers/BrowserHandler.swift
+++ b/ExternalIdP/ExternalIdP/Handlers/BrowserHandler.swift
@@ -12,6 +12,7 @@ import Foundation
 import PingBrowser
 import PingOrchestrate
 import PingNetwork
+import PingLogger
 
 /// A handler class for managing browser-based Identity Provider (IdP) authorization.
 @MainActor
@@ -40,7 +41,7 @@ public class BrowserHandler: IdpRequestHandler {
         }
         
         do {
-            let result = try await BrowserLauncher.currentBrowser.launch(url: continueUrl, customParams: nil, browserType: .ephemeralAuthSession, browserMode: .login, callbackURLScheme: callbackURLScheme)
+            let result = try await BrowserLauncher.currentBrowser.launch(url: continueUrl, customParams: nil, browserType: .ephemeralAuthSession, browserMode: .login, callbackURLScheme: callbackURLScheme, logger: LogManager.logger)
             
             guard let components = URLComponents(url: result, resolvingAgainstBaseURL: false),
                   let queryItems = components.queryItems else {

--- a/ExternalIdP/ExternalIdP/IdpExceptions.swift
+++ b/ExternalIdP/ExternalIdP/IdpExceptions.swift
@@ -2,7 +2,7 @@
 //  IdpExceptions.swift
 //  ExternalIdP
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/ExternalIdP/ExternalIdP/IdpExceptions.swift
+++ b/ExternalIdP/ExternalIdP/IdpExceptions.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 /// A class representing IdpExceptions
-public enum IdpExceptions: LocalizedError {
+public enum IdpExceptions: LocalizedError, Sendable {
     
     /// An unsupportedIdpException
     /// - Parameters:

--- a/Fido/Fido/Fido.swift
+++ b/Fido/Fido/Fido.swift
@@ -376,7 +376,7 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
 }
 
 /// Represents an error that can occur during FIDO operations.
-public enum FidoError: Error, Equatable {
+public enum FidoError: Error, LocalizedError, Equatable, Sendable {
     case invalidChallenge
     case invalidWindow
     case invalidResponse
@@ -384,8 +384,8 @@ public enum FidoError: Error, Equatable {
     case unsupportedAction(String)
     case missingParameters(String)
     case timeout
-    
-    public var localizedDescription: String {
+
+    public var errorDescription: String? {
         switch self {
         case .timeout:
             return "ERROR::TimeoutError:Operation timedout"

--- a/Fido/Fido/Fido.swift
+++ b/Fido/Fido/Fido.swift
@@ -2,7 +2,7 @@
 //  Fido.swift
 //  Fido
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Journey/Journey.xcodeproj/project.pbxproj
+++ b/Journey/Journey.xcodeproj/project.pbxproj
@@ -203,7 +203,6 @@
 		EC2326A52E0D744A00634A50 /* JourneyUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JourneyUserTests.swift; sourceTree = "<group>"; };
 		EC2326A72E0D7C7800634A50 /* AgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentTests.swift; sourceTree = "<group>"; };
 		EC4FF9122EE0569600A35D3A /* PingOidc.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingOidc.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		EC5382FA2F23AF6D00FC28AD /* JourneyPlugin.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = JourneyPlugin.xcodeproj; path = ../JourneyPlugin/JourneyPlugin.xcodeproj; sourceTree = SOURCE_ROOT; };
 		EC5C81E12ED0824200C91570 /* PingJourneyPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingJourneyPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC727A242E019243005D9E28 /* PingJourney.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PingJourney.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC727A2D2E019243005D9E28 /* JourneyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JourneyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -309,13 +308,6 @@
 			path = Callbacks;
 			sourceTree = "<group>";
 		};
-		EC5383692F23AFC900FC28AD /* Products */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		EC727A1A2E019243005D9E28 = {
 			isa = PBXGroup;
 			children = (
@@ -324,7 +316,6 @@
 				EC727A5F2E019258005D9E28 /* JourneyTests */,
 				EC727A902E02DCA9005D9E28 /* Frameworks */,
 				EC727A252E019243005D9E28 /* Products */,
-				EC5382FA2F23AF6D00FC28AD /* JourneyPlugin.xcodeproj */,
 			);
 			sourceTree = "<group>";
 		};
@@ -526,12 +517,6 @@
 			preferredProjectObjectVersion = 77;
 			productRefGroup = EC727A252E019243005D9E28 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = EC5383692F23AFC900FC28AD /* Products */;
-					ProjectRef = EC5382FA2F23AF6D00FC28AD /* JourneyPlugin.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				EC727A232E019243005D9E28 /* PingJourney */,

--- a/Journey/Journey/Journey.swift
+++ b/Journey/Journey/Journey.swift
@@ -64,7 +64,7 @@ public extension Journey {
     /// - Returns: A configured Journey.
     static func createJourney(block: @Sendable (JourneyConfig) -> Void = {_ in }) -> Journey {
         let config = JourneyConfig()
-        config.logger = LogManager.standard
+        config.logger = LogManager.logger
         config.timeout = 30
         config.module(CustomHeader.config) { customHeaderConfig in
             customHeaderConfig.header(name: NetworkConstants.headerRequestedWith, value: NetworkConstants.requestedWithValue)

--- a/Journey/Journey/Module/Transform.swift
+++ b/Journey/Journey/Module/Transform.swift
@@ -10,6 +10,7 @@
 
 import PingOrchestrate
 import PingJourneyPlugin
+import Foundation
 
 /// Define the module that transforms the response from Journey to a `Node`.
 public class NodeTransformModule: @unchecked Sendable {
@@ -95,11 +96,23 @@ public class NodeTransformModule: @unchecked Sendable {
 }
 
 /// Represents API errors that occur during response transformation.
-public enum ApiError: Error, @unchecked Sendable {
+///
+/// `@unchecked Sendable` is used here because the associated `[String: Any]` JSON dictionary
+/// does not conform to `Sendable` in Swift's type system. However, this is safe in practice
+/// because the dictionary is populated once at the call site during response parsing and is
+/// never mutated after the error value is constructed. All access is read-only.
+public enum ApiError: Error, LocalizedError, @unchecked Sendable {
     /// An error containing an HTTP status code, a JSON object, and a descriptive message.
     /// - Parameters:
     ///   - status: The HTTP status code of the error.
     ///   - json: The JSON data associated with the error.
     ///   - message: A descriptive message explaining the error.
     case error(Int, [String: Any], String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .error(let status, _, let message):
+            return "API error (HTTP \(status)): \(message)"
+        }
+    }
 }

--- a/Journey/Journey/User.swift
+++ b/Journey/Journey/User.swift
@@ -2,7 +2,7 @@
 //  User.swift
 //  Journey
 //
-// Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+// Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 // This software may be modified and distributed under the terms
 // of the MIT license. See the LICENSE file for details.

--- a/Journey/Journey/User.swift
+++ b/Journey/Journey/User.swift
@@ -28,9 +28,9 @@ extension Journey {
             return cachedUser
         }
         
-        if ((await session()) != nil) {
+        if let session = await session() {
             if let oidcClientConfig = self.sharedContext.get(key: SharedContext.Keys.oidcClientConfigKey) as? OidcClientConfig {
-                return await prepareUser(journey: self, user: OidcUser(config: oidcClientConfig))
+                return await prepareUser(journey: self, user: OidcUser(config: oidcClientConfig), session: session)
             }
         }
         return nil

--- a/Network/Network/HttpClientConfig.swift
+++ b/Network/Network/HttpClientConfig.swift
@@ -34,7 +34,7 @@ public final class HttpClientConfig {
     public var timeout: TimeInterval = 15.0
 
     /// Logger instance for network operations. Defaults to warning level.
-    public var logger: Logger = LogManager.warning
+    public var logger: Logger = LogManager.logger
 
     /// Internal storage for request interceptors.
     internal private(set) var requestInterceptors: [HttpRequestInterceptor] = []

--- a/Network/Network/HttpClientConfig.swift
+++ b/Network/Network/HttpClientConfig.swift
@@ -2,7 +2,7 @@
 //  HttpClientConfig.swift
 //  PingNetwork
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Network/Network/URLSession/URLSessionHttpClient.swift
+++ b/Network/Network/URLSession/URLSessionHttpClient.swift
@@ -85,7 +85,7 @@ public final class URLSessionHttpClient: NSObject, HttpClientProtocol, @unchecke
     ///
     /// - Returns: A new `URLSessionHttpRequest` with standard headers pre-configured.
     public func request() -> HttpRequest {
-        URLSessionHttpRequest()
+        URLSessionHttpRequest(logger: logger)
     }
 
     /// Executes a pre-configured HTTP request asynchronously.
@@ -196,7 +196,7 @@ public final class URLSessionHttpClient: NSObject, HttpClientProtocol, @unchecke
                 log += "Request Body: \(bodyString)\n"
             }
             log += "Request Timeout: \(request.timeoutInterval)\n"
-            LogManager.standard.d(log)
+            logger.d(log)
         }
     }
     
@@ -219,7 +219,7 @@ public final class URLSessionHttpClient: NSObject, HttpClientProtocol, @unchecke
                 log += "Response Data: \(dataString)"
             }
         }
-        LogManager.standard.d(log)
+        logger.d(log)
     }
 }
 

--- a/Network/Network/URLSession/URLSessionHttpRequest.swift
+++ b/Network/Network/URLSession/URLSessionHttpRequest.swift
@@ -19,6 +19,9 @@ import PingLogger
 /// **This class is NOT thread-safe.** It contains mutable state without synchronization
 /// and should not be shared across multiple threads or modified concurrently.
 public class URLSessionHttpRequest: HttpRequest, @unchecked Sendable {
+    
+    var logger: Logger
+    
     /// The target URL for this HTTP request.
     public var url: String? {
         get {
@@ -43,7 +46,10 @@ public class URLSessionHttpRequest: HttpRequest, @unchecked Sendable {
     /// Standard headers include:
     /// - `x-requested-with: ping-sdk`
     /// - `x-requested-platform: ios`
-    public init() {
+    ///
+    /// - Parameter logger: The logger to use for this request. Defaults to `LogManager.logger`.
+    public init(logger: Logger = LogManager.logger) {
+        self.logger = logger
         // Initialize with a placeholder URL - will be replaced when buildURLRequest is called
         urlRequest = URLRequest(url: URL(string: "https://")!)
         urlRequest.httpMethod = HttpMethod.get.rawValue
@@ -268,13 +274,13 @@ extension URLSessionHttpRequest {
         
         guard JSONSerialization.isValidJSONObject(json) else {
             jsonSerializationFailed = true
-            LogManager.standard.d("URLSessionHttpRequest: Invalid JSON object for serialization.")
+            logger.d("URLSessionHttpRequest: Invalid JSON object for serialization.")
             return nil
         }
         
         guard let data = try? JSONSerialization.data(withJSONObject: json, options: []) else {
             jsonSerializationFailed = true
-            LogManager.standard.d("URLSessionHttpRequest: JSON serialization failed.")
+            logger.d("URLSessionHttpRequest: JSON serialization failed.")
             return nil
         }
         

--- a/Oidc/Oidc/Module/Oidc.swift
+++ b/Oidc/Oidc/Module/Oidc.swift
@@ -141,7 +141,7 @@ internal extension Session {
 }
 
 // MARK: – Error types
-public enum AuthorizeError: Error, LocalizedError {
+public enum AuthorizeError: Error, LocalizedError, Sendable {
     case missingAuthCode
     case codeAlreadyUsed
 

--- a/Oidc/Oidc/Module/Web.swift
+++ b/Oidc/Oidc/Module/Web.swift
@@ -40,7 +40,7 @@ public class WebModule {
                     throw OidcError.authorizeError(message: "Browser authorization failed: URL not found")
                 }
                 // Ensure the redirect URI scheme is valid
-                let result = try await BrowserLauncher.currentBrowser.launch(url: url, customParams: nil, browserType: oidcLoginConfig?.browserType ?? .authSession, browserMode: oidcLoginConfig?.browserMode ?? .login, callbackURLScheme: callbackURLScheme)
+                let result = try await BrowserLauncher.currentBrowser.launch(url: url, customParams: nil, browserType: oidcLoginConfig?.browserType ?? .authSession, browserMode: oidcLoginConfig?.browserMode ?? .login, callbackURLScheme: callbackURLScheme, logger: oidcLoginFlow.config.logger)
                 
                 // Extract and verify the auth code response
                 let code = try WebModule.extractCode(from: result)

--- a/Oidc/Oidc/OidcClientConfig.swift
+++ b/Oidc/Oidc/OidcClientConfig.swift
@@ -23,7 +23,7 @@ public class OidcClientConfig: @unchecked Sendable {
     /// Agent delegate for handling OIDC operations.
     internal var agent: (any AgentDelegateProtocol)?
     /// Logger instance for logging.
-    public var logger: Logger
+    public var logger: Logger = LogManager.logger
     /// Storage delegate for storing tokens.
     public var storage: StorageDelegate<Token>
     /// Discovery endpoint URL.
@@ -55,7 +55,6 @@ public class OidcClientConfig: @unchecked Sendable {
     
     /// Initializes a new `OidcClientConfig` instance.
     public init() {
-        logger = LogManager.none
         storage = KeychainStorage<Token>(account: "ACCESS_TOKEN_STORAGE", encryptor: SecuredKeyEncryptor() ?? NoEncryptor(), cacheStrategy: .NO_CACHE)
     }
     

--- a/Oidc/Oidc/OidcUser.swift
+++ b/Oidc/Oidc/OidcUser.swift
@@ -2,7 +2,7 @@
 //  OidcUser.swift
 //  PingOidc
 //
-//  Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Oidc/Oidc/User.swift
+++ b/Oidc/Oidc/User.swift
@@ -2,7 +2,7 @@
 //  User.swift
 //  PingOidc
 //
-//  Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/PingDeviceId.podspec
+++ b/PingDeviceId.podspec
@@ -33,6 +33,7 @@ Pod::Spec.new do |s|
     'DeviceId' => [base_dir + '/*.xcprivacy']
   }
   
+  s.ios.dependency 'PingLogger', '~> 1.3.1'
   s.ios.dependency 'PingStorage', '~> 1.3.1'
     
 end

--- a/Protect/Protect/ProtectError.swift
+++ b/Protect/Protect/ProtectError.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 /// Custom error type for Protect SDK exceptions
-public struct ProtectError: Error, LocalizedError {
+public struct ProtectError: Error, LocalizedError, Sendable {
     public let message: String
 
     /// A localized description of the error.

--- a/Protect/Protect/ProtectError.swift
+++ b/Protect/Protect/ProtectError.swift
@@ -2,7 +2,7 @@
 //  ProtectError.swift
 //  Protect
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/ReCaptchaEnterprise/ReCaptchaEnterprise/ReCaptchaEnterpriseCallback.swift
+++ b/ReCaptchaEnterprise/ReCaptchaEnterprise/ReCaptchaEnterpriseCallback.swift
@@ -237,7 +237,7 @@ public final class ReCaptchaEnterpriseConfig: @unchecked Sendable {
     public var timeout: Double = ReCaptchaEnterpriseConstants.defaultTimeout
     
     /// Logger instance for recording reCAPTCHA events
-    public var logger: Logger = LogManager.warning
+    public var logger: Logger = LogManager.logger
     
     /// Sets additional payload value for the reCAPTCHA in callback response.
     /// Dictionary value of additional data

--- a/ReCaptchaEnterprise/ReCaptchaEnterprise/ReCaptchaEnterpriseCallback.swift
+++ b/ReCaptchaEnterprise/ReCaptchaEnterprise/ReCaptchaEnterpriseCallback.swift
@@ -2,7 +2,7 @@
 //  ReCaptchaEnterpriseCallback.swift
 //  ReCaptchaEnterprise
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Storage/Storage/KeychainStorage.swift
+++ b/Storage/Storage/KeychainStorage.swift
@@ -2,7 +2,7 @@
 //  KeychainStorage.swift
 //  PingStorage
 //
-//  Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Storage/Storage/KeychainStorage.swift
+++ b/Storage/Storage/KeychainStorage.swift
@@ -85,7 +85,7 @@ public actor Keychain<T: Codable & Sendable>: Storage {
 
 
 /// `KeychainError` represents errors that can occur while interacting with the keychain.
-public enum KeychainError: LocalizedError {
+public enum KeychainError: LocalizedError, Sendable {
     case unableToSave
     case unableToRetrieve
     case unableToDelete
@@ -101,6 +101,9 @@ public enum KeychainError: LocalizedError {
             return "Unable to delete from the keychain"
         }
     }
+
+    /// A localized description of the error, used by `LocalizedError`.
+    public var errorDescription: String? { errorMessage }
 }
 
 

--- a/Storage/Storage/SecuredKeyEncryptor.swift
+++ b/Storage/Storage/SecuredKeyEncryptor.swift
@@ -52,7 +52,7 @@ public struct SecuredKeyEncryptor: Encryptor {
 
 
 /// `EncryptorError` represents errors that can occur while encrypting/decrypting.
-public enum EncryptorError: LocalizedError {
+public enum EncryptorError: LocalizedError, Sendable {
     case failedToEncrypt
     case failedToDecrypt
     
@@ -65,4 +65,7 @@ public enum EncryptorError: LocalizedError {
             return "Failed to decrypt given data"
         }
     }
+
+    /// A localized description of the error, used by `LocalizedError`.
+    public var errorDescription: String? { errorMessage }
 }

--- a/Storage/Storage/SecuredKeyEncryptor.swift
+++ b/Storage/Storage/SecuredKeyEncryptor.swift
@@ -2,7 +2,7 @@
 //  SecuredKeyEncryptor.swift
 //  PingStorage
 //
-//  Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Storage/Storage/SecuredKeyEncryptor.swift
+++ b/Storage/Storage/SecuredKeyEncryptor.swift
@@ -56,8 +56,8 @@ public enum EncryptorError: LocalizedError, Sendable {
     case failedToEncrypt
     case failedToDecrypt
     
-    /// A localized message describing what error occurred.
-    public var errorMessage: String {
+    /// A localized description of the error, used by `LocalizedError`.
+    public var errorDescription: String? {
         switch self {
         case .failedToEncrypt:
             return "Failed to encrypt given data"
@@ -65,7 +65,4 @@ public enum EncryptorError: LocalizedError, Sendable {
             return "Failed to decrypt given data"
         }
     }
-
-    /// A localized description of the error, used by `LocalizedError`.
-    public var errorDescription: String? { errorMessage }
 }


### PR DESCRIPTION
# JIRA Ticket

[JIRA](https://bugster.forgerock.org/jira/browse/SDKS-4817) "Adding localized error and sendable compliance"

# Description

**NOTE**: Also addresses [TRIAGE-33163](https://pingidentity.atlassian.net/browse/TRIAGE-33163)

**1. Concurrency Safety (Sendable Adoption)**
The PR adds Sendable conformance to almost every public Error and enum across the workspace (Binding, Browser, Davinci, Fido, etc.).

This allows these error objects to be safely passed between actors and across distributed isolation boundaries in Swift 6/Strict Concurrency mode.

Note on ApiError: This uses @unchecked Sendable for ApiError in the Davinci and Journey modules. This is a pragmatic choice because they wrap [String: Any] (which isn't inherently Sendable), but as noted in the comments, the data is immutable after creation.

**2. Improved Error Localization (LocalizedError)**
Many enums were updated to conform to LocalizedError by implementing errorDescription.

User Experience: This ensures that when a developer accesses error.localizedDescription, they get a human-readable string instead of just the enum case name.

Standardization: It replaces custom property names (like errorMessage) with the standard protocol requirements.

# Checklist:

- [X] I ran all unit tests and they pass
- [X] I added test case coverage for my changes
