### PR TITLE
Add ReCaptcha Enterprise integration tests

### DIFF
--- a/Journey/JourneyTests/Callbacks/AbstractValidatedCallbackTests.swift
+++ b/Journey/JourneyTests/Callbacks/AbstractValidatedCallbackTests.swift
@@ -2,7 +2,7 @@
 //  AbstractValidatedCallbackTests.swift
 //  JourneyTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -16,8 +16,8 @@ class AbstractValidatedCallbackTests: XCTestCase {
 
     private var callback: AbstractValidatedCallback!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws{
+        try await super.setUp()
 
         let jsonString = """
         {
@@ -126,7 +126,7 @@ class AbstractValidatedCallbackTests: XCTestCase {
            let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
             // Initialize callback with parsed data
             callback = AbstractValidatedCallback()
-            _ = callback.initialize(with: jsonObject)
+            _ = await callback.initialize(with: jsonObject)
         } else {
             XCTFail("Failed to parse JSON string")
         }

--- a/Journey/JourneyTests/Callbacks/AttributeInputCallbackTests.swift
+++ b/Journey/JourneyTests/Callbacks/AttributeInputCallbackTests.swift
@@ -2,7 +2,7 @@
 //  AttributeInputCallbackTests.swift
 //  JourneyTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -16,8 +16,8 @@ class AttributeInputCallbackTests: XCTestCase {
 
     private var callback: AttributeInputCallback!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws{
+        try await super.setUp()
 
         let jsonString = """
         {
@@ -90,7 +90,7 @@ class AttributeInputCallbackTests: XCTestCase {
            let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
             // Initialize callback with parsed data
             callback = AttributeInputCallback()
-            _ = callback.initialize(with: jsonObject)
+            _ = await callback.initialize(with: jsonObject)
         } else {
             XCTFail("Failed to parse JSON string")
         }

--- a/Journey/JourneyTests/Callbacks/BooleanAttributeInputCallbackTests.swift
+++ b/Journey/JourneyTests/Callbacks/BooleanAttributeInputCallbackTests.swift
@@ -2,7 +2,7 @@
 //  BooleanAttributeInputCallbackTests.swift
 //  JourneyTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -16,8 +16,8 @@ class BooleanAttributeInputCallbackTests: XCTestCase {
 
     private var callback: BooleanAttributeInputCallback!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws{
+        try await super.setUp()
 
         let jsonString = """
         {
@@ -90,7 +90,7 @@ class BooleanAttributeInputCallbackTests: XCTestCase {
            let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
             // Initialize callback with parsed data
             callback = BooleanAttributeInputCallback()
-            _ = callback.initialize(with: jsonObject)
+            _ = await callback.initialize(with: jsonObject)
         } else {
             XCTFail("Failed to parse JSON string")
         }

--- a/Journey/JourneyTests/Callbacks/ChoiceCallbackTests.swift
+++ b/Journey/JourneyTests/Callbacks/ChoiceCallbackTests.swift
@@ -2,7 +2,7 @@
 //  ChoiceCallbackTests.swift
 //  JourneyTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -16,8 +16,8 @@ class ChoiceCallbackTests: XCTestCase {
 
     private var callback: ChoiceCallback!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws{
+        try await super.setUp()
         callback = ChoiceCallback()
 
         let jsonString = """
@@ -54,7 +54,7 @@ class ChoiceCallbackTests: XCTestCase {
         if let data = jsonString.data(using: .utf8),
            let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
             callback = ChoiceCallback()
-            _ = callback.initialize(with: jsonObject)
+            _ = await callback.initialize(with: jsonObject)
         } else {
             XCTFail("Failed to parse JSON string")
         }

--- a/Journey/JourneyTests/Callbacks/ConfirmationCallbackTests.swift
+++ b/Journey/JourneyTests/Callbacks/ConfirmationCallbackTests.swift
@@ -2,7 +2,7 @@
 //  ConfirmationCallbackTests.swift
 //  JourneyTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -16,8 +16,8 @@ class ConfirmationCallbackTests: XCTestCase {
 
     private var callback: ConfirmationCallback!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws{
+        try await super.setUp()
         callback = ConfirmationCallback()
 
         let jsonString = """
@@ -62,7 +62,7 @@ class ConfirmationCallbackTests: XCTestCase {
            let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
             // Set up the original json property to simulate the initial state
             callback = ConfirmationCallback()
-            _ = callback.initialize(with: jsonObject)
+            _ = await callback.initialize(with: jsonObject)
         } else {
             XCTFail("Failed to parse JSON string")
         }

--- a/Journey/JourneyTests/Callbacks/ConsentMappingCallbackTests.swift
+++ b/Journey/JourneyTests/Callbacks/ConsentMappingCallbackTests.swift
@@ -2,7 +2,7 @@
 //  ConsentMappingCallbackTests.swift
 //  JourneyTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -16,8 +16,8 @@ class ConsentMappingCallbackTests: XCTestCase {
 
     private var callback: ConsentMappingCallback!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws{
+        try await super.setUp()
         callback = ConsentMappingCallback()
 
         let jsonString = """
@@ -68,7 +68,7 @@ class ConsentMappingCallbackTests: XCTestCase {
 
             // Initialize callback with parsed data
             callback = ConsentMappingCallback()
-            _ = callback.initialize(with: jsonObject)
+            _ = await callback.initialize(with: jsonObject)
         } else {
             XCTFail("Failed to parse JSON string")
         }

--- a/Journey/JourneyTests/Callbacks/HiddenValueCallbackTests.swift
+++ b/Journey/JourneyTests/Callbacks/HiddenValueCallbackTests.swift
@@ -2,7 +2,7 @@
 //  HiddenValueCallbackTests.swift
 //  JourneyTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -16,8 +16,8 @@ class HiddenValueCallbackTests: XCTestCase {
 
     private var callback: HiddenValueCallback!
     
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         callback = HiddenValueCallback()
 
         let jsonString = """
@@ -48,7 +48,7 @@ class HiddenValueCallbackTests: XCTestCase {
 
             // Initialize callback with parsed data
             callback = HiddenValueCallback()
-            _ = callback.initialize(with: jsonObject)
+            _ = await callback.initialize(with: jsonObject)
         } else {
             XCTFail("Failed to parse JSON string")
         }

--- a/Journey/JourneyTests/Callbacks/KbaCreateCallbackTests.swift
+++ b/Journey/JourneyTests/Callbacks/KbaCreateCallbackTests.swift
@@ -2,7 +2,7 @@
 //  KbaCreateCallbackTests.swift
 //  JourneyTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -16,8 +16,8 @@ class KbaCreateCallbackTests: XCTestCase {
 
     private var callback: KbaCreateCallback!
     
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws{
+        try await super.setUp()
         callback = KbaCreateCallback()
 
         let jsonString = """
@@ -60,7 +60,7 @@ class KbaCreateCallbackTests: XCTestCase {
 
              // Initialize callback with parsed data
              callback = KbaCreateCallback()
-             _ = callback.initialize(with: jsonObject)
+            _ = await callback.initialize(with: jsonObject)
         } else {
             XCTFail("Failed to parse JSON string")
         }

--- a/Journey/JourneyTests/Callbacks/MetadataCallbackTests.swift
+++ b/Journey/JourneyTests/Callbacks/MetadataCallbackTests.swift
@@ -2,7 +2,7 @@
 //  MetadataCallbackTests.swift
 //  JourneyTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -16,8 +16,8 @@ class MetadataCallbackTests: XCTestCase {
 
     private var callback: MetadataCallback!
     
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws{
+        try await super.setUp()
         callback = MetadataCallback()
 
         let jsonString = """
@@ -48,7 +48,7 @@ class MetadataCallbackTests: XCTestCase {
 
              // Initialize callback with parsed data
              callback = MetadataCallback()
-             _ = callback.initialize(with: jsonObject)
+             _ = await callback.initialize(with: jsonObject)
         } else {
             XCTFail("Failed to parse JSON string")
         }
@@ -90,7 +90,7 @@ class MetadataCallbackTests: XCTestCase {
         }
     }
 
-    func testInitWithProtectInitialize() {
+    func testInitWithProtectInitialize() async {
         let protectInitializeJsonString = """
         {
           "type": "MetadataCallback",
@@ -121,7 +121,7 @@ class MetadataCallbackTests: XCTestCase {
            let parsed = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
 
             let newCallback = MetadataCallback()
-            let actualCallback = newCallback.initialize(with: parsed)
+            let actualCallback = await newCallback.initialize(with: parsed)
 
             // If PingOneProtectInitializeCallback is registered, it should return that type
             // Otherwise, it should return the original MetadataCallback
@@ -143,7 +143,7 @@ class MetadataCallbackTests: XCTestCase {
         }
     }
 
-    func testInitWithProtectEvaluation() {
+    func testInitWithProtectEvaluation() async {
         let protectEvaluationJsonString = """
         {
           "type": "MetadataCallback",
@@ -166,7 +166,7 @@ class MetadataCallbackTests: XCTestCase {
            let parsed = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
 
             let newCallback = MetadataCallback()
-            let actualCallback = newCallback.initialize(with: parsed)
+            let actualCallback = await newCallback.initialize(with: parsed)
 
             // If PingOneProtectEvaluationCallback is registered, it should return that type
             // Otherwise, it should return the original MetadataCallback
@@ -189,7 +189,7 @@ class MetadataCallbackTests: XCTestCase {
         }
     }
 
-    func testFidoRegistrationDetection() {
+    func testFidoRegistrationDetection() async {
         let fidoRegJsonString = """
         {
           "type": "MetadataCallback",
@@ -212,7 +212,7 @@ class MetadataCallbackTests: XCTestCase {
            let parsed = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
 
             let newCallback = MetadataCallback()
-            _ = newCallback.initialize(with: parsed)
+            _ = await newCallback.initialize(with: parsed)
 
             // Test that the metadata contains FIDO registration data
             XCTAssertEqual(newCallback.value["_action"] as? String, "webauthn_registration")
@@ -279,9 +279,9 @@ class MetadataCallbackTests: XCTestCase {
         }
     }
 
-    func testMetadataCallbackReturnsSelfWhenNoSpecializedCallback() {
+    func testMetadataCallbackReturnsSelfWhenNoSpecializedCallback() async {
         // Test that when no specialized callback is registered, it returns self
-        let actualCallback = callback.initialize(with: callback.json)
+        let actualCallback = await callback.initialize(with: callback.json)
 
         // Should return the same instance when no transformation occurs
         XCTAssertTrue(type(of: actualCallback) == MetadataCallback.self)

--- a/Journey/JourneyTests/Callbacks/NameCallbackTests.swift
+++ b/Journey/JourneyTests/Callbacks/NameCallbackTests.swift
@@ -2,7 +2,7 @@
 //  NameCallbackTests.swift
 //  JourneyTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -16,8 +16,8 @@ class NameCallbackTests: XCTestCase {
 
     private var callback: NameCallback!
     
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws{
+        try await super.setUp()
         callback = NameCallback()
 
         let jsonString = """
@@ -43,7 +43,7 @@ class NameCallbackTests: XCTestCase {
 
              // Initialize callback with parsed data
              callback = NameCallback()
-             _ = callback.initialize(with: jsonObject)
+             _ = await callback.initialize(with: jsonObject)
         } else {
             XCTFail("Failed to parse JSON string")
         }

--- a/Journey/JourneyTests/Callbacks/NumberAttributeInputCallbackTests.swift
+++ b/Journey/JourneyTests/Callbacks/NumberAttributeInputCallbackTests.swift
@@ -2,7 +2,7 @@
 //  NumberAttributeInputCallbackTests.swift
 //  JourneyTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -16,8 +16,8 @@ class NumberAttributeInputCallbackTests: XCTestCase {
 
     private var callback: NumberAttributeInputCallback!
     
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws{
+        try await super.setUp()
         callback = NumberAttributeInputCallback()
 
         let jsonString = """
@@ -92,7 +92,7 @@ class NumberAttributeInputCallbackTests: XCTestCase {
 
              // Initialize callback with parsed data
              callback = NumberAttributeInputCallback()
-             _ = callback.initialize(with: jsonObject)
+             _ = await callback.initialize(with: jsonObject)
         } else {
             XCTFail("Failed to parse JSON string")
         }

--- a/Journey/JourneyTests/Callbacks/PasswordCallbackTests.swift
+++ b/Journey/JourneyTests/Callbacks/PasswordCallbackTests.swift
@@ -2,7 +2,7 @@
 //  PasswordCallbackTests.swift
 //  JourneyTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -16,8 +16,8 @@ class PasswordCallbackTests: XCTestCase {
 
     private var callback: PasswordCallback!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws{
+        try await super.setUp()
         callback = PasswordCallback()
 
         let jsonString = """
@@ -43,7 +43,7 @@ class PasswordCallbackTests: XCTestCase {
 
              // Initialize callback with parsed data
              callback = PasswordCallback()
-             _ = callback.initialize(with: jsonObject)
+            _ = await callback.initialize(with: jsonObject)
         } else {
             XCTFail("Failed to parse JSON string")
         }

--- a/Journey/JourneyTests/Callbacks/PollingWaitCallbackTests.swift
+++ b/Journey/JourneyTests/Callbacks/PollingWaitCallbackTests.swift
@@ -2,7 +2,7 @@
 //  PollingWaitCallbackTests.swift
 //  JourneyTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -16,8 +16,8 @@ class PollingWaitCallbackTests: XCTestCase {
 
     private var callback: PollingWaitCallback!
     
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws{
+        try await super.setUp()
         callback = PollingWaitCallback()
 
         let jsonString = """
@@ -42,7 +42,7 @@ class PollingWaitCallbackTests: XCTestCase {
 
              // Initialize callback with parsed data
              callback = PollingWaitCallback()
-             _ = callback.initialize(with: jsonObject)
+             _ = await callback.initialize(with: jsonObject)
         } else {
             XCTFail("Failed to parse JSON string")
         }

--- a/Journey/JourneyTests/Callbacks/StringAttributeInputCallbackTests.swift
+++ b/Journey/JourneyTests/Callbacks/StringAttributeInputCallbackTests.swift
@@ -2,7 +2,7 @@
 //  StringAttributeInputCallbackTests.swift
 //  JourneyTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -16,8 +16,8 @@ class StringAttributeInputCallbackTests: XCTestCase {
 
     private var callback: StringAttributeInputCallback!
     
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws{
+        try await super.setUp()
         callback = StringAttributeInputCallback()
 
         let jsonString = """
@@ -106,7 +106,7 @@ class StringAttributeInputCallbackTests: XCTestCase {
 
              // Initialize callback with parsed data
              callback = StringAttributeInputCallback()
-             _ = callback.initialize(with: jsonObject)
+             _ = await callback.initialize(with: jsonObject)
         } else {
             XCTFail("Failed to parse JSON string")
         }

--- a/Journey/JourneyTests/Callbacks/SuspendedTextOutputCallbackTests.swift
+++ b/Journey/JourneyTests/Callbacks/SuspendedTextOutputCallbackTests.swift
@@ -2,7 +2,7 @@
 //  SuspendedTextOutputCallbackTests.swift
 //  JourneyTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -17,8 +17,8 @@ class SuspendedTextOutputCallbackTests: XCTestCase {
     private var callback: SuspendedTextOutputCallback!
     private var jsonObject: [String: Any]!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws{
+        try await super.setUp()
         callback = SuspendedTextOutputCallback()
 
         let jsonString = """
@@ -43,7 +43,7 @@ class SuspendedTextOutputCallbackTests: XCTestCase {
 
              // Initialize callback with parsed data
              callback = SuspendedTextOutputCallback()
-             _ = callback.initialize(with: jsonObject)
+             _ = await callback.initialize(with: jsonObject)
         } else {
             XCTFail("Failed to parse JSON string")
         }

--- a/Journey/JourneyTests/Callbacks/TermsAndConditionsCallbackTests.swift
+++ b/Journey/JourneyTests/Callbacks/TermsAndConditionsCallbackTests.swift
@@ -2,7 +2,7 @@
 //  TermsAndConditionsCallbackTests.swift
 //  JourneyTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -16,8 +16,8 @@ class TermsAndConditionsCallbackTests: XCTestCase {
 
     private var callback: TermsAndConditionsCallback!
     
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws{
+        try await super.setUp()
         callback = TermsAndConditionsCallback()
 
         let jsonString = """
@@ -52,7 +52,7 @@ class TermsAndConditionsCallbackTests: XCTestCase {
 
              // Initialize callback with parsed data
              callback = TermsAndConditionsCallback()
-             _ = callback.initialize(with: jsonObject)
+             _ = await callback.initialize(with: jsonObject)
         } else {
             XCTFail("Failed to parse JSON string")
         }

--- a/Journey/JourneyTests/Callbacks/TextInputCallbackTests.swift
+++ b/Journey/JourneyTests/Callbacks/TextInputCallbackTests.swift
@@ -2,7 +2,7 @@
 //  TextInputCallbackTests.swift
 //  JourneyTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -16,8 +16,8 @@ class TextInputCallbackTests: XCTestCase {
 
     private var callback: TextInputCallback!
     
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws{
+        try await super.setUp()
         callback = TextInputCallback()
 
         let jsonString = """
@@ -49,7 +49,7 @@ class TextInputCallbackTests: XCTestCase {
 
              // Initialize callback with parsed data
              callback = TextInputCallback()
-             _ = callback.initialize(with: jsonObject)
+            _ = await callback.initialize(with: jsonObject)
         } else {
             XCTFail("Failed to parse JSON string")
         }

--- a/Journey/JourneyTests/Callbacks/TextOutputCallbackTests.swift
+++ b/Journey/JourneyTests/Callbacks/TextOutputCallbackTests.swift
@@ -2,7 +2,7 @@
 //  TextOutputCallbackTests.swift
 //  JourneyTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -16,8 +16,8 @@ class TextOutputCallbackTests: XCTestCase {
 
     private var callback: TextOutputCallback!
     
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws{
+        try await super.setUp()
         callback = TextOutputCallback()
 
         let jsonString = """
@@ -42,7 +42,7 @@ class TextOutputCallbackTests: XCTestCase {
 
              // Initialize callback with parsed data
              callback = TextOutputCallback()
-             _ = callback.initialize(with: jsonObject)
+             _ = await callback.initialize(with: jsonObject)
         } else {
             XCTFail("Failed to parse JSON string")
         }

--- a/Journey/JourneyTests/Callbacks/ValidatedPasswordCallbackTests.swift
+++ b/Journey/JourneyTests/Callbacks/ValidatedPasswordCallbackTests.swift
@@ -2,7 +2,7 @@
 //  ValidatedPasswordCallbackTests.swift
 //  JourneyTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -16,8 +16,8 @@ class ValidatedPasswordCallbackTests: XCTestCase {
 
     private var callback: ValidatedPasswordCallback!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws{
+        try await super.setUp()
         callback = ValidatedPasswordCallback()
 
         let jsonString = """
@@ -84,7 +84,7 @@ class ValidatedPasswordCallbackTests: XCTestCase {
 
              // Initialize callback with parsed data
              callback = ValidatedPasswordCallback()
-             _ = callback.initialize(with: jsonObject)
+             _ = await callback.initialize(with: jsonObject)
         } else {
             XCTFail("Failed to parse JSON string")
         }

--- a/Journey/JourneyTests/Callbacks/ValidatedUsernameCallbackTests.swift
+++ b/Journey/JourneyTests/Callbacks/ValidatedUsernameCallbackTests.swift
@@ -2,7 +2,7 @@
 //  ValidatedUsernameCallbackTests.swift
 //  JourneyTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -16,8 +16,8 @@ class ValidatedUsernameCallbackTests: XCTestCase {
 
     private var callback: ValidatedUsernameCallback!
     
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws{
+        try await super.setUp()
         callback = ValidatedUsernameCallback()
 
         let jsonString = """
@@ -126,7 +126,7 @@ class ValidatedUsernameCallbackTests: XCTestCase {
 
              // Initialize callback with parsed data
              callback = ValidatedUsernameCallback()
-             _ = callback.initialize(with: jsonObject)
+             _ = await callback.initialize(with: jsonObject)
         } else {
             XCTFail("Failed to parse JSON string")
         }

--- a/JourneyPlugin/JourneyPlugin/AbstractCallback.swift
+++ b/JourneyPlugin/JourneyPlugin/AbstractCallback.swift
@@ -19,11 +19,6 @@ open class AbstractCallback: Callback, @unchecked Sendable {
 
     /// Initializes a new instance of `AbstractCallback` with the provided JSON.
     open func initialize(with json: [String: Any]) async -> any Callback {
-        return self.privateInit(with: json)
-    }
-    
-    /// Private convinient initializer, to allow both Async and Sync initializations
-    private func privateInit(with json: [String: Any]) -> any Callback {
         self.json = json
         if let output = json[JourneyConstants.output] as? [[String: Any]] {
             for item in output {

--- a/JourneyPlugin/JourneyPlugin/AbstractCallback.swift
+++ b/JourneyPlugin/JourneyPlugin/AbstractCallback.swift
@@ -2,7 +2,7 @@
 //  AbstractCallback.swift
 //  PingJourneyPlugin
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -19,12 +19,6 @@ open class AbstractCallback: Callback, @unchecked Sendable {
 
     /// Initializes a new instance of `AbstractCallback` with the provided JSON.
     open func initialize(with json: [String: Any]) async -> any Callback {
-        return self.privateInit(with: json)
-    }
-
-    
-    /// Initializes a new instance of `AbstractCallback` with the provided JSON.
-    open func initialize(with json: [String: Any]) -> any Callback {
         return self.privateInit(with: json)
     }
     

--- a/JourneyPlugin/JourneyPlugin/Callback.swift
+++ b/JourneyPlugin/JourneyPlugin/Callback.swift
@@ -2,7 +2,7 @@
 //  Callbacks.swift
 //  PingJourneyPlugin
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -18,9 +18,6 @@ import PingOrchestrate
 public protocol Callback: Action, Identifiable, Sendable {
     /// Required default initializer.
     init()
-    /// Initializes this callback from a server-provided JSON dictionary and returns `self` (synchronous variant).
-    /// - Parameter json: The raw JSON dictionary describing this callback instance.
-    func initialize(with json: [String: Any]) -> any Callback
     /// Initializes this callback from a server-provided JSON dictionary and returns `self` (async variant).
     /// - Parameter json: The raw JSON dictionary describing this callback instance.
     func initialize(with json: [String: Any]) async -> any Callback
@@ -36,10 +33,6 @@ public protocol Callback: Action, Identifiable, Sendable {
 public extension Callback {
     func initialize(with json: [String: Any]) async -> any Callback {
         return await initialize(with: json)
-    }
-    
-    func initialize(with json: [String: Any]) -> any Callback {
-        return initialize(with: json)
     }
 }
 

--- a/Protect/Protect/Journey/AbstractProtectCallback.swift
+++ b/Protect/Protect/Journey/AbstractProtectCallback.swift
@@ -2,7 +2,7 @@
 //  AbstractProtectCallback.swift
 //  Protect
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -27,7 +27,7 @@ open class AbstractProtectCallback: AbstractCallback, ContinueNodeAware, @unchec
     }
     
     /// Initialize from JSON object
-    public override func initialize(with json: [String: Any]) -> any Callback {
+    public override func initialize(with json: [String: Any]) async -> any Callback {
         if let type = json[JourneyConstants.type] as? String, type == JourneyConstants.metadataCallback {
             derivedCallback = true
             if let output = json[JourneyConstants.output] as? [[String: Any]],
@@ -42,7 +42,7 @@ open class AbstractProtectCallback: AbstractCallback, ContinueNodeAware, @unchec
             return self
         } else {
             // Use standard initialization
-            return super.initialize(with: json)
+            return await super.initialize(with: json)
         }
     }
     

--- a/ReCaptchaEnterprise/ReCaptchaEnterprise.xcodeproj/project.pbxproj
+++ b/ReCaptchaEnterprise/ReCaptchaEnterprise.xcodeproj/project.pbxproj
@@ -610,7 +610,7 @@
 			repositoryURL = "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk";
 			requirement = {
 				kind = exactVersion;
-				version = "18.9.0-beta01";
+				version = 18.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ReCaptchaEnterprise/ReCaptchaEnterprise.xcodeproj/project.pbxproj
+++ b/ReCaptchaEnterprise/ReCaptchaEnterprise.xcodeproj/project.pbxproj
@@ -610,7 +610,7 @@
 			repositoryURL = "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = "18.9.0-beta01";
+				minimumVersion = 18.8.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ReCaptchaEnterprise/ReCaptchaEnterprise.xcodeproj/project.pbxproj
+++ b/ReCaptchaEnterprise/ReCaptchaEnterprise.xcodeproj/project.pbxproj
@@ -609,8 +609,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk";
 			requirement = {
-				kind = exactVersion;
-				version = "18.9.0-beta01";
+				kind = upToNextMajorVersion;
+				minimumVersion = "18.9.0-beta01";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ReCaptchaEnterprise/ReCaptchaEnterprise.xcodeproj/project.pbxproj
+++ b/ReCaptchaEnterprise/ReCaptchaEnterprise.xcodeproj/project.pbxproj
@@ -609,8 +609,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk";
 			requirement = {
-				kind = exactVersion;
-				version = 18.7.0;
+				kind = upToNextMajorVersion;
+				minimumVersion = "18.9.0-beta01";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ReCaptchaEnterprise/ReCaptchaEnterprise.xcodeproj/project.pbxproj
+++ b/ReCaptchaEnterprise/ReCaptchaEnterprise.xcodeproj/project.pbxproj
@@ -610,7 +610,7 @@
 			repositoryURL = "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk";
 			requirement = {
 				kind = exactVersion;
-				version = 18.8.1;
+				version = "18.9.0-beta01";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ReCaptchaEnterprise/ReCaptchaEnterprise.xcodeproj/project.pbxproj
+++ b/ReCaptchaEnterprise/ReCaptchaEnterprise.xcodeproj/project.pbxproj
@@ -610,7 +610,7 @@
 			repositoryURL = "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk";
 			requirement = {
 				kind = exactVersion;
-				version = 18.8.0;
+				version = "18.9.0-beta01";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ReCaptchaEnterprise/ReCaptchaEnterprise.xcodeproj/project.pbxproj
+++ b/ReCaptchaEnterprise/ReCaptchaEnterprise.xcodeproj/project.pbxproj
@@ -9,6 +9,12 @@
 /* Begin PBXBuildFile section */
 		A56742632EE21DC1009D29B9 /* PingCommons.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A56742622EE21DC1009D29B9 /* PingCommons.framework */; };
 		A56742642EE21DC1009D29B9 /* PingCommons.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A56742622EE21DC1009D29B9 /* PingCommons.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A568D7352F5B27A9007631AA /* ReCaptchaEnterpriseCallbackE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A568D7342F5B2789007631AA /* ReCaptchaEnterpriseCallbackE2ETests.swift */; };
+		A568D7382F5B2AC1007631AA /* Config.json in Resources */ = {isa = PBXBuildFile; fileRef = A568D7372F5B2AC1007631AA /* Config.json */; };
+		A568D73A2F5B2AC1007631AA /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = A568D7392F5B2AC1007631AA /* Config.swift */; };
+		A568D73C2F5B2ADF007631AA /* BindingE2EBaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A568D73B2F5B2ADF007631AA /* BindingE2EBaseTest.swift */; };
+		A568D73E2F5B2C54007631AA /* PingJourney.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A568D73D2F5B2C54007631AA /* PingJourney.framework */; };
+		A568D73F2F5B2C54007631AA /* PingJourney.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A568D73D2F5B2C54007631AA /* PingJourney.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A58CFBF02EB00508007C4A31 /* RecaptchaEnterprise in Frameworks */ = {isa = PBXBuildFile; productRef = A58CFBEF2EB00508007C4A31 /* RecaptchaEnterprise */; };
 		A58CFBF22EB00600007C4A31 /* ReCaptchaEnterpriseCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = A58CFBF12EB005FF007C4A31 /* ReCaptchaEnterpriseCallback.swift */; };
 		A58CFBFD2EB03693007C4A31 /* ReCaptchaEnterpriseConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A58CFBFC2EB03692007C4A31 /* ReCaptchaEnterpriseConfigTests.swift */; };
@@ -42,10 +48,26 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A568D7402F5B2C54007631AA /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				A568D73F2F5B2C54007631AA /* PingJourney.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		A56742622EE21DC1009D29B9 /* PingCommons.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingCommons.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A568D7342F5B2789007631AA /* ReCaptchaEnterpriseCallbackE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReCaptchaEnterpriseCallbackE2ETests.swift; sourceTree = "<group>"; };
+		A568D7372F5B2AC1007631AA /* Config.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Config.json; sourceTree = "<group>"; };
+		A568D7392F5B2AC1007631AA /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
+		A568D73B2F5B2ADF007631AA /* BindingE2EBaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindingE2EBaseTest.swift; sourceTree = "<group>"; };
+		A568D73D2F5B2C54007631AA /* PingJourney.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingJourney.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A58CFBF12EB005FF007C4A31 /* ReCaptchaEnterpriseCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReCaptchaEnterpriseCallback.swift; sourceTree = "<group>"; };
 		A58CFBF42EB00637007C4A31 /* PingJourney.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingJourney.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A58CFBFC2EB03692007C4A31 /* ReCaptchaEnterpriseConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReCaptchaEnterpriseConfigTests.swift; sourceTree = "<group>"; };
@@ -75,15 +97,35 @@
 			buildActionMask = 2147483647;
 			files = (
 				A5C0ABFE2EAFFFDF00846D16 /* PingReCaptchaEnterprise.framework in Frameworks */,
+				A568D73E2F5B2C54007631AA /* PingJourney.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		A568D7332F5B275D007631AA /* Integration Tests */ = {
+			isa = PBXGroup;
+			children = (
+				A568D7342F5B2789007631AA /* ReCaptchaEnterpriseCallbackE2ETests.swift */,
+				A568D73B2F5B2ADF007631AA /* BindingE2EBaseTest.swift */,
+			);
+			path = "Integration Tests";
+			sourceTree = "<group>";
+		};
+		A568D7362F5B2AAB007631AA /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				A568D7372F5B2AC1007631AA /* Config.json */,
+				A568D7392F5B2AC1007631AA /* Config.swift */,
+			);
+			path = Config;
+			sourceTree = "<group>";
+		};
 		A58CFBF32EB00637007C4A31 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				A568D73D2F5B2C54007631AA /* PingJourney.framework */,
 				A56742622EE21DC1009D29B9 /* PingCommons.framework */,
 				EC5C81E42ED084E300C91570 /* PingJourneyPlugin.framework */,
 				A58CFBF42EB00637007C4A31 /* PingJourney.framework */,
@@ -125,8 +167,10 @@
 		A5C0AC3F2EAFFFF300846D16 /* ReCaptchaEnterpriseTests */ = {
 			isa = PBXGroup;
 			children = (
+				A568D7332F5B275D007631AA /* Integration Tests */,
 				A5C0AC3E2EAFFFF300846D16 /* ReCaptchaEnterpriseCallbackTests.swift */,
 				A58CFBFC2EB03692007C4A31 /* ReCaptchaEnterpriseConfigTests.swift */,
+				A568D7362F5B2AAB007631AA /* Config */,
 			);
 			path = ReCaptchaEnterpriseTests;
 			sourceTree = "<group>";
@@ -174,6 +218,7 @@
 				A5C0ABF92EAFFFDF00846D16 /* Sources */,
 				A5C0ABFA2EAFFFDF00846D16 /* Frameworks */,
 				A5C0ABFB2EAFFFDF00846D16 /* Resources */,
+				A568D7402F5B2C54007631AA /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -241,6 +286,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A568D7382F5B2AC1007631AA /* Config.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -261,7 +307,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				A5C0AC402EAFFFF300846D16 /* ReCaptchaEnterpriseCallbackTests.swift in Sources */,
+				A568D73A2F5B2AC1007631AA /* Config.swift in Sources */,
 				A58CFBFD2EB03693007C4A31 /* ReCaptchaEnterpriseConfigTests.swift in Sources */,
+				A568D73C2F5B2ADF007631AA /* BindingE2EBaseTest.swift in Sources */,
+				A568D7352F5B27A9007631AA /* ReCaptchaEnterpriseCallbackE2ETests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -426,7 +475,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0-alpha;
+				MARKETING_VERSION = "2.0.0-alpha";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pingidentity.ReCaptchaEnterprise;
@@ -464,7 +513,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0-alpha;
+				MARKETING_VERSION = "2.0.0-alpha";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pingidentity.ReCaptchaEnterprise;
@@ -489,7 +538,7 @@
 				DEVELOPMENT_TEAM = 9QSE66762D;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				MARKETING_VERSION = 2.0.0-alpha;
+				MARKETING_VERSION = "2.0.0-alpha";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pingidentity.ReCaptchaEnterpriseTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -510,7 +559,7 @@
 				DEVELOPMENT_TEAM = 9QSE66762D;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				MARKETING_VERSION = 2.0.0-alpha;
+				MARKETING_VERSION = "2.0.0-alpha";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pingidentity.ReCaptchaEnterpriseTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;

--- a/ReCaptchaEnterprise/ReCaptchaEnterprise.xcodeproj/project.pbxproj
+++ b/ReCaptchaEnterprise/ReCaptchaEnterprise.xcodeproj/project.pbxproj
@@ -609,8 +609,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 18.8.1;
+				kind = exactVersion;
+				version = 18.8.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ReCaptchaEnterprise/ReCaptchaEnterprise.xcodeproj/project.pbxproj
+++ b/ReCaptchaEnterprise/ReCaptchaEnterprise.xcodeproj/project.pbxproj
@@ -609,8 +609,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 18.8.1;
+				kind = exactVersion;
+				version = 18.7.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ReCaptchaEnterprise/ReCaptchaEnterprise/ReCaptchaEnterpriseCallback.swift
+++ b/ReCaptchaEnterprise/ReCaptchaEnterprise/ReCaptchaEnterpriseCallback.swift
@@ -2,7 +2,7 @@
 //  ReCaptchaEnterpriseCallback.swift
 //  ReCaptchaEnterprise
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -62,8 +62,8 @@ public class ReCaptchaEnterpriseCallback: AbstractCallback, @unchecked Sendable 
     // MARK: - Initialization
     
     /// Initializes a new instance of `ReCaptchaEnterpriseCallback` with the provided JSON.
-    public override func initialize(with json: [String: Any]) -> any Callback {
-        _ = super.initialize(with: json)
+    public override func initialize(with json: [String: Any]) async -> any Callback {
+        _ = await super.initialize(with: json)
         
         // Assign input keys
         if let inputItems = json[JourneyConstants.input] as? [[String: Any]] {

--- a/ReCaptchaEnterprise/ReCaptchaEnterpriseTests/Config/Config.json
+++ b/ReCaptchaEnterprise/ReCaptchaEnterpriseTests/Config/Config.json
@@ -1,0 +1,19 @@
+{
+    "username" : "sdkuser",
+    "userFname" : "Sdk",
+    "userLname" : "User",
+    "password" : "password",
+    "newPassword" : "New1234#1",
+    "verificationCode" : "1234",
+    
+    "clientId": "iosclient",
+    "scopes": "openid profile email address",
+    "redirectUri": "frauth://oauth2redirect",
+    "signOutUri": "frauth://oauth2redirect",
+    "discoveryEndpoint": "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration",
+    "environment": "AIC",
+    "cookieName": "5421aeddf91aa20",
+    "serverUrl": "https://openam-sdks.forgeblocks.com/am",
+    "realm": "alpha",
+    "acrValues" : "79220c5e3a217a3d9b6739585cb160aa"
+}

--- a/ReCaptchaEnterprise/ReCaptchaEnterpriseTests/Config/Config.swift
+++ b/ReCaptchaEnterprise/ReCaptchaEnterpriseTests/Config/Config.swift
@@ -1,0 +1,137 @@
+//
+//  Config.swift
+//  ReCaptchaEnterprise
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+
+import Foundation
+
+public enum ConfigError: Error {
+    case emptyConfiguration
+    case invalidConfiguration(String)
+}
+
+class Config: NSObject {
+    var username: String
+    var userFname: String
+    var userLname: String
+    var password: String
+    var newPassword: String
+    var verificationCode: String
+    
+    var clientId: String
+    var discoveryEndpoint: String
+    var scopes: [String]
+    var redirectUri: String
+    var acrValues: String
+    var configPlistFileName: String?
+    var serverUrl: String
+    var cookieName: String
+    var realm: String
+    
+    var configJSON: [String: Any]?
+    
+    override init() {
+        username = ""
+        userFname = ""
+        userLname = ""
+        password = ""
+        newPassword = ""
+        verificationCode = ""
+        
+        clientId = ""
+        discoveryEndpoint = ""
+        scopes = []
+        redirectUri = ""
+        acrValues = ""
+        serverUrl = ""
+        cookieName = ""
+        realm = ""
+    }
+    
+    
+    init(_ configFileName: String) throws {
+        
+        username = ""
+        userFname = ""
+        userLname = ""
+        password = ""
+        newPassword = ""
+        verificationCode = ""
+        
+        clientId = ""
+        discoveryEndpoint = ""
+        scopes = []
+        redirectUri = ""
+        acrValues = ""
+        serverUrl = ""
+        cookieName = ""
+        realm = ""
+        
+        if let path = Bundle(for: ReCaptchaEnterpriseCallbackTests.self).path(forResource: configFileName, ofType: "json") {
+            do {
+                let data = try Data(contentsOf: URL(fileURLWithPath: path), options: .mappedIfSafe)
+                let jsonResult = try JSONSerialization.jsonObject(with: data, options: .mutableLeaves)
+                if let config = jsonResult as? [String: Any] {
+                    self.configJSON = config
+                    guard let username = config["username"] as? String,
+                          let userFname = config["userFname"] as? String,
+                          let userLname = config["userLname"] as? String,
+                          let password = config["password"] as? String,
+                          let newPassword = config["newPassword"] as? String,
+                          let verificationCode = config["verificationCode"] as? String
+                    else {
+                        throw ConfigError.invalidConfiguration("Test config data is empty or invalid")
+                    }
+                    
+                    self.username = username
+                    self.userFname = userFname
+                    self.userLname = userLname
+                    self.password = password
+                    self.newPassword = newPassword
+                    self.verificationCode = verificationCode
+                    
+                    if let configPlistFileName = config["configPlistFileName"] as? String {
+                        self.configPlistFileName = configPlistFileName
+                    }
+                                                            
+                    guard let clientId = config["clientId"] as? String,
+                          let discoveryEndpoint = config["discoveryEndpoint"] as? String,
+                          let scopes = config["scopes"] as? String,
+                          let redirectUri = config["redirectUri"] as? String,
+                          let acrValues = config["acrValues"] as? String,
+                          let serverUrl = config["serverUrl"] as? String,
+                          let realm = config["realm"] as? String,
+                          let cookieName = config["cookieName"] as? String
+                    else {
+                        throw ConfigError.invalidConfiguration("Test DV config data is empty or invalid")
+                    }
+                    
+                    self.clientId = clientId
+                    self.discoveryEndpoint = discoveryEndpoint
+                    self.scopes = scopes
+                      .components(separatedBy: .whitespaces)
+                      .filter { !$0.isEmpty }
+                    self.redirectUri = redirectUri
+                    self.acrValues = acrValues
+                    self.serverUrl = serverUrl
+                    self.realm = realm
+                    self.cookieName = cookieName
+                }
+                else {
+                    throw ConfigError.invalidConfiguration("\(configFileName) is invalid or missing some value")
+                }
+            } catch {
+                throw error
+            }
+        }
+        else {
+            throw ConfigError.emptyConfiguration
+        }
+    }
+}

--- a/ReCaptchaEnterprise/ReCaptchaEnterpriseTests/Integration Tests/BindingE2EBaseTest.swift
+++ b/ReCaptchaEnterprise/ReCaptchaEnterpriseTests/Integration Tests/BindingE2EBaseTest.swift
@@ -1,0 +1,118 @@
+//
+//  BindingE2EBaseTest.swift
+//  ReCaptchaEnterprise
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+@testable import PingJourney
+@testable import PingOrchestrate
+@testable import PingLogger
+@testable import PingReCaptchaEnterprise
+@testable import PingJourneyPlugin
+@testable import PingOidc
+
+open class BindingE2EBaseTest: XCTestCase {
+    private(set) var config: Config!
+    var configFileName = "Config"
+    
+    open var defaultJourney: Journey!
+    open var username: String!
+    open var userFirstName: String!
+    open var userLastName: String!
+    open var password: String!
+    
+    open var serverUrl: String!
+    open var realm: String!
+    open var cookie: String!
+    
+    open var clientId: String!
+    open var scopes: [String]!
+    open var redirectUri: String!
+    open var discoveryEndpoint: String!
+    
+    open override func setUp() async throws {
+        // Load config or fail
+        config = try XCTUnwrap(
+            try? Config(configFileName),
+            "Failed to load test configuration file: \(configFileName)"
+        )
+        
+        // Fail fast if any required property is missing
+        username = try XCTUnwrap(config.username, "Missing 'username' in config")
+        userFirstName = try XCTUnwrap(config.userFname, "Missing 'userFname' in config")
+        userLastName = try XCTUnwrap(config.userLname, "Missing 'userLname' in config")
+        password = try XCTUnwrap(config.password, "Missing 'password' in config")
+        
+        serverUrl = try XCTUnwrap(config.serverUrl, "Missing 'serverUrl' in config")
+        realm = try XCTUnwrap(config.realm, "Missing 'realm' in config")
+        cookie = try XCTUnwrap(config.cookieName, "Missing 'cookieName' in config")
+        
+        discoveryEndpoint = try XCTUnwrap(config.discoveryEndpoint, "Missing 'discoveryEndpoint' in config")
+        clientId = try XCTUnwrap(config.clientId, "Missing 'clientId' in config")
+        scopes = try XCTUnwrap(config.scopes, "Missing 'scopes' in config")
+        redirectUri = try XCTUnwrap(config.redirectUri, "Missing 'redirectUri' in config")
+                
+        // Capture values locally to avoid capturing self in @Sendable closures
+        let serverUrl = self.serverUrl!
+        let realm = self.realm!
+        let cookie = self.cookie!
+        let discoveryEndpoint = self.discoveryEndpoint!
+        let clientId = self.clientId!
+        let scopes = self.scopes!
+        let redirectUri = self.redirectUri!
+        
+        defaultJourney = Journey.createJourney { config in
+            config.timeout = 30
+            config.logger = LogManager.standard
+            config.serverUrl = serverUrl
+            config.realm = realm
+            config.cookie = cookie
+            config.module(PingJourney.OidcModule.config) { oidcValue in
+                oidcValue.discoveryEndpoint = discoveryEndpoint
+                oidcValue.clientId = clientId
+                oidcValue.scopes = Set(scopes)
+                oidcValue.redirectUri = redirectUri
+            }
+        }
+        
+        // Register ReCaptchaEnterprise callbacks
+        ReCaptchaEnterprise.registerCallbacks()
+        
+        // Start with a clean session
+        await defaultJourney?.journeyUser()?.logout()
+    }
+    
+    open override func tearDown() async throws {
+        try await super.tearDown()
+        await defaultJourney?.journeyUser()?.logout()
+    }
+    
+    /// Helper to handle login callbacks (username + password)
+    @discardableResult
+    func handleLoginCallbacks(journey: Journey? = nil, treeName: String? = nil) async throws -> Node {
+        let activeJourney = journey ?? defaultJourney!
+        let treeName = treeName ?? "Login"
+        let node = await activeJourney.start(treeName)
+        
+        guard let continueNode = node as? ContinueNode else {
+            XCTFail("Expected ContinueNode but got \(type(of: node))")
+            throw XCTSkip("Login step failed")
+        }
+        
+        guard let usernameCallback = continueNode.callbacks.first as? NameCallback,
+              let passwordCallback = continueNode.callbacks.last as? PasswordCallback else {
+            XCTFail("Missing expected Name and Password callbacks")
+            throw XCTSkip("Callbacks missing")
+        }
+        
+        usernameCallback.name = username
+        passwordCallback.password = password
+        
+        return await continueNode.next()
+    }
+}

--- a/ReCaptchaEnterprise/ReCaptchaEnterpriseTests/Integration Tests/ReCaptchaEnterpriseCallbackE2ETests.swift
+++ b/ReCaptchaEnterprise/ReCaptchaEnterpriseTests/Integration Tests/ReCaptchaEnterpriseCallbackE2ETests.swift
@@ -1,0 +1,348 @@
+// 
+//  ReCaptchaEnterpriseCallbackE2ETests.swift
+//  ReCaptchaEnterprise
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+
+import XCTest
+@testable import PingJourney
+@testable import PingOrchestrate
+@testable import PingLogger
+@testable import PingReCaptchaEnterprise
+@testable import PingJourneyPlugin
+
+class ReCaptchaEnterpriseCallbackE2ETests: BindingE2EBaseTest, @unchecked Sendable {
+    
+    var logger = LogManager.logger
+    var testTree = "TEST-e2e-recaptcha-enterprise"
+    
+    static let SITE_KEY: String = "6Lc0NUIqAAAAALRSrhXb5CWrZPzWkezBFB_0mnqS" // this is configured in the test journey
+    
+    func testRecaptchaEnterpriseSuccess() async throws {
+        // Navigate to the ReCaptchaEnterprise node
+        let node = try await startTest(nodeConfiguration: "success")
+        
+        // We expect ReCaptchaEnterpriseCallback here
+        guard let reCaptchaEnterpriseCallback = node.callbacks.first as? ReCaptchaEnterpriseCallback else {
+            XCTFail("Expected ReCaptchaEnterpriseCallback but got \(node.callbacks.map { type(of: $0) })")
+            return
+        }
+        
+        XCTAssertEqual(reCaptchaEnterpriseCallback.recaptchaSiteKey, ReCaptchaEnterpriseCallbackE2ETests.SITE_KEY)
+        
+        // Execute reCAPTCHA verification
+        let verifyResult = await reCaptchaEnterpriseCallback.verify()
+        
+        var tokenResult = ""
+        switch verifyResult {
+        case .success(let token):
+            XCTAssertFalse(token.isEmpty, "Token should not be empty")
+            tokenResult = token
+        case .failure(let error):
+            XCTFail("reCaptchaEnterpriseCallback.verify() failed: \(error)")
+            return
+        }
+        
+        // Submit ReCaptchaEnterpriseCallback and continue
+        guard let nextNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after submitting ReCaptchaEnterpriseCallback")
+            return
+        }
+        
+        // Confirm that reCAPTCHA Enterprise node execution is successful.
+        // Note: Upon success the test tree returns CaptchaEnterpriseNode.ASSESSMENT_RESULT in a TextOutput callback...
+        guard let textOutputCallback = nextNode.callbacks.first as? TextOutputCallback else {
+            XCTFail("Expected TextOutputCallback with assessment result")
+            return
+        }
+        
+        let assessmentData = Data(textOutputCallback.message.utf8)
+        
+        do {
+            if let assessmentDictionary = try JSONSerialization.jsonObject(with: assessmentData, options: []) as? [String: Any] {
+                // Assert a few things in the assessment data:
+                let event = assessmentDictionary["event"] as! [String: Any]
+                let tokenProperties = assessmentDictionary["tokenProperties"] as! [String: Any]
+                let riskAnalysis = assessmentDictionary["riskAnalysis"] as! [String: Any]
+                
+                let userAgent = event["userAgent"] as! String
+                let siteKey = event["siteKey"] as! String
+                let userIpAddress = event["userIpAddress"] as! String
+                let token = event["token"] as! String
+                let action = tokenProperties["action"] as! String
+                let valid = tokenProperties["valid"] as! Bool
+                let iosBundleId = tokenProperties["iosBundleId"] as! String
+                let score = riskAnalysis["score"] as! Double
+                
+                XCTAssertEqual(siteKey, ReCaptchaEnterpriseCallbackE2ETests.SITE_KEY)
+                XCTAssert(userAgent.contains("Darwin"))
+                XCTAssert(!userIpAddress.isEmpty)
+                XCTAssertEqual(token, tokenResult)
+                XCTAssertEqual(action, "login")
+                XCTAssertTrue(valid)
+                XCTAssertEqual(iosBundleId, "com.pingidentity.PingTestHost")
+                XCTAssertGreaterThanOrEqual(score, 0.0)
+                XCTAssertLessThanOrEqual(score, 1.0)
+            }
+        } catch {
+            XCTFail("Error parsing the assessment data \(error)")
+        }
+        
+        // Submit the TextOutput callback and complete the flow
+        guard let result = await nextNode.next() as? SuccessNode else {
+            XCTFail("Expected SuccessNode after submitting TextOutput callback")
+            return
+        }
+        
+        // At the end the user should be logged in
+        XCTAssertNotNil(result.session)
+        let session = await defaultJourney.session()
+        XCTAssertNotNil(session)
+    }
+    
+    func testRecaptchaEnterpriseSuccessCustom() async throws {
+        // Navigate to the ReCaptchaEnterprise node
+        let node = try await startTest(nodeConfiguration: "success")
+        
+        // We expect ReCaptchaEnterpriseCallback here
+        guard let reCaptchaEnterpriseCallback = node.callbacks.first as? ReCaptchaEnterpriseCallback else {
+            XCTFail("Expected ReCaptchaEnterpriseCallback but got \(node.callbacks.map { type(of: $0) })")
+            return
+        }
+        
+        // Execute reCAPTCHA verification with custom payload and action
+        let verifyResult = await reCaptchaEnterpriseCallback.verify { config in
+            config.action = "custom_action"
+            config.payload = ["firewallPolicyEvaluation": false,
+                              "express": false,
+                              "transaction_data": [
+                                "transaction_id": "custom-payload-1234567890",
+                                "payment_method": "credit-card",
+                                "card_bin": "1111",
+                                "card_last_four": "1234",
+                                "currency_code": "CAD"
+                              ]]
+        }
+        
+        switch verifyResult {
+        case .success:
+            break // Expected
+        case .failure(let error):
+            XCTFail("reCaptchaEnterpriseCallback.verify() failed: \(error)")
+            return
+        }
+        
+        // Submit ReCaptchaEnterpriseCallback and continue
+        guard let nextNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after submitting ReCaptchaEnterpriseCallback")
+            return
+        }
+        
+        // Confirm that reCAPTCHA Enterprise node execution is successful.
+        // Note: Upon success the test tree returns CaptchaEnterpriseNode.ASSESSMENT_RESULT in a TextOutput callback...
+        guard let textOutputCallback = nextNode.callbacks.first as? TextOutputCallback else {
+            XCTFail("Expected TextOutputCallback with assessment result")
+            return
+        }
+        
+        let assessmentData = Data(textOutputCallback.message.utf8)
+        
+        do {
+            if let assessmentDictionary = try JSONSerialization.jsonObject(with: assessmentData, options: []) as? [String: Any] {
+                // Assert that the custom payload and action has been taken into account...
+                let event = assessmentDictionary["event"] as! [String: Any]
+                let tokenProperties = assessmentDictionary["tokenProperties"] as! [String: Any]
+                let transactionData = event["transactionData"] as! [String: Any]
+                
+                let firewallPolicyEvaluation = event["firewallPolicyEvaluation"] as! Bool
+                let express = event["express"] as! Bool
+                let action = tokenProperties["action"] as! String
+                let valid = tokenProperties["valid"] as! Bool
+                
+                let transactionId = transactionData["transactionId"] as! String
+                let paymentMethod = transactionData["paymentMethod"] as! String
+                let cardBin = transactionData["cardBin"] as! String
+                let cardLastFour = transactionData["cardLastFour"] as! String
+                let currencyCode = transactionData["currencyCode"] as! String
+                
+                XCTAssertFalse(firewallPolicyEvaluation) // This is to prove that custom payload has been applied
+                XCTAssertFalse(express)
+                XCTAssertEqual(action, "custom_action")
+                XCTAssertTrue(valid)
+                
+                // These come from the custom payload:
+                XCTAssertEqual(transactionId, "custom-payload-1234567890")
+                XCTAssertEqual(paymentMethod, "credit-card")
+                XCTAssertEqual(cardBin, "1111")
+                XCTAssertEqual(cardLastFour, "1234")
+                XCTAssertEqual(currencyCode, "CAD")
+            }
+        } catch {
+            XCTFail("Error parsing the assessment data \(error)")
+        }
+        
+        // Submit the TextOutput callback and complete the flow
+        guard let result = await nextNode.next() as? SuccessNode else {
+            XCTFail("Expected SuccessNode after submitting TextOutput callback")
+            return
+        }
+        
+        // At the end the user should be logged in
+        XCTAssertNotNil(result.session)
+        let session = await defaultJourney.session()
+        XCTAssertNotNil(session)
+    }
+    
+    func testRecaptchaEnterpriseFailScore() async throws {
+        // Navigate to the ReCaptchaEnterprise node with score_failure configuration
+        let node = try await startTest(nodeConfiguration: "score_failure")
+        
+        // We expect ReCaptchaEnterpriseCallback here
+        guard let reCaptchaEnterpriseCallback = node.callbacks.first as? ReCaptchaEnterpriseCallback else {
+            XCTFail("Expected ReCaptchaEnterpriseCallback but got \(node.callbacks.map { type(of: $0) })")
+            return
+        }
+        
+        XCTAssertNotNil(reCaptchaEnterpriseCallback.recaptchaSiteKey)
+        
+        // Execute reCAPTCHA verification
+        let verifyResult = await reCaptchaEnterpriseCallback.verify()
+        
+        switch verifyResult {
+        case .success:
+            break // Token acquisition succeeds, but score validation should fail server-side
+        case .failure(let error):
+            XCTFail("reCaptchaEnterpriseCallback.verify() failed: \(error)")
+            return
+        }
+        
+        // Submit ReCaptchaEnterpriseCallback and continue
+        guard let nextNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after submitting ReCaptchaEnterpriseCallback")
+            return
+        }
+        
+        // Confirm that reCAPTCHA Enterprise node execution fails (since the "Score threshold" is set to 1.0)
+        // Note: Upon failure the test tree returns CaptchaEnterpriseNode.FAILURE in a TextOutput callback...
+        guard let textOutputCallback = nextNode.callbacks.first as? TextOutputCallback else {
+            XCTFail("Expected TextOutputCallback with failure message")
+            return
+        }
+        XCTAssertTrue(textOutputCallback.message.contains("VALIDATION_ERROR:CAPTCHA validation failed"))
+        
+        // Submit the TextOutput callback and complete the flow
+        guard let result = await nextNode.next() as? SuccessNode else {
+            XCTFail("Expected SuccessNode after submitting TextOutput callback")
+            return
+        }
+        
+        // At the end the user should be logged in
+        XCTAssertNotNil(result.session)
+        let session = await defaultJourney.session()
+        XCTAssertNotNil(session)
+    }
+    
+    func testRecaptchaEnterpriseCustomClientError() async throws {
+        // Navigate to the ReCaptchaEnterprise node with custom_client_error configuration
+        let node = try await startTest(nodeConfiguration: "custom_client_error")
+        
+        // We expect ReCaptchaEnterpriseCallback here
+        guard let reCaptchaEnterpriseCallback = node.callbacks.first as? ReCaptchaEnterpriseCallback else {
+            XCTFail("Expected ReCaptchaEnterpriseCallback but got \(node.callbacks.map { type(of: $0) })")
+            return
+        }
+        
+        // Set a custom client error before executing
+        reCaptchaEnterpriseCallback.setClientError("CUSTOM_CLIENT_ERROR")
+        
+        // Execute reCAPTCHA verification
+        let verifyResult = await reCaptchaEnterpriseCallback.verify()
+        
+        switch verifyResult {
+        case .success:
+            break // Token acquisition may still succeed
+        case .failure:
+            break // Or it may fail - either way, the client error should be reported
+        }
+        
+        // Submit ReCaptchaEnterpriseCallback and continue
+        guard let nextNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after submitting ReCaptchaEnterpriseCallback")
+            return
+        }
+        
+        // Confirm that reCAPTCHA Enterprise node execution fails (since we have set client error)
+        // Note: Upon failure the test tree returns CaptchaEnterpriseNode.FAILURE in a TextOutput callback...
+        guard let textOutputCallback = nextNode.callbacks.first as? TextOutputCallback else {
+            XCTFail("Expected TextOutputCallback with failure message")
+            return
+        }
+        XCTAssertTrue(textOutputCallback.message.contains("CLIENT_ERROR:CUSTOM_CLIENT_ERROR"))
+        
+        // Submit the TextOutput callback and complete the flow
+        guard let result = await nextNode.next() as? SuccessNode else {
+            XCTFail("Expected SuccessNode after submitting TextOutput callback")
+            return
+        }
+        
+        // At the end the user should be logged in
+        XCTAssertNotNil(result.session)
+        let session = await defaultJourney.session()
+        XCTAssertNotNil(session)
+    }
+    
+    // MARK: - Helper Methods
+    
+    /// Common steps for all test cases:
+    /// 1. Start journey and provide username via NameCallback
+    /// 2. Select nodeConfiguration via ChoiceCallback
+    /// 3. Return the resulting ContinueNode (typically the ReCaptchaEnterprise node)
+    private func startTest(nodeConfiguration: String) async throws -> ContinueNode {
+        // Start the journey
+        let node = await defaultJourney.start(testTree)
+        
+        // First node: Username collector
+        guard let usernameNode = node as? ContinueNode else {
+            XCTFail("Expected ContinueNode (Username collector) but got \(type(of: node))")
+            throw XCTSkip("Failed to get username collector node")
+        }
+        
+        guard let nameCallback = usernameNode.callbacks.first as? NameCallback else {
+            XCTFail("Expected NameCallback for username collection")
+            throw XCTSkip("Missing NameCallback")
+        }
+        nameCallback.name = username
+        
+        // Second node: Choice collector
+        guard let choiceNode = await usernameNode.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode (Choice collector) after username")
+            throw XCTSkip("Failed to get choice collector node")
+        }
+        
+        guard let choiceCallback = choiceNode.callbacks.first as? ChoiceCallback else {
+            XCTFail("Expected ChoiceCallback for node configuration selection")
+            throw XCTSkip("Missing ChoiceCallback")
+        }
+        
+        // Select the requested node configuration
+        if let choiceIndex = choiceCallback.choices.firstIndex(of: nodeConfiguration) {
+            choiceCallback.selectedIndex = choiceIndex
+        } else {
+            XCTFail("Choice '\(nodeConfiguration)' not found in available choices: \(choiceCallback.choices)")
+            throw XCTSkip("Invalid choice configuration")
+        }
+        
+        // Third node: ReCaptchaEnterprise callback (or result node)
+        guard let resultNode = await choiceNode.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after selecting '\(nodeConfiguration)'")
+            throw XCTSkip("Failed to get result node")
+        }
+        
+        return resultNode
+    }
+}

--- a/ReCaptchaEnterprise/ReCaptchaEnterpriseTests/ReCaptchaEnterpriseCallbackTests.swift
+++ b/ReCaptchaEnterprise/ReCaptchaEnterpriseTests/ReCaptchaEnterpriseCallbackTests.swift
@@ -2,7 +2,7 @@
 //  ReCaptchaEnterpriseTests.swift
 //  ReCaptchaEnterpriseTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -19,8 +19,8 @@ class ReCaptchaEnterpriseCallbackTests: XCTestCase {
     var callback: ReCaptchaEnterpriseCallback!
     var jsonString: [String: Any]!
     
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         
         // Create mock JSON that simulates server response
         jsonString = [
@@ -38,7 +38,7 @@ class ReCaptchaEnterpriseCallbackTests: XCTestCase {
         
         // Initialize callback with mock data
         callback = ReCaptchaEnterpriseCallback()
-        _ = callback.initialize(with: jsonString)
+        _ = await callback.initialize(with: jsonString)
 
     }
     

--- a/SampleApps/Ping.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SampleApps/Ping.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk",
       "state" : {
-        "revision" : "fb634e89a36fd91725ad654d5576d800c061b37d",
-        "version" : "18.8.2"
+        "revision" : "c6ce6a5790f0e0b70e66025ec1aa3c4aced13cc6",
+        "version" : "18.8.1"
       }
     },
     {

--- a/SampleApps/Ping.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SampleApps/Ping.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk",
       "state" : {
-        "revision" : "1f3ac7ac4a8d73e8af514aae794b1a84696477c7",
-        "version" : "18.9.0-beta01"
+        "revision" : "093cd2c9cfaa964b885023b0b513303d6b565ae5",
+        "version" : "18.8.0"
       }
     },
     {

--- a/SampleApps/Ping.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SampleApps/Ping.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk",
       "state" : {
-        "revision" : "c6ce6a5790f0e0b70e66025ec1aa3c4aced13cc6",
-        "version" : "18.8.1"
+        "revision" : "1f3ac7ac4a8d73e8af514aae794b1a84696477c7",
+        "version" : "18.9.0-beta01"
       }
     },
     {

--- a/SampleApps/Ping.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SampleApps/Ping.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk",
       "state" : {
-        "revision" : "5ec74256124faa7e7814c574509723f49e1fccfb",
-        "version" : "18.7.0"
+        "revision" : "1f3ac7ac4a8d73e8af514aae794b1a84696477c7",
+        "version" : "18.9.0-beta01"
       }
     },
     {

--- a/SampleApps/Ping.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SampleApps/Ping.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk",
       "state" : {
-        "revision" : "fb634e89a36fd91725ad654d5576d800c061b37d",
-        "version" : "18.8.2"
+        "revision" : "5ec74256124faa7e7814c574509723f49e1fccfb",
+        "version" : "18.7.0"
       }
     },
     {

--- a/SampleApps/Ping.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SampleApps/Ping.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk",
       "state" : {
-        "revision" : "1f3ac7ac4a8d73e8af514aae794b1a84696477c7",
-        "version" : "18.9.0-beta01"
+        "revision" : "fb634e89a36fd91725ad654d5576d800c061b37d",
+        "version" : "18.8.2"
       }
     },
     {

--- a/SampleApps/Ping.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SampleApps/Ping.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk",
       "state" : {
-        "revision" : "093cd2c9cfaa964b885023b0b513303d6b565ae5",
-        "version" : "18.8.0"
+        "revision" : "1f3ac7ac4a8d73e8af514aae794b1a84696477c7",
+        "version" : "18.9.0-beta01"
       }
     },
     {


### PR DESCRIPTION
[SDKS-4379](https://pingidentity.atlassian.net/browse/SDKS-4379) [iOS] Test ReCaptcha Callbacks

1. Add ReCaptcha Enterprise i**ntegration tests**
2. Fix the bug when _non async_ version of **`initialize`** method was being used in **`AbstractProtectCallback`** and **`ReCaptchaEnterpriseCallback`**
3. Remove _non async_ version of **initialize** method from **`Callback`** protocol and **`AbstractCallback`** class as it is never called and has been replaced by _async_ version of **`initialize`** in JourneyPlugin
4. Update all Callback Tests to use _async_ version of **`initialize`** in Journey module tests
