### PR TITLE
Add Phone Number Extension support in PingOne Forms

### DIFF
--- a/Davinci/Davinci/collector/PhoneNumberCollector.swift
+++ b/Davinci/Davinci/collector/PhoneNumberCollector.swift
@@ -2,7 +2,7 @@
 //  PhoneNumberCollector.swift
 //  Davinci
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -17,15 +17,23 @@ open class PhoneNumberCollector: FieldCollector<[String: Any]>, @unchecked Senda
     public private(set) var defaultCountryCode: String
     /// validate phone number
     public private(set) var validatePhoneNumber: Bool
+    /// show extension field
+    public private(set) var showExtension: Bool
+    /// extension label
+    public private(set) var extensionLabel: String
     /// country code
     public var countryCode: String = ""
     /// phone number
     public var phoneNumber: String = ""
+    /// extension
+    public var `extension`: String = ""
     
     /// Initializes a new instance of `PhoneNumberCollector` with the given JSON input.
     public required init(with json: [String : Any]) {
         self.defaultCountryCode = json[Constants.defaultCountryCode] as? String ?? ""
         self.validatePhoneNumber = json[Constants.validatePhoneNumber] as? Bool ?? false
+        self.showExtension = json[Constants.showExtension] as? Bool ?? false
+        self.extensionLabel = json[Constants.extensionLabel] as? String ?? ""
         super.init(with: json)
     }
     
@@ -37,6 +45,7 @@ open class PhoneNumberCollector: FieldCollector<[String: Any]>, @unchecked Senda
         if let dictValue = input as? [String: Any] {
             self.phoneNumber = dictValue[Constants.phoneNumber] as? String ?? ""
             self.countryCode = dictValue[Constants.countryCode] as? String ?? ""
+            self.extension = dictValue[Constants.phoneExtension] as? String ?? ""
         }
         // Fallback to the legacy structure (a simple string)
         else if let stringValue = input as? String {
@@ -52,6 +61,7 @@ open class PhoneNumberCollector: FieldCollector<[String: Any]>, @unchecked Senda
         var payload: [String: Any] = [:]
         payload[Constants.phoneNumber] = phoneNumber
         payload[Constants.countryCode] = countryCode
+        payload[Constants.phoneExtension] = self.extension
         return payload
     }
 }

--- a/Davinci/DavinciTests/PhoneNumberCollectorTests.swift
+++ b/Davinci/DavinciTests/PhoneNumberCollectorTests.swift
@@ -2,7 +2,7 @@
 //  PhoneNumberCollectorTests.swift
 //  Davinci
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -82,5 +82,79 @@ class PhoneNumberCollectorTests: XCTestCase {
         // Assert
         XCTAssertEqual(collector.phoneNumber, "CA-1-+17783186380-7783186380")
         XCTAssertEqual(collector.countryCode, "CA")
+    }
+    
+    func testInitWithoutRequiredDefaultsToFalse() {
+        let collector = PhoneNumberCollector(with: [:])
+        XCTAssertEqual(collector.required, false)
+    }
+    
+    func testInitWithNullDefaultCountryCodeUsesEmptyString() {
+        let collector = PhoneNumberCollector(with: [:])
+        XCTAssertEqual(collector.defaultCountryCode, "")
+    }
+    
+    func testPayloadReturnsProperlyFormattedPhoneNumber() {
+        let collector = PhoneNumberCollector(with: [:])
+        collector.countryCode = "US"
+        collector.phoneNumber = "5555555555"
+        
+        let result = collector.payload()
+        
+        XCTAssertEqual(result?["countryCode"] as? String, "US")
+        XCTAssertEqual(result?["phoneNumber"] as? String, "5555555555")
+    }
+    
+    func testInitializeWithPhoneNumberAndExtension() {
+        let input: [String: Any] = [
+            "phoneNumber": "CA-1-+17783186380-7783186380",
+            "countryCode": "CA",
+            "extension": "1234"
+        ]
+        let collector = PhoneNumberCollector(with: [:])
+        
+        collector.initialize(with: input)
+        
+        XCTAssertEqual(collector.phoneNumber, "CA-1-+17783186380-7783186380")
+        XCTAssertEqual(collector.countryCode, "CA")
+        XCTAssertEqual(collector.extension, "1234")
+    }
+    
+    func testInitWithShowExtensionAndExtensionLabel() {
+        let input: [String: Any] = [
+            "type": "PHONE_NUMBER",
+            "key": "phone-field",
+            "label": "Phone",
+            "showExtension": true,
+            "extensionLabel": "Ext."
+        ]
+        
+        let collector = PhoneNumberCollector(with: input)
+        XCTAssertEqual(collector.showExtension, true)
+        XCTAssertEqual(collector.extensionLabel, "Ext.")
+    }
+    
+    func testPayloadIncludesExtension() {
+        let collector = PhoneNumberCollector(with: [:])
+        collector.countryCode = "US"
+        collector.phoneNumber = "5555555555"
+        collector.extension = "1234"
+        
+        let result = collector.payload()
+        
+        XCTAssertEqual(result?["countryCode"] as? String, "US")
+        XCTAssertEqual(result?["phoneNumber"] as? String, "5555555555")
+        XCTAssertEqual(result?["extension"] as? String, "1234")
+    }
+    
+    func testPayloadReturnsNilWhenFieldsEmpty() {
+        let collector = PhoneNumberCollector(with: [:])
+        XCTAssertNil(collector.payload())
+    }
+    
+    func testPayloadReturnsNilWhenOnlyCountryCode() {
+        let collector = PhoneNumberCollector(with: [:])
+        collector.countryCode = "US"
+        XCTAssertNil(collector.payload())
     }
 }

