### PR TITLE
Make httpClient public in WorkFlowConfig

### DIFF
--- a/Orchestrate/Orchestrate/RequestInterceptor.swift
+++ b/Orchestrate/Orchestrate/RequestInterceptor.swift
@@ -12,8 +12,23 @@
 import Foundation
 import PingNetwork
 
-/// A protocol for request interceptor. To be implemented by classes that need to override the request.
+/// A protocol for callback/collector-level request interception.
+///
+/// Conforming types (e.g., `IdpCollector`) can modify the outgoing HTTP request
+/// when a `ContinueNode` builds its submission request via `asRequest()`.
+/// This is invoked per-callback/collector inside Journey's `JourneyContinueNode`
+/// and DaVinci's `Connector`, allowing individual actions to inject headers,
+/// parameters, or replace the request entirely based on their internal state.
+///
+/// For workflow-wide request customization, use modules like `CustomHeader` instead.
+///
+/// - Note: Not related to `HttpRequestInterceptor` in PingNetwork, which operates
+///   at the HTTP client transport level via `HttpClientConfig.onRequest(_:)`.
 public protocol RequestInterceptor {
-    /// Intercepts the request before it is sent. Implement this method to override the request.
+    /// Intercepts the request before it is sent.
+    /// - Parameters:
+    ///   - context: The current flow context.
+    ///   - request: The request to modify.
+    /// - Returns: The original or modified request.
     func intercept(context: FlowContext, request: Request) -> Request
 }

--- a/Orchestrate/Orchestrate/WorkFlowConfig.swift
+++ b/Orchestrate/Orchestrate/WorkFlowConfig.swift
@@ -37,8 +37,7 @@ open class WorkflowConfig: @unchecked Sendable {
     /// HTTP client for the engine
     /// If not set, a default client will be created during workflow registration
     /// - see register(workflow:)
-    /// - note: This property is internal(set) to allow setting it from tests.
-    public internal(set) var httpClient: HttpClientProtocol!
+    public var httpClient: HttpClientProtocol!
     
     /// Initializes a new WorkflowConfig instance.
     public init() {}


### PR DESCRIPTION
[SDKS-4861](https://pingidentity.atlassian.net/browse/SDKS-4861)

[iOS][Unified SDKs] Allow the setting of RequestInterceptors in Journey and Davinci Workflow

- Make `httpClient` setter public in `HttpClientProtocol`
- Update `RequestInterceptor` docs to better reflect it's purpose

Note: `RequestInterceptor` protocol works correctly but is only used at the collector/callback level in Journey and DaVinci. Updated doc comments clarifying its scope