### PR TITLE
SDKS-4695 Password policy updates

### DIFF
--- a/Davinci/Davinci/collector/PasswordCollector.swift
+++ b/Davinci/Davinci/collector/PasswordCollector.swift
@@ -20,10 +20,24 @@ public class PasswordCollector: ValidatedCollector, ContinueNodeAware, Closeable
     /// The continue node for the DaVinci flow.
     /// Declared `weak` to break the retain cycle: `ContinueNode → PasswordCollector → ContinueNode`.
     public weak var continueNode: ContinueNode?
-    /// Caches the decoded password policy so it’s only decoded once.
+    /// Caches the decoded password policy so it's only decoded once.
     private var cachedPasswordPolicy: PasswordPolicy?
     /// A flag to determine whether to clear the password or not after submission.
     public var clearPassword: Bool = true
+    
+    /// Initializes a new instance of `PasswordCollector`.
+    /// Extracts the password policy from the field-level JSON if present.
+    /// - Parameter json: The JSON dictionary for this field component.
+    public required init(with json: [String: Any]) {
+        super.init(with: json)
+        
+        // Extract passwordPolicy from the field-level JSON (component scope)
+        if let policyDict = json[Constants.passwordPolicy] as? [String: Any] {
+            if let data = try? JSONSerialization.data(withJSONObject: policyDict, options: []) {
+                cachedPasswordPolicy = try? JSONDecoder().decode(PasswordPolicy.self, from: data)
+            }
+        }
+    }
     
     /// Overrides the close function from the Closeable protocol.
     /// It is used to clear the value of the password field when the collector is closed.
@@ -34,25 +48,24 @@ public class PasswordCollector: ValidatedCollector, ContinueNodeAware, Closeable
     }
     
     /// Method to retrieve the password policy, if available.
+    /// Checks the field-level (component scope) first, then falls back to the global scope
+    /// for backward compatibility with older server responses.
     /// - Returns: The password policy, if available.
     public func passwordPolicy() -> PasswordPolicy? {
         if cachedPasswordPolicy == nil {
-            // If there's a dictionary under "passwordPolicy"
+            // Fallback: check the global scope (top-level input) for backward compatibility
             if let policyDict = continueNode?.input[Constants.passwordPolicy] as? [String: Any] {
-                
-                guard let data = try? JSONSerialization.data(withJSONObject: policyDict, options: []) else { return nil }
-                return try? JSONDecoder().decode(PasswordPolicy.self, from: data)
+                if let data = try? JSONSerialization.data(withJSONObject: policyDict, options: []) {
+                    cachedPasswordPolicy = try? JSONDecoder().decode(PasswordPolicy.self, from: data)
+                }
             }
         }
         return cachedPasswordPolicy
     }
     
     public override func validate() -> [ValidationError] {
-        let errors = super.validate()
+        var errors = super.validate()
         
-        // If we have a password policy, check additional constraints
-        // TODO: Uncomment password policy validation
-        /*
         if let policy = passwordPolicy() {
             // 1. Check length range
             if !(policy.length.min...policy.length.max).contains(value.count) {
@@ -74,17 +87,15 @@ public class PasswordCollector: ValidatedCollector, ContinueNodeAware, Closeable
                 errors.append(.maxRepeat(max: policy.maxRepeatedCharacters))
             }
             
-            // 4. Check minimum required characters (e.g. "digits" -> 2)
+            // 4. Check minimum required characters
             for (chars, minCount) in policy.minCharacters {
-                // `chars` might be a string of characters, or some other token
-                // We count how many characters in `value` are in `chars`
                 let foundCount = value.filter { chars.contains($0) }.count
                 if foundCount < minCount {
                     errors.append(.minCharacters(character: chars, min: minCount))
                 }
             }
         }
-        */
+        
         return errors
     }
 }