--- a/Davinci/DavinciTests/integration tests/MFADeviceTests.swift
+++ b/Davinci/DavinciTests/integration tests/MFADeviceTests.swift
@@ -430,10 +430,13 @@ class MFADeviceTests: XCTestCase {
         // Then a phone number collector for the phone number
         let phoneNumberCollector = node.collectors[2] as! PhoneNumberCollector
         
+        XCTAssertTrue(phoneNumberCollector.showExtension)
+        
         // Select a country code and enter a valid phone number:...
         dropdown.value = "359"  // Select Bulgaria...
         phoneNumberCollector.phoneNumber = phone
         phoneNumberCollector.countryCode = "BG"
+        phoneNumberCollector.extension = "100" // Enter extension
         
         // Submit the form
         (node.collectors[3] as? SubmitCollector)?.value = "click"

--- a/DavinciPlugin/DavinciPlugin/Constants.swift
+++ b/DavinciPlugin/DavinciPlugin/Constants.swift
@@ -91,6 +91,9 @@ public enum Constants {
     public static let phoneNumber = "phoneNumber"
     public static let defaultCountryCode = "defaultCountryCode"
     public static let validatePhoneNumber = "validatePhoneNumber"
+    public static let showExtension = "showExtension"
+    public static let extensionLabel = "extensionLabel"
+    public static let phoneExtension = "extension"
     
     // MARK: - Polling & QR Code
     public static let POLLING = "POLLING"

--- a/SampleApps/PingExample/PingExample/Collectors/PhoneNumberView.swift
+++ b/SampleApps/PingExample/PingExample/Collectors/PhoneNumberView.swift
@@ -2,7 +2,7 @@
 //  PhoneNumberView.swift
 //  PingExample
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -69,12 +69,14 @@ struct PhoneNumberView: View {
     
     @EnvironmentObject var validationViewModel: ValidationViewModel
     @State var text: String = ""
+    @State private var extensionText: String = ""
     @State private var isValid: Bool = true
     @State private var expanded: Bool = false
     @State private var selectedCountry: Country?
     
     var body: some View {
-        HStack {
+        VStack(alignment: .leading) {
+            HStack {
             Menu {
                 ForEach(listOfCountries) { country in
                     Button(action: {
@@ -111,13 +113,12 @@ struct PhoneNumberView: View {
                         return (codeNumber == nil) ? "Select an option" : "+" + codeNumber!
                     }())
                         .foregroundColor((selectedCountry?.countryCodeNumber ?? "").isEmpty ? .gray : .primary)
-                    Spacer()
                     Image(systemName: "chevron.down")
                         .rotationEffect(Angle(degrees: expanded ? 180 : 0))
                         .foregroundStyle(Color.themeButtonBackground)
                 }
                 .padding()
-                .frame(maxWidth: .infinity)
+                .frame(width: 100)
                 .background(
                     RoundedRectangle(cornerRadius: 8)
                         .stroke(isValid ? Color.gray : Color.red, lineWidth: 1)
@@ -127,6 +128,7 @@ struct PhoneNumberView: View {
                 field.required ? "\(field.label)*" : field.label,
                 text: $text
             )
+            .keyboardType(.phonePad)
             .autocorrectionDisabled()
             .textInputAutocapitalization(.never)
             .padding()
@@ -136,12 +138,33 @@ struct PhoneNumberView: View {
             )
             .onAppear(perform: {
                 text = field.phoneNumber
+                extensionText = field.extension
             })
             .onChange(of: text) { newValue in
                 field.phoneNumber = newValue
                 isValid = field.validate().isEmpty
                 onNodeUpdated()
             }
+            if field.showExtension {
+                TextField(
+                    field.extensionLabel.isEmpty ? "Ext." : field.extensionLabel,
+                    text: $extensionText
+                )
+                .keyboardType(.phonePad)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .padding()
+                .frame(width: 80)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color.gray, lineWidth: 1)
+                )
+                .onChange(of: extensionText) { newValue in
+                    field.extension = newValue
+                    onNodeUpdated()
+                }
+            }
+        }
             if !isValid {
                 ErrorMessageView(errors: field.validate().map { $0.errorMessage }.sorted())
             }


### PR DESCRIPTION
[SDKS-4668](https://pingidentity.atlassian.net/browse/SDKS-4668) [Ping SDK] [DaVinci] [iOS] - Support Phone Number Extension in PingOne Forms

<img width="315" height="684" alt="Simulator Screenshot - iPhone Air - 2026-04-22 at 11 40 27" src="https://github.com/user-attachments/assets/2e68a5ae-e300-4f2a-9d97-a27ad9970b25" />
<img width="315" height="684" alt="Simulator Screenshot - iPhone Air - 2026-04-22 at 11 40 39" src="https://github.com/user-attachments/assets/51b82e72-40d0-476a-a9da-1d53b829af8b" />