--- a/Davinci/Davinci/collector/PasswordPolicy.swift
+++ b/Davinci/Davinci/collector/PasswordPolicy.swift
@@ -2,7 +2,7 @@
 //  PasswordPolicy.swift
 //  PingDavinci
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Davinci/DavinciTests/PasswordCollectorTests.swift
+++ b/Davinci/DavinciTests/PasswordCollectorTests.swift
@@ -2,7 +2,7 @@
 //  PasswordCollectorTests.swift
 //  DavinciTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -37,108 +37,92 @@ final class PasswordCollectorTests: XCTestCase {
     }
     
     func testValidatesSuccessfullyWhenNoErrors() {
-        let input: [String: Any] = [
-            "passwordPolicy": [
-                "length": [
-                    "min": 8,
-                    "max": 20
-                ],
-                "minUniqueCharacters": 3,
-                "maxRepeatedCharacters": 2,
-                "minCharacters": [
-                    "0123456789": 1,
-                    "!@#$%^&*()": 1
-                ]
+        let fieldJson = fieldJsonWithPasswordPolicy([
+            "length": [
+                "min": 8,
+                "max": 20
+            ],
+            "minUniqueCharacters": 3,
+            "maxRepeatedCharacters": 2,
+            "minCharacters": [
+                "0123456789": 1,
+                "!@#$%^&*()": 1
             ]
-        ]
+        ])
         
-        let collector = PasswordCollector(with: [:])
-        collector.continueNode =  MockContinueNode(context: FlowContext(flowContext: SharedContext()), workflow: Workflow(config: WorkflowConfig()), input: input, actions: [])
+        let collector = PasswordCollector(with: fieldJson)
+        collector.continueNode = MockContinueNode(context: FlowContext(flowContext: SharedContext()), workflow: Workflow(config: WorkflowConfig()), input: [:], actions: [])
         collector.value = "Valid1@Password"
         
         XCTAssertEqual(collector.validate(), [])
     }
     
-    // TODO: Reinclude when multiple password validation errors are supported
-//    func testAddsInvalidLengthErrorWhenValueTooShort() {
-//        let input: [String: Any] = [
-//            "passwordPolicy": [
-//                "length": [
-//                    "min": 8,
-//                    "max": 20
-//                ]
-//            ]
-//        ]
-//        
-//        let collector = PasswordCollector(with: [:])
-//        collector.continueNode = MockContinueNode(context: FlowContext(flowContext: SharedContext()), workflow: Workflow(config: WorkflowConfig()), input: input, actions: [])
-//        
-//        collector.value = "Short1@"
-//        
-//        XCTAssertEqual(collector.validate(), [.invalidLength(min: 8, max: 20)])
-//    }
-    
-    // TODO: Reinclude when multiple password validation errors are supported
-//    func testAddsUniqueCharacterErrorWhenNotEnoughUniqueCharacters() {
-//        let input: [String: Any] = [
-//            "passwordPolicy": [
-//                "minUniqueCharacters": 5
-//            ]
-//        ]
-//        
-//        let collector = PasswordCollector(with: [:])
-//        collector.continueNode = MockContinueNode(context: FlowContext(flowContext: SharedContext()), workflow: Workflow(config: WorkflowConfig()), input: input, actions: [])
-//        
-//        collector.value = "aaa111@@@"
-//        
-//        XCTAssertEqual(collector.validate(), [.uniqueCharacter(min: 5)])
-//    }
-    
-    // TODO: Reinclude when multiple password validation errors are supported
-//    func testAddsMaxRepeatErrorWhenTooManyRepeatedCharacters() {
-//        let input: [String: Any] = [
-//            "passwordPolicy": [
-//                "maxRepeatedCharacters": 2
-//            ]
-//        ]
-//        
-//        let collector = PasswordCollector(with: [:])
-//        collector.continueNode = MockContinueNode(context: FlowContext(flowContext: SharedContext()), workflow: Workflow(config: WorkflowConfig()), input: input, actions: [])
-//        
-//        collector.value = "aaabbbccc"
-//        
-//        XCTAssertEqual(collector.validate(), [.maxRepeat(max: 2)])
-//    }
-    
-    // TODO: Reinclude when multiple password validation errors are supported
-//    func testAddsMinCharactersErrorWhenNotEnoughDigits() {
-//        let input: [String: Any] = [
-//            "passwordPolicy": [
-//                "minCharacters": [
-//                    "0123456789": 2
-//                ]
-//            ]
-//        ]
-//        
-//        let collector = PasswordCollector(with: [:])
-//        collector.continueNode = MockContinueNode(context: FlowContext(flowContext: SharedContext()), workflow: Workflow(config: WorkflowConfig()), input: input, actions: [])
-//        
-//        collector.value = "Password@1"
-//        
-//        XCTAssertEqual(collector.validate(), [.minCharacters(character: "0123456789", min: 2)])
-//    }
-    
-    func testAddsMinCharactersErrorWhenEnoughSpecialCharacters() {
-        let input: [String: Any] = [
-            "passwordPolicy": [
-                "minCharacters": [
-                    "!@#$%^&*()": 2
-                ]
+    func testAddsInvalidLengthErrorWhenValueTooShort() {
+        let fieldJson = fieldJsonWithPasswordPolicy([
+            "length": [
+                "min": 8,
+                "max": 20
             ]
-        ]
+        ])
         
-        let collector = PasswordCollector(with: [:])
-        collector.continueNode = MockContinueNode(context: FlowContext(flowContext: SharedContext()), workflow: Workflow(config: WorkflowConfig()), input: input, actions: [])
+        let collector = PasswordCollector(with: fieldJson)
+        collector.continueNode = MockContinueNode(context: FlowContext(flowContext: SharedContext()), workflow: Workflow(config: WorkflowConfig()), input: [:], actions: [])
+        
+        collector.value = "Short1@"
+        
+        XCTAssertEqual(collector.validate(), [.invalidLength(min: 8, max: 20)])
+    }
+    
+    func testAddsUniqueCharacterErrorWhenNotEnoughUniqueCharacters() {
+        let fieldJson = fieldJsonWithPasswordPolicy([
+            "minUniqueCharacters": 5
+        ])
+        
+        let collector = PasswordCollector(with: fieldJson)
+        collector.continueNode = MockContinueNode(context: FlowContext(flowContext: SharedContext()), workflow: Workflow(config: WorkflowConfig()), input: [:], actions: [])
+        
+        collector.value = "aaa111@@@"
+        
+        XCTAssertEqual(collector.validate(), [.uniqueCharacter(min: 5)])
+    }
+    
+    func testAddsMaxRepeatErrorWhenTooManyRepeatedCharacters() {
+        let fieldJson = fieldJsonWithPasswordPolicy([
+            "maxRepeatedCharacters": 2
+        ])
+        
+        let collector = PasswordCollector(with: fieldJson)
+        collector.continueNode = MockContinueNode(context: FlowContext(flowContext: SharedContext()), workflow: Workflow(config: WorkflowConfig()), input: [:], actions: [])
+        
+        collector.value = "aaabbbccc"
+        
+        XCTAssertEqual(collector.validate(), [.maxRepeat(max: 2)])
+    }
+    
+    func testAddsMinCharactersErrorWhenNotEnoughDigits() {
+        let fieldJson = fieldJsonWithPasswordPolicy([
+            "minCharacters": [
+                "0123456789": 2
+            ]
+        ])
+        
+        let collector = PasswordCollector(with: fieldJson)
+        collector.continueNode = MockContinueNode(context: FlowContext(flowContext: SharedContext()), workflow: Workflow(config: WorkflowConfig()), input: [:], actions: [])
+        
+        collector.value = "Password@1"
+        
+        XCTAssertEqual(collector.validate(), [.minCharacters(character: "0123456789", min: 2)])
+    }
+    
+    func testValidatesSuccessfullyWhenEnoughSpecialCharacters() {
+        let fieldJson = fieldJsonWithPasswordPolicy([
+            "minCharacters": [
+                "!@#$%^&*()": 2
+            ]
+        ])
+        
+        let collector = PasswordCollector(with: fieldJson)
+        collector.continueNode = MockContinueNode(context: FlowContext(flowContext: SharedContext()), workflow: Workflow(config: WorkflowConfig()), input: [:], actions: [])
         
         collector.value = "Password1!&"
         
@@ -152,6 +136,132 @@ final class PasswordCollectorTests: XCTestCase {
         XCTAssertEqual("test", collector.value)
     }
     
+    func testPasswordPolicyReadFromComponentScope() {
+        let fieldJson: [String: Any] = [
+            "type": "PASSWORD_VERIFY",
+            "key": "user.password",
+            "label": "Password",
+            "passwordPolicy": [
+                "name": "Standard",
+                "length": [
+                    "min": 8,
+                    "max": 255
+                ],
+                "minUniqueCharacters": 5,
+                "maxRepeatedCharacters": 2,
+                "minCharacters": [
+                    "0123456789": 1,
+                    "ABCDEFGHIJKLMNOPQRSTUVWXYZ": 1,
+                    "abcdefghijklmnopqrstuvwxyz": 1,
+                    "~!@#$%^&*()-_=+[]{}|;:,.<>/?": 1
+                ]
+            ]
+        ]
+        
+        let collector = PasswordCollector(with: fieldJson)
+        collector.continueNode = MockContinueNode(context: FlowContext(flowContext: SharedContext()), workflow: Workflow(config: WorkflowConfig()), input: [:], actions: [])
+        
+        let policy = collector.passwordPolicy()
+        XCTAssertNotNil(policy)
+        XCTAssertEqual("Standard", policy?.name)
+        XCTAssertEqual(8, policy?.length.min)
+        XCTAssertEqual(255, policy?.length.max)
+        XCTAssertEqual(5, policy?.minUniqueCharacters)
+        XCTAssertEqual(2, policy?.maxRepeatedCharacters)
+        XCTAssertTrue(policy?.minCharacters.keys.contains("0123456789") ?? false)
+        XCTAssertTrue(policy?.minCharacters.keys.contains("ABCDEFGHIJKLMNOPQRSTUVWXYZ") ?? false)
+        XCTAssertTrue(policy?.minCharacters.keys.contains("abcdefghijklmnopqrstuvwxyz") ?? false)
+        XCTAssertTrue(policy?.minCharacters.keys.contains("~!@#$%^&*()-_=+[]{}|;:,.<>/?") ?? false)
+        
+        // A valid password should produce no errors
+        collector.value = "Valid1@Pass"
+        XCTAssertEqual(collector.validate(), [])
+        
+        // A password that is too short should produce an InvalidLength error
+        collector.value = "Sh0rt!"
+        XCTAssertTrue(collector.validate().contains(.invalidLength(min: 8, max: 255)))
+    }
+    
+    func testNoValidationErrorsWhenFormHasNoPasswordPolicy() {
+        let fieldJson: [String: Any] = [
+            "type": "PASSWORD_VERIFY",
+            "key": "user.password",
+            "label": "Password"
+        ]
+        
+        let collector = PasswordCollector(with: fieldJson)
+        collector.continueNode = MockContinueNode(context: FlowContext(flowContext: SharedContext()), workflow: Workflow(config: WorkflowConfig()), input: [:], actions: [])
+        collector.value = "any"
+        
+        XCTAssertNil(collector.passwordPolicy())
+        XCTAssertEqual(collector.validate(), [])
+    }
+    
+    func testFallbackToGlobalScopePasswordPolicy() {
+        // No passwordPolicy in field JSON
+        let collector = PasswordCollector(with: [:])
+        
+        // passwordPolicy provided at the global scope (top-level input)
+        let globalInput: [String: Any] = [
+            "passwordPolicy": [
+                "length": [
+                    "min": 10,
+                    "max": 50
+                ]
+            ]
+        ]
+        let mockNode = MockContinueNode(context: FlowContext(flowContext: SharedContext()), workflow: Workflow(config: WorkflowConfig()), input: globalInput, actions: [])
+        collector.continueNode = mockNode
+        
+        let policy = collector.passwordPolicy()
+        XCTAssertNotNil(policy)
+        XCTAssertEqual(10, policy?.length.min)
+        XCTAssertEqual(50, policy?.length.max)
+        
+        collector.value = "Short"
+        XCTAssertTrue(collector.validate().contains(.invalidLength(min: 10, max: 50)))
+    }
+    
+    func testComponentScopeTakesPrecedenceOverGlobalScope() {
+        // passwordPolicy in field JSON (component scope)
+        let fieldJson: [String: Any] = [
+            "passwordPolicy": [
+                "length": [
+                    "min": 8,
+                    "max": 100
+                ]
+            ]
+        ]
+        let collector = PasswordCollector(with: fieldJson)
+        
+        // Different passwordPolicy at the global scope
+        let globalInput: [String: Any] = [
+            "passwordPolicy": [
+                "length": [
+                    "min": 20,
+                    "max": 50
+                ]
+            ]
+        ]
+        let mockNode = MockContinueNode(context: FlowContext(flowContext: SharedContext()), workflow: Workflow(config: WorkflowConfig()), input: globalInput, actions: [])
+        collector.continueNode = mockNode
+        
+        let policy = collector.passwordPolicy()
+        XCTAssertNotNil(policy)
+        // Component scope should win
+        XCTAssertEqual(8, policy?.length.min)
+        XCTAssertEqual(100, policy?.length.max)
+    }
+    
+    // MARK: - Helpers
+    
+    /// Creates a field-level JSON dictionary with a PASSWORD_VERIFY type containing the given password policy.
+    private func fieldJsonWithPasswordPolicy(_ policy: [String: Any]) -> [String: Any] {
+        return [
+            "type": "PASSWORD_VERIFY",
+            "passwordPolicy": policy
+        ]
+    }
 }
 
 class MockContinueNode: ContinueNode, @unchecked Sendable { }

--- a/Davinci/DavinciTests/integration tests/FormFieldValidationTests.swift
+++ b/Davinci/DavinciTests/integration tests/FormFieldValidationTests.swift
@@ -100,7 +100,6 @@ class FormFieldValidationTests: DaVinciBaseTests, @unchecked Sendable {
     }
     
     // TestRailCase(26034, 26031)
-    // TODO: Reinclude PasswordPolicy test
     func testPasswordValidation() async throws {
         // Go to the "Form Fields Validation" form
         var node = await daVinci.start() as! ContinueNode
@@ -140,24 +139,22 @@ class FormFieldValidationTests: DaVinciBaseTests, @unchecked Sendable {
         // Validate should return list of all the failing password policy items
         var passwordValidationResult = password.validate()
         
-        XCTAssertEqual(1, passwordValidationResult.count) //TODO: change to 7 when all validations are reenabled
+        XCTAssertEqual(7, passwordValidationResult.count)
         XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("This field cannot be empty."))
-        // TODO: Reenable these assertions when multiple password validation errors are supported
-//        XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input length must be between 8 and 255 characters."))
-//        XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input must contain at least 5 unique characters."))
-//        XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input must include at least 1 character(s) from this set: \'ABCDEFGHIJKLMNOPQRSTUVWXYZ\'."))
-//        XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input must include at least 1 character(s) from this set: \'abcdefghijklmnopqrstuvwxyz\'."))
-//        XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input must include at least 1 character(s) from this set: \'~!@#$%^&*()-_=+[]{}|;:,.<>/?\'."))
-//        XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input must include at least 1 character(s) from this set: \'0123456789\'."))
+        XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input length must be between 8 and 255 characters."))
+        XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input must contain at least 5 unique characters."))
+        XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input must include at least 1 character(s) from this set: \'ABCDEFGHIJKLMNOPQRSTUVWXYZ\'."))
+        XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input must include at least 1 character(s) from this set: \'abcdefghijklmnopqrstuvwxyz\'."))
+        XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input must include at least 1 character(s) from this set: \'~!@#$%^&*()-_=+[]{}|;:,.<>/?\'."))
+        XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input must include at least 1 character(s) from this set: \'0123456789\'."))
         
         // Set password that meets some of the policy requirements
         password.value = "password123"
         passwordValidationResult = password.validate()
         
-        XCTAssertEqual(0, passwordValidationResult.count) // TODO: change to 2 when all validations are reenabled
-        // TODO: Reenable these assertions when multiple password validation errors are supported
-//        XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input must include at least 1 character(s) from this set: \'ABCDEFGHIJKLMNOPQRSTUVWXYZ\'."))
-//        XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input must include at least 1 character(s) from this set: \'~!@#$%^&*()-_=+[]{}|;:,.<>/?\'."))
+        XCTAssertEqual(2, passwordValidationResult.count)
+        XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input must include at least 1 character(s) from this set: \'ABCDEFGHIJKLMNOPQRSTUVWXYZ\'."))
+        XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input must include at least 1 character(s) from this set: \'~!@#$%^&*()-_=+[]{}|;:,.<>/?\'."))
         
         // Set password that meets all of the policy requirements
         password.value = "Password123!"

--- a/Davinci/DavinciTests/mock/MockResponse.swift
+++ b/Davinci/DavinciTests/mock/MockResponse.swift
@@ -314,7 +314,52 @@ struct MockResponse {
                   "type": "PASSWORD",
                   "key": "password",
                   "label": "Password",
-                  "required": true
+                  "required": true,
+                  "passwordPolicy": {
+                    "_links": {
+                      "environment": {
+                        "href": "http://10.76.235.122:4140/directory-api/environments/02fb4743-189a-4bc7-9d6c-a919edfe6447"
+                      },
+                      "self": {
+                        "href": "http://10.76.235.122:4140/directory-api/environments/02fb4743-189a-4bc7-9d6c-a919edfe6447/passwordPolicies/39cad7af-3c2f-4672-9c3f-c47e5169e582"
+                      }
+                    },
+                    "id": "39cad7af-3c2f-4672-9c3f-c47e5169e582",
+                    "environment": {
+                      "id": "02fb4743-189a-4bc7-9d6c-a919edfe6447"
+                    },
+                    "name": "Standard",
+                    "description": "A standard policy that incorporates industry best practices",
+                    "excludesProfileData": true,
+                    "notSimilarToCurrent": true,
+                    "excludesCommonlyUsed": true,
+                    "maxAgeDays": 182,
+                    "minAgeDays": 1,
+                    "maxRepeatedCharacters": 2,
+                    "minUniqueCharacters": 5,
+                    "history": {
+                      "count": 6,
+                      "retentionDays": 365
+                    },
+                    "lockout": {
+                      "failureCount": 5,
+                      "durationSeconds": 900
+                    },
+                    "length": {
+                      "min": 8,
+                      "max": 255
+                    },
+                    "minCharacters": {
+                      "~!@#$%^&*()-_=+[]{}|;:,.<>/?": 1,
+                      "0123456789": 1,
+                      "ABCDEFGHIJKLMNOPQRSTUVWXYZ": 1,
+                      "abcdefghijklmnopqrstuvwxyz": 1
+                    },
+                    "populationCount": 1,
+                    "createdAt": "2024-01-03T19:50:39.586Z",
+                    "updatedAt": "2024-01-03T19:50:39.586Z",
+                    "default": true
+                  }
                 },
                 {
                   "type": "SUBMIT_BUTTON",
@@ -438,51 +483,6 @@ struct MockResponse {
           "region": "CA",
           "themeId": "activeTheme",
           "formId": "f0cf83ab-f8f4-4f4a-9260-8f7d27061fa7",
-          "passwordPolicy": {
-            "_links": {
-              "environment": {
-                "href": "http://10.76.235.122:4140/directory-api/environments/02fb4743-189a-4bc7-9d6c-a919edfe6447"
-              },
-              "self": {
-                "href": "http://10.76.235.122:4140/directory-api/environments/02fb4743-189a-4bc7-9d6c-a919edfe6447/passwordPolicies/39cad7af-3c2f-4672-9c3f-c47e5169e582"
-              }
-            },
-            "id": "39cad7af-3c2f-4672-9c3f-c47e5169e582",
-            "environment": {
-              "id": "02fb4743-189a-4bc7-9d6c-a919edfe6447"
-            },
-            "name": "Standard",
-            "description": "A standard policy that incorporates industry best practices",
-            "excludesProfileData": true,
-            "notSimilarToCurrent": true,
-            "excludesCommonlyUsed": true,
-            "maxAgeDays": 182,
-            "minAgeDays": 1,
-            "maxRepeatedCharacters": 2,
-            "minUniqueCharacters": 5,
-            "history": {
-              "count": 6,
-              "retentionDays": 365
-            },
-            "lockout": {
-              "failureCount": 5,
-              "durationSeconds": 900
-            },
-            "length": {
-              "min": 8,
-              "max": 255
-            },
-            "minCharacters": {
-              "~!@#$%^&*()-_=+[]{}|;:,.<>/?": 1,
-              "0123456789": 1,
-              "ABCDEFGHIJKLMNOPQRSTUVWXYZ": 1,
-              "abcdefghijklmnopqrstuvwxyz": 1
-            },
-            "populationCount": 1,
-            "createdAt": "2024-01-03T19:50:39.586Z",
-            "updatedAt": "2024-01-03T19:50:39.586Z",
-            "default": true
-          },
           "isResponseCompatibleWithMobileAndWebSdks": true,
           "fieldTypes": [
             "LABEL",

--- a/SampleApps/PingExample/PingExample.xcodeproj/project.pbxproj
+++ b/SampleApps/PingExample/PingExample.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		ECC52B0D2E81AF5B00C468C7 /* ScenePhaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC52B0C2E81AF5B00C468C7 /* ScenePhaseManager.swift */; };
 		ECCAB3692E3A6C3300BA1C73 /* PingDeviceId.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ECCAB3682E3A6C3300BA1C73 /* PingDeviceId.framework */; };
 		ECCAB36A2E3A6C3300BA1C73 /* PingDeviceId.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = ECCAB3682E3A6C3300BA1C73 /* PingDeviceId.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		ECD372762F924A1D002AC7EB /* PasswordRequirementsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD372752F924A1C002AC7EB /* PasswordRequirementsView.swift */; };
 		ECE2B8812DB7DBEC00E2C51E /* PhoneNumberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECE2B8722DB7DBE500E2C51E /* PhoneNumberView.swift */; };
 		ECF7EB862E464EDD002A5E8E /* IdpCallbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECF7EB852E464ED8002A5E8E /* IdpCallbackView.swift */; };
 		ECF7EB882E464F31002A5E8E /* SelectIdpCallbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECF7EB872E464F2C002A5E8E /* SelectIdpCallbackView.swift */; };
@@ -773,6 +774,7 @@
 		ECC52B0C2E81AF5B00C468C7 /* ScenePhaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScenePhaseManager.swift; sourceTree = "<group>"; };
 		ECCAB3682E3A6C3300BA1C73 /* PingDeviceId.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingDeviceId.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ECCAB3A42E3B600B00BA1C73 /* DeviceId.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DeviceId.xcodeproj; path = ../../DeviceId/DeviceId.xcodeproj; sourceTree = SOURCE_ROOT; };
+		ECD372752F924A1C002AC7EB /* PasswordRequirementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordRequirementsView.swift; sourceTree = "<group>"; };
 		ECD5A3132E90218200A27205 /* PingFido2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingFido2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ECE2B8722DB7DBE500E2C51E /* PhoneNumberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumberView.swift; sourceTree = "<group>"; };
 		ECF7EB852E464ED8002A5E8E /* IdpCallbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdpCallbackView.swift; sourceTree = "<group>"; };
@@ -1207,6 +1209,7 @@
 				A5E9AEE22D318521000533ED /* FlowButtonView.swift */,
 				A5E9AEDA2D30A01D000533ED /* LabelView.swift */,
 				A5EFA97E2D35F88C00F771FE /* PasswordView.swift */,
+				ECD372752F924A1C002AC7EB /* PasswordRequirementsView.swift */,
 				ECE2B8722DB7DBE500E2C51E /* PhoneNumberView.swift */,
 				A5A31CEB2E0A5B3F00ABBEF7 /* ProtectView.swift */,
 				A5EFA9782D35F62C00F771FE /* RadioButtonView.swift */,
@@ -1980,6 +1983,7 @@
 				A5E9AED62D30393F000533ED /* LoggerView.swift in Sources */,
 				A5768D1C2E29B369000290EE /* ConsentMappingCallbackView.swift in Sources */,
 				A5EFA97B2D35F6D700F771FE /* DropdownView.swift in Sources */,
+				ECD372762F924A1D002AC7EB /* PasswordRequirementsView.swift in Sources */,
 				A5E9AECC2D303428000533ED /* LogOutView.swift in Sources */,
 				A5768D0A2E2958C7000290EE /* TermsAndConditionsCallbackView.swift in Sources */,
 				A5768D082E288DB7000290EE /* ChoiceCallbackView.swift in Sources */,

--- a/SampleApps/PingExample/PingExample/Collectors/PasswordRequirementsView.swift
+++ b/SampleApps/PingExample/PingExample/Collectors/PasswordRequirementsView.swift
@@ -1,0 +1,83 @@
+//
+//  PasswordRequirementsView.swift
+//  PingExample
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+
+import SwiftUI
+import PingDavinci
+
+/// A view that displays password policy requirements with live pass/fail indicators.
+struct PasswordRequirementsView: View {
+    let policy: PasswordPolicy
+    let password: String
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Password Requirements")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundColor(.secondary)
+            
+            requirementRow(
+                label: "Between \(policy.length.min) and \(policy.length.max) characters",
+                isMet: password.count >= policy.length.min && password.count <= policy.length.max
+            )
+            
+            if policy.minUniqueCharacters > 0 {
+                requirementRow(
+                    label: "At least \(policy.minUniqueCharacters) unique characters",
+                    isMet: Set(password).count >= policy.minUniqueCharacters
+                )
+            }
+            
+            if policy.maxRepeatedCharacters < Int.max {
+                let maxRepeated = password.reduce(into: [Character: Int]()) { counts, char in
+                    counts[char, default: 0] += 1
+                }.values.max() ?? 0
+                requirementRow(
+                    label: "No more than \(policy.maxRepeatedCharacters) repeated characters",
+                    isMet: password.isEmpty || maxRepeated <= policy.maxRepeatedCharacters
+                )
+            }
+            
+            ForEach(policy.minCharacters.sorted(by: { $0.key < $1.key }), id: \.key) { chars, minCount in
+                let foundCount = password.filter { chars.contains($0) }.count
+                requirementRow(
+                    label: "\(minCount) \(characterSetLabel(chars))",
+                    isMet: foundCount >= minCount
+                )
+            }
+        }
+        .padding(.vertical, 4)
+    }
+    
+    @ViewBuilder
+    private func requirementRow(label: String, isMet: Bool) -> some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: isMet ? "checkmark.circle.fill" : "circle")
+                .foregroundColor(isMet ? .green : .secondary)
+                .font(.footnote)
+            Text(label)
+                .font(.footnote)
+                .foregroundColor(isMet ? .primary : .secondary)
+        }
+    }
+    
+    private func characterSetLabel(_ chars: String) -> String {
+        if chars.allSatisfy({ $0.isLowercase }) {
+            return "lowercase letter(s)"
+        } else if chars.allSatisfy({ $0.isUppercase }) {
+            return "uppercase letter(s)"
+        } else if chars.allSatisfy({ $0.isNumber }) {
+            return "number(s)"
+        } else {
+            return "special character(s)"
+        }
+    }
+}

--- a/SampleApps/PingExample/PingExample/Collectors/PasswordView.swift
+++ b/SampleApps/PingExample/PingExample/Collectors/PasswordView.swift
@@ -2,7 +2,7 @@
 //  PasswordView.swift
 //  PingExample
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -46,6 +46,11 @@ struct PasswordView: View {
                 if newValue {
                     isValid = field.validate().isEmpty
                 }
+            }
+            
+            // Password Policy Requirements
+            if let policy = field.passwordPolicy() {
+                PasswordRequirementsView(policy: policy, password: text)
             }
             
             // Password Verification Field


### PR DESCRIPTION
Added validate functionality for password collector and change to capture the embedded field

# JIRA Ticket

[JIRA](https://bugster.forgerock.org/jira/browse/SDKS-4695) "Password Policy updates"

# Description
**Key updates include**:

**Component-Scope Policy Extraction**: PasswordCollector now parses the passwordPolicy directly from its own field-level JSON upon initialization.

**Backward Compatibility**: A fallback mechanism was implemented in PasswordCollector.passwordPolicy() to check the global scope if a component-level policy is missing.

**Enabled Local Validations**: The validate() method in PasswordCollector has been fully uncommented and updated to validate length, minimum unique characters, maximum repeated characters, and required character sets.

**Test Coverage**: Extensive updates to PasswordCollectorTests and FormFieldValidationTests to test the new scope hierarchy (component vs. global) and to assert the newly enabled multiple validation errors.

**New UI Component**: Added a PasswordRequirementsView in the sample app to provide users with real-time, visual pass/fail indicators for password rules as they type. PasswordView was updated to embed this new view.


# Checklist:

- [X] I ran all unit tests and they pass
- [X] I added test case coverage for my changes
