### PR TITLE
SDKS-4235 Implementation of PAR

### DIFF
--- a/Davinci/Davinci.xcodeproj/project.pbxproj
+++ b/Davinci/Davinci.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		3A292C822BF58462006977EF /* Agent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A292C812BF58462006977EF /* Agent.swift */; };
 		3A5441AA2BCDF20700385131 /* PingDavinci.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A5441A12BCDF20700385131 /* PingDavinci.framework */; };
 		3A5441AF2BCDF20700385131 /* DaVinciTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5441AE2BCDF20700385131 /* DaVinciTests.swift */; };
+		25554859C34DBAACE79ABA36 /* DaVinciPARTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AD0544A9787573F4A02A278 /* DaVinciPARTests.swift */; };
 		3A5441B02BCDF20700385131 /* Davinci.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A5441A42BCDF20700385131 /* Davinci.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3A57CB622C44D68C001EC9A0 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A57CB612C44D688001EC9A0 /* User.swift */; };
 		3AC13E352C3FFF1000DEF23A /* Form.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC13E322C3FFF1000DEF23A /* Form.swift */; };
@@ -107,6 +108,7 @@
 		3A5441A42BCDF20700385131 /* Davinci.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Davinci.h; sourceTree = "<group>"; };
 		3A5441A92BCDF20700385131 /* DavinciTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DavinciTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A5441AE2BCDF20700385131 /* DaVinciTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinciTests.swift; sourceTree = "<group>"; };
+		2AD0544A9787573F4A02A278 /* DaVinciPARTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinciPARTests.swift; sourceTree = "<group>"; };
 		3A57CB612C44D688001EC9A0 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		3AC13E312C3FFF1000DEF23A /* Connector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Connector.swift; sourceTree = "<group>"; };
 		3AC13E322C3FFF1000DEF23A /* Form.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Form.swift; sourceTree = "<group>"; };
@@ -242,6 +244,7 @@
 				A51D4CF12C65729A00FE09E0 /* DaVinciErrorTests.swift */,
 				EC7279B32DF9B289005D9E28 /* DaVinciBaseTests.swift */,
 				3A5441AE2BCDF20700385131 /* DaVinciTests.swift */,
+				2AD0544A9787573F4A02A278 /* DaVinciPARTests.swift */,
 				EC92B3A22DA52DA200E4246D /* DeviceAuthenticatorCollectorTests.swift */,
 				EC92B3A42DA52DC900E4246D /* DeviceRegistrationCollectorTests.swift */,
 				A51D4CED2C656EE100FE09E0 /* FieldCollectorTests.swift */,
@@ -499,6 +502,7 @@
 				A51D4CF42C6572E600FE09E0 /* MockURLProtocol.swift in Sources */,
 				A51D4CF82C65978300FE09E0 /* DaVinciIntegrationTests.swift in Sources */,
 				3A5441AF2BCDF20700385131 /* DaVinciTests.swift in Sources */,
+				25554859C34DBAACE79ABA36 /* DaVinciPARTests.swift in Sources */,
 				A51D4CF22C65729A00FE09E0 /* DaVinciErrorTests.swift in Sources */,
 				A5EFAA102D3F50A700F771FE /* SingleSelectCollectorTests.swift in Sources */,
 				95C256792DF22BFB004266AB /* MFADeviceTests.swift in Sources */,

--- a/Davinci/Davinci/module/Oidc.swift
+++ b/Davinci/Davinci/module/Oidc.swift
@@ -45,7 +45,7 @@ public class OidcModule {
             
             let pkce = Pkce.generate()
             context.flowContext.set(key: SharedContext.Keys.pkceKey, value: pkce)
-            return config.populateRequest(request: request, pkce: pkce)
+            return try await config.populateRequest(request: request, pkce: pkce)
         }
         
         // Handles success of the module.

--- a/Davinci/Davinci/module/Request.swift
+++ b/Davinci/Davinci/module/Request.swift
@@ -26,18 +26,3 @@ extension OidcClientConfig {
     }
 }
 
-
-extension OidcClient.Constants {
-    static let response_mode = "response_mode"
-    static let response_type = "response_type"
-    static let scope = "scope"
-    static let code_challenge = "code_challenge"
-    static let code_challenge_method = "code_challenge_method"
-    static let acr_values = "acr_values"
-    static let display = "display"
-    static let nonce = "nonce"
-    static let prompt = "prompt"
-    static let ui_locales = "ui_locales"
-    static let login_hint = "login_hint"
-    static let piflow = "pi.flow"
-}

--- a/Davinci/Davinci/module/Request.swift
+++ b/Davinci/Davinci/module/Request.swift
@@ -15,49 +15,28 @@ import PingOrchestrate
 import PingNetwork
 
 extension OidcClientConfig {
+    /// Populates a DaVinci authorization request (synchronous, non-PAR).
+    /// Kept for backwards compatibility.
     internal func populateRequest(
         request: Request,
         pkce: Pkce
     ) -> Request {
         let request = request
         request.url = openId?.authorizationEndpoint ?? ""
-        request.setParameter(name: OidcClient.Constants.response_mode, value: "pi.flow")
-        request.setParameter(name: OidcClient.Constants.client_id, value: clientId)
-        request.setParameter(name: OidcClient.Constants.response_type, value: OidcClient.Constants.code)
-        request.setParameter(name: OidcClient.Constants.scope, value: scopes.joined(separator: " "))
-        request.setParameter(name: OidcClient.Constants.redirect_uri, value: redirectUri)
-        request.setParameter(name: OidcClient.Constants.code_challenge, value: pkce.codeChallenge)
-        request.setParameter(name: OidcClient.Constants.code_challenge_method, value: pkce.codeChallengeMethod)
-        
-        if let acr = acrValues {
-            request.setParameter(name: OidcClient.Constants.acr_values, value: acr)
-        }
-        
-        if let display = display {
-            request.setParameter(name: OidcClient.Constants.display, value: display)
-        }
-        
-        for (key, value) in additionalParameters {
+        request.setParameter(name: OidcClient.Constants.response_mode, value: OidcClient.Constants.piflow)
+        buildAuthorizeParams(pkce: pkce) { key, value in
             request.setParameter(name: key, value: value)
         }
-        
-        if let loginHint = loginHint {
-            request.setParameter(name: OidcClient.Constants.login_hint, value: loginHint)
-        }
-        
-        if let nonce = nonce {
-            request.setParameter(name: OidcClient.Constants.nonce, value: nonce)
-        }
-        
-        if let prompt = prompt {
-            request.setParameter(name: OidcClient.Constants.prompt, value: prompt)
-        }
-        
-        if let uiLocales = uiLocales {
-            request.setParameter(name: OidcClient.Constants.ui_locales, value: uiLocales)
-        }
-        
         return request
+    }
+    
+    /// Populates a DaVinci authorization request handling both standard and PAR (RFC 9126) flows.
+    internal func populateRequest(
+        request: Request,
+        pkce: Pkce
+    ) async throws -> Request {
+        // Delegate to the shared async populateRequest with pi.flow response mode
+        return try await populateRequest(request: request, pkce: pkce, responseMode: OidcClient.Constants.piflow)
     }
 }
 

--- a/Davinci/Davinci/module/Request.swift
+++ b/Davinci/Davinci/module/Request.swift
@@ -15,27 +15,13 @@ import PingOrchestrate
 import PingNetwork
 
 extension OidcClientConfig {
-    /// Populates a DaVinci authorization request (synchronous, non-PAR).
-    /// Kept for backwards compatibility.
-    internal func populateRequest(
-        request: Request,
-        pkce: Pkce
-    ) -> Request {
-        let request = request
-        request.url = openId?.authorizationEndpoint ?? ""
-        request.setParameter(name: OidcClient.Constants.response_mode, value: OidcClient.Constants.piflow)
-        buildAuthorizeParams(pkce: pkce) { key, value in
-            request.setParameter(name: key, value: value)
-        }
-        return request
-    }
-    
-    /// Populates a DaVinci authorization request handling both standard and PAR (RFC 9126) flows.
+    /// Populates a DaVinci authorization request, handling both standard and
+    /// PAR (RFC 9126) flows. Delegates to the shared async `populateRequest`
+    /// in `PingOidc` with the DaVinci-specific `pi.flow` response mode.
     internal func populateRequest(
         request: Request,
         pkce: Pkce
     ) async throws -> Request {
-        // Delegate to the shared async populateRequest with pi.flow response mode
         return try await populateRequest(request: request, pkce: pkce, responseMode: OidcClient.Constants.piflow)
     }
 }

--- a/Davinci/DavinciTests/DaVinciPARTests.swift
+++ b/Davinci/DavinciTests/DaVinciPARTests.swift
@@ -1,0 +1,280 @@
+//
+//  DaVinciPARTests.swift
+//  DavinciTests
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+import PingDavinciPlugin
+@testable import PingOrchestrate
+@testable import PingLogger
+@testable import PingOidc
+@testable import PingStorage
+@testable import PingDavinci
+@testable import PingNetwork
+
+final class DaVinciPARTests: XCTestCase, @unchecked Sendable {
+    
+    /// Helper to read httpBodyStream data from URLRequest (httpBody is nil when using URLSession with URLProtocol)
+    private func bodyData(from request: URLRequest) -> Data {
+        if let body = request.httpBody {
+            return body
+        }
+        guard let stream = request.httpBodyStream else {
+            return Data()
+        }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 4096
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let bytesRead = stream.read(buffer, maxLength: bufferSize)
+            if bytesRead > 0 {
+                data.append(buffer, count: bytesRead)
+            } else {
+                break
+            }
+        }
+        return data
+    }
+    
+    let testClientId = "test"
+    let testScopes = ["openid", "email", "address"]
+    let testRedirectUri = "http://localhost:8080"
+    let testDiscoveryEndpoint = "http://localhost/.well-known/openid-configuration"
+    
+    /// Creates an `HTTPURLResponse` or throws, replacing force-unwrap (`!`) in mock handlers.
+    private func mockResponse(url: URL, statusCode: Int, headers: [String: String]? = nil) throws -> HTTPURLResponse {
+        guard let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: headers) else {
+            throw URLError(.badServerResponse)
+        }
+        return response
+    }
+    
+    override func setUp() {
+        super.setUp()
+        MockURLProtocol.startInterceptingRequests()
+        _ = CollectorFactory.shared
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        MockURLProtocol.stopInterceptingRequests()
+    }
+    
+    // MARK: - PAR Happy Path
+    
+    func testDaVinciPARHappyPath() async throws {
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url!.path {
+            case MockAPIEndpoint.discovery.url.path:
+                return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, headers: MockResponse.headers), MockResponse.openIdConfigurationWithPARResponse)
+            case MockAPIEndpoint.par.url.path:
+                return (try mockResponse(url: MockAPIEndpoint.par.url, statusCode: 201, headers: MockResponse.headers), MockResponse.parResponse)
+            case MockAPIEndpoint.token.url.path:
+                return (try mockResponse(url: MockAPIEndpoint.token.url, statusCode: 200, headers: MockResponse.headers), MockResponse.tokenResponse)
+            case MockAPIEndpoint.userinfo.url.path:
+                return (try mockResponse(url: MockAPIEndpoint.userinfo.url, statusCode: 200, headers: MockResponse.headers), MockResponse.userinfoResponse)
+            case MockAPIEndpoint.customHTMLTemplate.url.path:
+                return (try mockResponse(url: MockAPIEndpoint.customHTMLTemplate.url, statusCode: 200, headers: MockResponse.customHTMLTemplateHeaders), MockResponse.customHTMLTemplate)
+            case MockAPIEndpoint.authorization.url.path:
+                return (try mockResponse(url: MockAPIEndpoint.authorization.url, statusCode: 200, headers: MockResponse.authorizeResponseHeaders), MockResponse.authorizeResponse)
+            default:
+                return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 500), Data())
+            }
+        }
+        
+        let daVinci = DaVinci.createDaVinci { config in
+            config.httpClient = MockURLProtocol.makeClient()
+            
+            config.module(PingDavinci.OidcModule.config) { oidcValue in
+                oidcValue.clientId = self.testClientId
+                oidcValue.scopes = Set(self.testScopes)
+                oidcValue.redirectUri = self.testRedirectUri
+                oidcValue.discoveryEndpoint = self.testDiscoveryEndpoint
+                oidcValue.storage = MemoryStorage()
+                oidcValue.logger = LogManager.standard
+                oidcValue.par = true
+            }
+            
+            config.module(CookieModule.config) { cookieValue in
+                cookieValue.cookieStorage = MemoryStorage()
+                cookieValue.persist = ["ST"]
+            }
+        }
+        
+        var node = await daVinci.start()
+        XCTAssertTrue(node is ContinueNode, "Expected ContinueNode, got \(type(of: node))")
+        
+        // Verify request sequence: [0]=discovery, [1]=PAR POST, [2]=authorize
+        XCTAssertGreaterThanOrEqual(MockURLProtocol.requestHistory.count, 3)
+        
+        // Verify PAR request
+        let parRequest = MockURLProtocol.requestHistory[1]
+        XCTAssertEqual(parRequest.url!.path, "/par")
+        XCTAssertEqual(parRequest.httpMethod, "POST")
+        
+        // Verify PAR POST body contains expected OIDC params
+        let parBody = String(data: bodyData(from: parRequest), encoding: .utf8) ?? ""
+        XCTAssertTrue(parBody.contains("client_id=test"), "PAR body should contain client_id")
+        XCTAssertTrue(parBody.contains("response_type=code"), "PAR body should contain response_type")
+        XCTAssertTrue(parBody.contains("code_challenge="), "PAR body should contain code_challenge")
+        XCTAssertTrue(parBody.contains("code_challenge_method=S256"), "PAR body should contain code_challenge_method")
+        XCTAssertTrue(parBody.contains("response_mode=pi.flow"), "PAR body should contain response_mode")
+        
+        // Verify authorize request uses request_uri
+        let authorizeReq = MockURLProtocol.requestHistory[2]
+        XCTAssertTrue(authorizeReq.url!.query?.contains("request_uri=") ?? false, "Authorize URL should contain request_uri")
+        XCTAssertTrue(authorizeReq.url!.query?.contains("client_id=test") ?? false, "Authorize URL should contain client_id")
+        XCTAssertTrue(authorizeReq.url!.query?.contains("response_mode=pi.flow") ?? false, "Authorize URL should contain response_mode")
+        
+        // Verify authorize URL does NOT contain full OIDC params
+        XCTAssertFalse(authorizeReq.url!.query?.contains("code_challenge=") ?? true, "Authorize URL should NOT contain code_challenge when PAR is used")
+        XCTAssertFalse(authorizeReq.url!.query?.contains("response_type=") ?? true, "Authorize URL should NOT contain response_type when PAR is used")
+        
+        // Complete the flow
+        let continueNode = node as! ContinueNode
+        (continueNode.collectors[0] as? TextCollector)?.value = "My First Name"
+        (continueNode.collectors[1] as? PasswordCollector)?.value = "My Password"
+        (continueNode.collectors[2] as? SubmitCollector)?.value = "click me"
+        
+        node = await continueNode.next()
+        XCTAssertTrue(node is SuccessNode, "Expected SuccessNode, got \(type(of: node))")
+        
+        let successNode = node as! SuccessNode
+        let user = successNode.user
+        let userToken = await user?.token()
+        switch userToken! {
+        case .success(let token):
+            XCTAssertEqual(token.accessToken, "Dummy AccessToken")
+        case .failure(_):
+            XCTFail("Should have succeeded")
+        }
+    }
+    
+    // MARK: - PAR Disabled (Standard Flow)
+    
+    func testDaVinciWithoutPAR() async throws {
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url!.path {
+            case MockAPIEndpoint.discovery.url.path:
+                return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, headers: MockResponse.headers), MockResponse.openIdConfigurationWithPARResponse)
+            case MockAPIEndpoint.token.url.path:
+                return (try mockResponse(url: MockAPIEndpoint.token.url, statusCode: 200, headers: MockResponse.headers), MockResponse.tokenResponse)
+            case MockAPIEndpoint.customHTMLTemplate.url.path:
+                return (try mockResponse(url: MockAPIEndpoint.customHTMLTemplate.url, statusCode: 200, headers: MockResponse.customHTMLTemplateHeaders), MockResponse.customHTMLTemplate)
+            case MockAPIEndpoint.authorization.url.path:
+                return (try mockResponse(url: MockAPIEndpoint.authorization.url, statusCode: 200, headers: MockResponse.authorizeResponseHeaders), MockResponse.authorizeResponse)
+            default:
+                return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 500), Data())
+            }
+        }
+        
+        let daVinci = DaVinci.createDaVinci { config in
+            config.httpClient = MockURLProtocol.makeClient()
+            
+            config.module(PingDavinci.OidcModule.config) { oidcValue in
+                oidcValue.clientId = self.testClientId
+                oidcValue.scopes = Set(self.testScopes)
+                oidcValue.redirectUri = self.testRedirectUri
+                oidcValue.discoveryEndpoint = self.testDiscoveryEndpoint
+                oidcValue.storage = MemoryStorage()
+                oidcValue.logger = LogManager.standard
+                // par is false by default
+            }
+            
+            config.module(CookieModule.config) { cookieValue in
+                cookieValue.cookieStorage = MemoryStorage()
+                cookieValue.persist = ["ST"]
+            }
+        }
+        
+        var node = await daVinci.start()
+        XCTAssertTrue(node is ContinueNode, "Expected ContinueNode, got \(type(of: node))")
+        
+        // Verify request sequence: [0]=discovery, [1]=authorize (NO PAR request)
+        XCTAssertEqual(MockURLProtocol.requestHistory.count, 2)
+        
+        // Verify authorize request has full OIDC params (standard flow)
+        let authorizeReq = MockURLProtocol.requestHistory[1]
+        XCTAssertTrue(authorizeReq.url!.query?.contains("client_id=test") ?? false)
+        XCTAssertTrue(authorizeReq.url!.query?.contains("response_mode=pi.flow") ?? false)
+        XCTAssertTrue(authorizeReq.url!.query?.contains("code_challenge=") ?? false)
+        XCTAssertTrue(authorizeReq.url!.query?.contains("code_challenge_method=S256") ?? false)
+        XCTAssertFalse(authorizeReq.url!.query?.contains("request_uri=") ?? true, "Standard flow should NOT use request_uri")
+        
+        // Complete the flow
+        let continueNode = node as! ContinueNode
+        (continueNode.collectors[0] as? TextCollector)?.value = "My First Name"
+        (continueNode.collectors[1] as? PasswordCollector)?.value = "My Password"
+        (continueNode.collectors[2] as? SubmitCollector)?.value = "click me"
+        
+        node = await continueNode.next()
+        XCTAssertTrue(node is SuccessNode, "Expected SuccessNode, got \(type(of: node))")
+    }
+    
+    // MARK: - PAR with Additional OIDC Parameters
+    
+    func testDaVinciPARWithAdditionalOidcParameters() async throws {
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url!.path {
+            case MockAPIEndpoint.discovery.url.path:
+                return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, headers: MockResponse.headers), MockResponse.openIdConfigurationWithPARResponse)
+            case MockAPIEndpoint.par.url.path:
+                return (try mockResponse(url: MockAPIEndpoint.par.url, statusCode: 201, headers: MockResponse.headers), MockResponse.parResponse)
+            case MockAPIEndpoint.token.url.path:
+                return (try mockResponse(url: MockAPIEndpoint.token.url, statusCode: 200, headers: MockResponse.headers), MockResponse.tokenResponse)
+            case MockAPIEndpoint.customHTMLTemplate.url.path:
+                return (try mockResponse(url: MockAPIEndpoint.customHTMLTemplate.url, statusCode: 200, headers: MockResponse.customHTMLTemplateHeaders), MockResponse.customHTMLTemplate)
+            case MockAPIEndpoint.authorization.url.path:
+                return (try mockResponse(url: MockAPIEndpoint.authorization.url, statusCode: 200, headers: MockResponse.authorizeResponseHeaders), MockResponse.authorizeResponse)
+            default:
+                return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 500), Data())
+            }
+        }
+        
+        let daVinci = DaVinci.createDaVinci { config in
+            config.httpClient = MockURLProtocol.makeClient()
+            
+            config.module(PingDavinci.OidcModule.config) { oidcValue in
+                oidcValue.clientId = self.testClientId
+                oidcValue.scopes = Set(self.testScopes)
+                oidcValue.redirectUri = self.testRedirectUri
+                oidcValue.discoveryEndpoint = self.testDiscoveryEndpoint
+                oidcValue.storage = MemoryStorage()
+                oidcValue.logger = LogManager.standard
+                oidcValue.par = true
+                oidcValue.acrValues = "acrValues"
+                oidcValue.loginHint = "login_hint"
+                oidcValue.nonce = "nonce"
+            }
+            
+            config.module(CookieModule.config) { cookieValue in
+                cookieValue.cookieStorage = MemoryStorage()
+                cookieValue.persist = ["ST"]
+            }
+        }
+        
+        let node = await daVinci.start()
+        XCTAssertTrue(node is ContinueNode, "Expected ContinueNode, got \(type(of: node))")
+        
+        // Verify PAR POST body contains additional OIDC params
+        let parRequest = MockURLProtocol.requestHistory[1]
+        let parBody = String(data: bodyData(from: parRequest), encoding: .utf8) ?? ""
+        XCTAssertTrue(parBody.contains("acr_values=acrValues"), "PAR body should contain acr_values")
+        XCTAssertTrue(parBody.contains("login_hint=login_hint"), "PAR body should contain login_hint")
+        XCTAssertTrue(parBody.contains("nonce=nonce"), "PAR body should contain nonce")
+        
+        // Verify authorize URL does NOT contain these params
+        let authorizeReq = MockURLProtocol.requestHistory[2]
+        XCTAssertFalse(authorizeReq.url!.query?.contains("acr_values=") ?? true, "Authorize URL should NOT contain acr_values when PAR is used")
+        XCTAssertFalse(authorizeReq.url!.query?.contains("login_hint=") ?? true, "Authorize URL should NOT contain login_hint when PAR is used")
+        XCTAssertFalse(authorizeReq.url!.query?.contains("nonce=") ?? true, "Authorize URL should NOT contain nonce when PAR is used")
+    }
+}

--- a/Davinci/DavinciTests/DaVinciPARTests.swift
+++ b/Davinci/DavinciTests/DaVinciPARTests.swift
@@ -72,7 +72,8 @@ final class DaVinciPARTests: XCTestCase, @unchecked Sendable {
     
     func testDaVinciPARHappyPath() async throws {
         MockURLProtocol.requestHandler = { [self] request in
-            switch request.url!.path {
+            let path = request.url?.path ?? ""
+            switch path {
             case MockAPIEndpoint.discovery.url.path:
                 return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, headers: MockResponse.headers), MockResponse.openIdConfigurationWithPARResponse)
             case MockAPIEndpoint.par.url.path:
@@ -110,14 +111,15 @@ final class DaVinciPARTests: XCTestCase, @unchecked Sendable {
         }
         
         var node = await daVinci.start()
-        XCTAssertTrue(node is ContinueNode, "Expected ContinueNode, got \(type(of: node))")
+        let continueNode = try XCTUnwrap(node as? ContinueNode, "Expected ContinueNode, got \(type(of: node))")
         
         // Verify request sequence: [0]=discovery, [1]=PAR POST, [2]=authorize
         XCTAssertGreaterThanOrEqual(MockURLProtocol.requestHistory.count, 3)
         
         // Verify PAR request
         let parRequest = MockURLProtocol.requestHistory[1]
-        XCTAssertEqual(parRequest.url!.path, "/par")
+        let parUrl = try XCTUnwrap(parRequest.url, "PAR request should have a URL")
+        XCTAssertEqual(parUrl.path, "/par")
         XCTAssertEqual(parRequest.httpMethod, "POST")
         
         // Verify PAR POST body contains expected OIDC params
@@ -130,31 +132,31 @@ final class DaVinciPARTests: XCTestCase, @unchecked Sendable {
         
         // Verify authorize request uses request_uri
         let authorizeReq = MockURLProtocol.requestHistory[2]
-        XCTAssertTrue(authorizeReq.url!.query?.contains("request_uri=") ?? false, "Authorize URL should contain request_uri")
-        XCTAssertTrue(authorizeReq.url!.query?.contains("client_id=test") ?? false, "Authorize URL should contain client_id")
-        XCTAssertTrue(authorizeReq.url!.query?.contains("response_mode=pi.flow") ?? false, "Authorize URL should contain response_mode")
+        let authorizeUrl = try XCTUnwrap(authorizeReq.url, "Authorize request should have a URL")
+        let authorizeQuery = authorizeUrl.query ?? ""
+        XCTAssertTrue(authorizeQuery.contains("request_uri="), "Authorize URL should contain request_uri")
+        XCTAssertTrue(authorizeQuery.contains("client_id=test"), "Authorize URL should contain client_id")
+        XCTAssertTrue(authorizeQuery.contains("response_mode=pi.flow"), "Authorize URL should contain response_mode")
         
         // Verify authorize URL does NOT contain full OIDC params
-        XCTAssertFalse(authorizeReq.url!.query?.contains("code_challenge=") ?? true, "Authorize URL should NOT contain code_challenge when PAR is used")
-        XCTAssertFalse(authorizeReq.url!.query?.contains("response_type=") ?? true, "Authorize URL should NOT contain response_type when PAR is used")
+        XCTAssertFalse(authorizeQuery.contains("code_challenge="), "Authorize URL should NOT contain code_challenge when PAR is used")
+        XCTAssertFalse(authorizeQuery.contains("response_type="), "Authorize URL should NOT contain response_type when PAR is used")
         
         // Complete the flow
-        let continueNode = node as! ContinueNode
         (continueNode.collectors[0] as? TextCollector)?.value = "My First Name"
         (continueNode.collectors[1] as? PasswordCollector)?.value = "My Password"
         (continueNode.collectors[2] as? SubmitCollector)?.value = "click me"
         
         node = await continueNode.next()
-        XCTAssertTrue(node is SuccessNode, "Expected SuccessNode, got \(type(of: node))")
+        let successNode = try XCTUnwrap(node as? SuccessNode, "Expected SuccessNode, got \(type(of: node))")
         
-        let successNode = node as! SuccessNode
-        let user = successNode.user
-        let userToken = await user?.token()
-        switch userToken! {
+        let user = try XCTUnwrap(successNode.user, "SuccessNode should have a user")
+        let userToken = await user.token()
+        switch userToken {
         case .success(let token):
             XCTAssertEqual(token.accessToken, "Dummy AccessToken")
-        case .failure(_):
-            XCTFail("Should have succeeded")
+        case .failure(let error):
+            XCTFail("Should have succeeded, got error: \(error)")
         }
     }
     
@@ -162,7 +164,8 @@ final class DaVinciPARTests: XCTestCase, @unchecked Sendable {
     
     func testDaVinciWithoutPAR() async throws {
         MockURLProtocol.requestHandler = { [self] request in
-            switch request.url!.path {
+            let path = request.url?.path ?? ""
+            switch path {
             case MockAPIEndpoint.discovery.url.path:
                 return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, headers: MockResponse.headers), MockResponse.openIdConfigurationWithPARResponse)
             case MockAPIEndpoint.token.url.path:
@@ -196,21 +199,21 @@ final class DaVinciPARTests: XCTestCase, @unchecked Sendable {
         }
         
         var node = await daVinci.start()
-        XCTAssertTrue(node is ContinueNode, "Expected ContinueNode, got \(type(of: node))")
+        let continueNode = try XCTUnwrap(node as? ContinueNode, "Expected ContinueNode, got \(type(of: node))")
         
         // Verify request sequence: [0]=discovery, [1]=authorize (NO PAR request)
         XCTAssertEqual(MockURLProtocol.requestHistory.count, 2)
         
         // Verify authorize request has full OIDC params (standard flow)
         let authorizeReq = MockURLProtocol.requestHistory[1]
-        XCTAssertTrue(authorizeReq.url!.query?.contains("client_id=test") ?? false)
-        XCTAssertTrue(authorizeReq.url!.query?.contains("response_mode=pi.flow") ?? false)
-        XCTAssertTrue(authorizeReq.url!.query?.contains("code_challenge=") ?? false)
-        XCTAssertTrue(authorizeReq.url!.query?.contains("code_challenge_method=S256") ?? false)
-        XCTAssertFalse(authorizeReq.url!.query?.contains("request_uri=") ?? true, "Standard flow should NOT use request_uri")
+        let authorizeQuery = try XCTUnwrap(authorizeReq.url?.query, "Authorize request should have a query string")
+        XCTAssertTrue(authorizeQuery.contains("client_id=test"))
+        XCTAssertTrue(authorizeQuery.contains("response_mode=pi.flow"))
+        XCTAssertTrue(authorizeQuery.contains("code_challenge="))
+        XCTAssertTrue(authorizeQuery.contains("code_challenge_method=S256"))
+        XCTAssertFalse(authorizeQuery.contains("request_uri="), "Standard flow should NOT use request_uri")
         
         // Complete the flow
-        let continueNode = node as! ContinueNode
         (continueNode.collectors[0] as? TextCollector)?.value = "My First Name"
         (continueNode.collectors[1] as? PasswordCollector)?.value = "My Password"
         (continueNode.collectors[2] as? SubmitCollector)?.value = "click me"
@@ -223,7 +226,8 @@ final class DaVinciPARTests: XCTestCase, @unchecked Sendable {
     
     func testDaVinciPARWithAdditionalOidcParameters() async throws {
         MockURLProtocol.requestHandler = { [self] request in
-            switch request.url!.path {
+            let path = request.url?.path ?? ""
+            switch path {
             case MockAPIEndpoint.discovery.url.path:
                 return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, headers: MockResponse.headers), MockResponse.openIdConfigurationWithPARResponse)
             case MockAPIEndpoint.par.url.path:
@@ -273,8 +277,9 @@ final class DaVinciPARTests: XCTestCase, @unchecked Sendable {
         
         // Verify authorize URL does NOT contain these params
         let authorizeReq = MockURLProtocol.requestHistory[2]
-        XCTAssertFalse(authorizeReq.url!.query?.contains("acr_values=") ?? true, "Authorize URL should NOT contain acr_values when PAR is used")
-        XCTAssertFalse(authorizeReq.url!.query?.contains("login_hint=") ?? true, "Authorize URL should NOT contain login_hint when PAR is used")
-        XCTAssertFalse(authorizeReq.url!.query?.contains("nonce=") ?? true, "Authorize URL should NOT contain nonce when PAR is used")
+        let authorizeQuery = try XCTUnwrap(authorizeReq.url?.query, "Authorize request should have a query string")
+        XCTAssertFalse(authorizeQuery.contains("acr_values="), "Authorize URL should NOT contain acr_values when PAR is used")
+        XCTAssertFalse(authorizeQuery.contains("login_hint="), "Authorize URL should NOT contain login_hint when PAR is used")
+        XCTAssertFalse(authorizeQuery.contains("nonce="), "Authorize URL should NOT contain nonce when PAR is used")
     }
 }

--- a/Davinci/DavinciTests/mock/MockAPIEndpoint.swift
+++ b/Davinci/DavinciTests/mock/MockAPIEndpoint.swift
@@ -21,6 +21,7 @@ enum MockAPIEndpoint {
     case revocation
     case discovery
     case customHTMLTemplate
+    case par
     
     var url: URL {
         switch self {
@@ -38,6 +39,8 @@ enum MockAPIEndpoint {
             return URL(string: "\(MockAPIEndpoint.baseURL)/.well-known/openid-configuration")!
         case .customHTMLTemplate:
             return URL(string: "\(MockAPIEndpoint.baseURL)/customHTMLTemplate")!
+        case .par:
+            return URL(string: "\(MockAPIEndpoint.baseURL)/par")!
         }
     }
 }

--- a/Davinci/DavinciTests/mock/MockResponse.swift
+++ b/Davinci/DavinciTests/mock/MockResponse.swift
@@ -27,6 +27,30 @@ struct MockResponse {
         """.data(using: .utf8)!
     }
     
+    // Return the OpenID configuration response with PAR endpoint as Data
+    static var openIdConfigurationWithPARResponse: Data {
+        return """
+        {
+            "authorization_endpoint" : "http://auth.test-one-pingone.com/authorize",
+            "token_endpoint" : "https://auth.test-one-pingone.com/token",
+            "userinfo_endpoint" : "https://auth.test-one-pingone.com/userinfo",
+            "end_session_endpoint" : "https://auth.test-one-pingone.com/signoff",
+            "revocation_endpoint" : "https://auth.test-one-pingone.com/revoke",
+            "pushed_authorization_request_endpoint" : "https://auth.test-one-pingone.com/par"
+        }
+        """.data(using: .utf8)!
+    }
+    
+    // Return a successful PAR response as Data
+    static var parResponse: Data {
+        return """
+        {
+            "request_uri" : "urn:ietf:params:oauth:request_uri:test-request-uri",
+            "expires_in" : 60
+        }
+        """.data(using: .utf8)!
+    }
+    
     // return the token response as Data
     static var tokenResponse: Data {
         return """

--- a/Davinci/README.md
+++ b/Davinci/README.md
@@ -73,6 +73,24 @@ let daVinci = DaVinci.createDaVinci { config in
 }
 ```
 
+### Pushed Authorization Requests (PAR)
+
+DaVinci supports [Pushed Authorization Requests (RFC 9126)](https://datatracker.ietf.org/doc/html/rfc9126). When enabled, authorization parameters are sent to the server via a secure back-channel POST before the authorization redirect, improving security by keeping sensitive parameters out of the URL.
+
+```swift
+let daVinci = DaVinci.createDaVinci { config in
+    config.module(OidcModule.config) { oidcValue in
+        oidcValue.clientId = "test"
+        oidcValue.discoveryEndpoint = "https://auth.example.com/.well-known/openid-configuration"
+        oidcValue.scopes = ["openid", "email", "address"]
+        oidcValue.redirectUri = "org.forgerock.demo://oauth2redirect"
+        oidcValue.par = true // Enable Pushed Authorization Requests
+    }
+}
+```
+
+The PAR endpoint is discovered automatically from the OpenID configuration. If the server does not advertise a `pushed_authorization_request_endpoint`, the SDK falls back to the standard authorization flow.
+
 
 ### Navigate the authentication Flow
 

--- a/Journey/Journey/Module/Agent.swift
+++ b/Journey/Journey/Module/Agent.swift
@@ -66,8 +66,8 @@ internal final class CreateAgent: Agent, Sendable {
         
         // Create a fresh request, populate it (handles both PAR and standard flow),
         // then attach Journey-specific headers before sending.
-        let request = httpClient.request()
-        let _ = try await config.populateRequest(request: request, pkce: pkce, responseMode: "")
+        var request = httpClient.request()
+        request = try await config.populateRequest(request: request, pkce: pkce, responseMode: "")
         request.setHeader(name: JourneyConstants.acceptApiVersion, value: JourneyConstants.resource21Protocol10)
         request.setHeader(name: self.cookieName, value: self.session.value)
         

--- a/Journey/Journey/Module/Agent.swift
+++ b/Journey/Journey/Module/Agent.swift
@@ -64,28 +64,14 @@ internal final class CreateAgent: Agent, Sendable {
             throw OidcError.networkError(message: "HTTP client not found")
         }
         
-        guard let openId = config.openId else {
-            throw OidcError.unknown(message: "OpenID configuration not found")
-        }
+        // Create a fresh request, populate it (handles both PAR and standard flow),
+        // then attach Journey-specific headers before sending.
+        let request = httpClient.request()
+        let _ = try await config.populateRequest(request: request, pkce: pkce, responseMode: "")
+        request.setHeader(name: JourneyConstants.acceptApiVersion, value: JourneyConstants.resource21Protocol10)
+        request.setHeader(name: self.cookieName, value: self.session.value)
         
-        let params: [String: String] = [
-            JourneyConstants.response_type: JourneyConstants.code,
-            JourneyConstants.redirect_uri: config.redirectUri,
-            JourneyConstants.client_id: config.clientId,
-            JourneyConstants.scope: config.scopes.joined(separator: " "),
-            JourneyConstants.state: pkce.state,
-            JourneyConstants.code_challenge: pkce.codeChallenge,
-            JourneyConstants.code_challenge_method: pkce.codeChallengeMethod
-        ]
-        
-        let response = try await httpClient.request { request in
-            request.url = openId.authorizationEndpoint
-            for (name, value) in params {
-                request.setParameter(name: name, value: value)
-                request.setHeader(name: JourneyConstants.acceptApiVersion, value: JourneyConstants.resource21Protocol10)
-                request.setHeader(name: self.cookieName, value: self.session.value)
-            }
-        }
+        let response = try await httpClient.request(request: request)
         
         guard response.status.isRedirect() else {
             throw OidcError.apiError(code: response.status, message: response.bodyAsString())

--- a/Journey/README.md
+++ b/Journey/README.md
@@ -149,6 +149,25 @@ let journey = Journey.createJourney { config in
           }
 ```
 
+### Pushed Authorization Requests (PAR)
+
+Journey supports [Pushed Authorization Requests (RFC 9126)](https://datatracker.ietf.org/doc/html/rfc9126). When enabled, authorization parameters are sent to the server via a secure back-channel POST before the authorization redirect, improving security by keeping sensitive parameters out of the URL.
+
+```swift
+let journey = Journey.createJourney { config in
+            config.serverUrl = "https://openam-sdks.forgeblocks.com/am"
+            config.module(PingJourney.OidcModule.config) { oidcValue in
+                oidcValue.clientId = "test"
+                oidcValue.discoveryEndpoint = "https://your_openam_domain/am/oauth2/alpha/.well-known/openid-configuration"
+                oidcValue.scopes = ["openid", "email", "address"]
+                oidcValue.redirectUri = "org.forgerock.demo://oauth2redirect"
+                oidcValue.par = true // Enable Pushed Authorization Requests
+            }
+          }
+```
+
+The PAR endpoint is discovered automatically from the OpenID configuration. If the server does not advertise a `pushed_authorization_request_endpoint`, the SDK falls back to the standard authorization flow.
+
 ### Navigating the Authentication Flow
 
 The `start()` method initiates the authentication journey and returns a `Node` instance,

--- a/Oidc/Oidc.xcodeproj/project.pbxproj
+++ b/Oidc/Oidc.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		A50966DF2C4DF3CD00A4E5B5 /* OidcClientConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50966DE2C4DF3CD00A4E5B5 /* OidcClientConfigTests.swift */; };
 		A50966E12C4F1D9D00A4E5B5 /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50966E02C4F1D9D00A4E5B5 /* MockURLProtocol.swift */; };
 		A50966E32C4F2F4300A4E5B5 /* OidcClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50966E22C4F2F4300A4E5B5 /* OidcClientTests.swift */; };
+		700AADB6B22EDCF175F25320 /* OidcClientPARTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7101980CC54DBB835D4F7DB3 /* OidcClientPARTests.swift */; };
+		CE68EBE71BABE65295E0CFCA /* OidcAdditionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E2E5250895DD43A8388F8A /* OidcAdditionalTests.swift */; };
 		A50966EF2C4FF75400A4E5B5 /* MockStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50966EE2C4FF75400A4E5B5 /* MockStorage.swift */; };
 		A50967092C50843E00A4E5B5 /* MockAPIEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50967082C50843E00A4E5B5 /* MockAPIEndpoint.swift */; };
 		A50981BE2CEBDF1700F4B487 /* PingOrchestrate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A50981BD2CEBDF1700F4B487 /* PingOrchestrate.framework */; };
@@ -87,6 +89,8 @@
 		A50966DE2C4DF3CD00A4E5B5 /* OidcClientConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcClientConfigTests.swift; sourceTree = "<group>"; };
 		A50966E02C4F1D9D00A4E5B5 /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
 		A50966E22C4F2F4300A4E5B5 /* OidcClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcClientTests.swift; sourceTree = "<group>"; };
+		7101980CC54DBB835D4F7DB3 /* OidcClientPARTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcClientPARTests.swift; sourceTree = "<group>"; };
+		77E2E5250895DD43A8388F8A /* OidcAdditionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcAdditionalTests.swift; sourceTree = "<group>"; };
 		A50966EE2C4FF75400A4E5B5 /* MockStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStorage.swift; sourceTree = "<group>"; };
 		A50967082C50843E00A4E5B5 /* MockAPIEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAPIEndpoint.swift; sourceTree = "<group>"; };
 		A50981BD2CEBDF1700F4B487 /* PingOrchestrate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingOrchestrate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -178,6 +182,8 @@
 				A509D1CC2C6D04E9003A0006 /* mock */,
 				A50966DE2C4DF3CD00A4E5B5 /* OidcClientConfigTests.swift */,
 				A50966E22C4F2F4300A4E5B5 /* OidcClientTests.swift */,
+						7101980CC54DBB835D4F7DB3 /* OidcClientPARTests.swift */,
+						77E2E5250895DD43A8388F8A /* OidcAdditionalTests.swift */,
 				EC23D5142E2E7A1100C43D42 /* OidcWebClientTests.swift */,
 				A50966DA2C4DDFAE00A4E5B5 /* PkceTests.swift */,
 				A50966D42C4DD79000A4E5B5 /* TokenTests.swift */,
@@ -347,6 +353,8 @@
 				A50966DD2C4DE4D700A4E5B5 /* MockResponse.swift in Sources */,
 				A50966D52C4DD79000A4E5B5 /* TokenTests.swift in Sources */,
 				A50966E32C4F2F4300A4E5B5 /* OidcClientTests.swift in Sources */,
+						700AADB6B22EDCF175F25320 /* OidcClientPARTests.swift in Sources */,
+						CE68EBE71BABE65295E0CFCA /* OidcAdditionalTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Oidc/Oidc/Module/Oidc.swift
+++ b/Oidc/Oidc/Module/Oidc.swift
@@ -51,7 +51,7 @@ public class OidcModule {
             let url = URL(string: config.redirectUri)
             context.flowContext.set(key: SharedContext.Keys.callbackURLSchemeKey, value: url?.scheme ?? "https")
                 
-            let oidcRequest = config.populateRequest(request: request, pkce: pkce, responseMode: "")
+            let oidcRequest = try await config.populateRequest(request: request, pkce: pkce, responseMode: "")
             
             let parameters = oidcLoginFlow.sharedContext.get(key: SharedContext.Keys.oidcParameters) as? [String: String] ?? [:]
             for parameter in parameters {

--- a/Oidc/Oidc/OidcClient.swift
+++ b/Oidc/Oidc/OidcClient.swift
@@ -369,9 +369,11 @@ extension OidcClientConfig {
             onParam(OidcClient.Constants.login_hint, loginHint)
         }
         
-        if let state = state {
-            onParam("state", state)
-        }
+        // Always emit `state`. Prefer the integrator-supplied value on
+        // `OidcClientConfig.state`; otherwise fall back to the PKCE-generated
+        // state so the parameter is present for CSRF protection on
+        // redirect-based flows and remains available to server-side policies.
+        onParam(OidcClient.Constants.state, self.state ?? pkce.state)
         
         if let nonce = nonce {
             onParam(OidcClient.Constants.nonce, nonce)
@@ -485,6 +487,7 @@ extension OidcClient.Constants {
     static let prompt = "prompt"
     static let ui_locales = "ui_locales"
     static let login_hint = "login_hint"
+    static let state = "state"
     static let piflow = "pi.flow"
     static let query = "query"
 }

--- a/Oidc/Oidc/OidcClient.swift
+++ b/Oidc/Oidc/OidcClient.swift
@@ -49,6 +49,28 @@ public class OidcClient {
         return url
     }
     
+    /// OidcClient generateAuthorizeUrl with PAR support.
+    /// When PAR is enabled in the configuration, authorization parameters are pushed to the server before generating the URL.
+    /// - Parameter customParams: Custom parameters to include in the authorization request.
+    public func generateAuthorizeUrl(customParams: [String: String]? = nil) async throws -> URL {
+        guard let httpClient = config.httpClient else {
+            throw OidcError.networkError(message: "HTTP client not found")
+        }
+        var request = httpClient.request()
+        self.pkce = Pkce.generate()
+        request = try await config.populateRequest(request: request, pkce: pkce!, responseMode: OidcClient.Constants.query)
+        if let customParams = customParams {
+            for parameter in customParams {
+                request.setParameter(name: parameter.key, value: parameter.value)
+            }
+        }
+        guard let urlString = request.url, let url = URL(string: urlString), let redirectURI = URL(string: config.redirectUri), let _ = redirectURI.scheme else {
+            throw OidcError.networkError(message: "URL not found")
+        }
+        
+        return url
+    }
+    
     /// Extracts the code from the URL and exchanges it for an access token.
     ///  - Parameter url: The URL to extract the code from.
     public func extractCodeAndGetToken(from url: URL) async throws -> Token {
@@ -306,10 +328,68 @@ public class OidcClient {
         public static let code_verifier = "code_verifier"
         public static let code = "code"
         public static let id_token_hint = "id_token_hint"
+        public static let request_uri = "request_uri"
     }
 }
 
 extension OidcClientConfig {
+    /// Builds OIDC authorization request parameters using the provided configuration.
+    /// This function populates all required and optional OAuth2/OIDC parameters for an authorization request.
+    /// - Parameters:
+    ///   - pkce: PKCE parameters for enhanced security.
+    ///   - extraParameters: Additional parameters specific to this authorization request.
+    ///   - onParam: Callback function to handle each parameter (name, value) pair.
+    public func buildAuthorizeParams(
+        pkce: Pkce,
+        extraParameters: [String: String] = [:],
+        onParam: (String, String) -> Void
+    ) {
+        onParam(OidcClient.Constants.client_id, clientId)
+        onParam(OidcClient.Constants.response_type, OidcClient.Constants.code)
+        onParam(OidcClient.Constants.scope, scopes.joined(separator: " "))
+        onParam(OidcClient.Constants.redirect_uri, redirectUri)
+        onParam(OidcClient.Constants.code_challenge, pkce.codeChallenge)
+        onParam(OidcClient.Constants.code_challenge_method, pkce.codeChallengeMethod)
+        
+        if let acr = acrValues {
+            onParam(OidcClient.Constants.acr_values, acr)
+        }
+        
+        if let display = display {
+            onParam(OidcClient.Constants.display, display)
+        }
+        
+        for (key, value) in additionalParameters {
+            onParam(key, value)
+        }
+        
+        if let loginHint = loginHint {
+            onParam(OidcClient.Constants.login_hint, loginHint)
+        }
+        
+        if let state = state {
+            onParam("state", state)
+        }
+        
+        if let nonce = nonce {
+            onParam(OidcClient.Constants.nonce, nonce)
+        }
+        
+        if let prompt = prompt {
+            onParam(OidcClient.Constants.prompt, prompt)
+        }
+        
+        if let uiLocales = uiLocales {
+            onParam(OidcClient.Constants.ui_locales, uiLocales)
+        }
+        
+        for (key, value) in extraParameters {
+            onParam(key, value)
+        }
+    }
+    
+    /// Populates an OIDC authorization request with the necessary parameters (synchronous, non-PAR).
+    /// This method is kept for backwards compatibility.
     internal func populateRequest(
         request: Request,
         pkce: Pkce,
@@ -319,41 +399,73 @@ extension OidcClientConfig {
         if !responseMode.isEmpty {
             request.setParameter(name: OidcClient.Constants.response_mode, value: responseMode)
         }
-        request.setParameter(name: OidcClient.Constants.client_id, value: clientId)
-        request.setParameter(name: OidcClient.Constants.response_type, value: OidcClient.Constants.code)
-        request.setParameter(name: OidcClient.Constants.scope, value: scopes.joined(separator: " "))
-        request.setParameter(name: OidcClient.Constants.redirect_uri, value: redirectUri)
-        request.setParameter(name: OidcClient.Constants.code_challenge, value: pkce.codeChallenge)
-        request.setParameter(name: OidcClient.Constants.code_challenge_method, value: pkce.codeChallengeMethod)
-        
-        if let acr = acrValues {
-            request.setParameter(name: OidcClient.Constants.acr_values, value: acr)
-        }
-        
-        if let display = display {
-            request.setParameter(name: OidcClient.Constants.display, value: display)
-        }
-        
-        for (key, value) in additionalParameters {
+        buildAuthorizeParams(pkce: pkce) { key, value in
             request.setParameter(name: key, value: value)
         }
         
-        if let loginHint = loginHint {
-            request.setParameter(name: OidcClient.Constants.login_hint, value: loginHint)
+        return request
+    }
+    
+    /// Populates an OIDC authorization request handling both standard and PAR (RFC 9126) flows.
+    ///
+    /// **Standard Flow:** Builds authorization URL with all parameters in the query string.
+    /// **PAR Flow:** POSTs parameters to the PAR endpoint, then uses the returned `request_uri` in the authorization request.
+    ///
+    /// - Parameters:
+    ///   - request: The request to populate.
+    ///   - pkce: PKCE parameters for enhanced security.
+    ///   - responseMode: The response mode to use.
+    /// - Returns: The populated request ready for execution.
+    public func populateRequest(
+        request: Request,
+        pkce: Pkce,
+        responseMode: String = "pi.flow"
+    ) async throws -> Request {
+        if par, let parEndpoint = openId?.pushedAuthorizationRequestEndpoint {
+            // PAR flow: POST all params to PAR endpoint
+            var formParams: [String: String] = [:]
+            if !responseMode.isEmpty {
+                formParams[OidcClient.Constants.response_mode] = responseMode
+            }
+            buildAuthorizeParams(pkce: pkce) { key, value in
+                formParams[key] = value
+            }
+            
+            guard let httpClient else {
+                throw OidcError.networkError(message: "HTTP client not found")
+            }
+            
+            let immutableParams = formParams
+            let response = try await httpClient.request { req in
+                req.url = parEndpoint
+                req.form(parameters: immutableParams)
+            }
+            guard response.status.isSuccess() else {
+                throw OidcError.apiError(code: response.status, message: "Failed to create PAR request: \(response.bodyAsString())")
+            }
+            
+            let json = try JSONSerialization.jsonObject(with: response.body ?? Data()) as? [String: Any] ?? [:]
+            guard let requestUri = json[OidcClient.Constants.request_uri] as? String else {
+                throw OidcError.authorizeError(message: "PAR response missing required 'request_uri' field")
+            }
+            
+            // Build authorize URL with only request_uri and client_id
+            request.url = openId?.authorizationEndpoint ?? ""
+            if !responseMode.isEmpty {
+                request.setParameter(name: OidcClient.Constants.response_mode, value: responseMode)
+            }
+            request.setParameter(name: OidcClient.Constants.request_uri, value: requestUri)
+            request.setParameter(name: OidcClient.Constants.client_id, value: clientId)
+        } else {
+            // Standard flow: all params on the authorization URL
+            request.url = openId?.authorizationEndpoint ?? ""
+            if !responseMode.isEmpty {
+                request.setParameter(name: OidcClient.Constants.response_mode, value: responseMode)
+            }
+            buildAuthorizeParams(pkce: pkce) { key, value in
+                request.setParameter(name: key, value: value)
+            }
         }
-        
-        if let nonce = nonce {
-            request.setParameter(name: OidcClient.Constants.nonce, value: nonce)
-        }
-        
-        if let prompt = prompt {
-            request.setParameter(name: OidcClient.Constants.prompt, value: prompt)
-        }
-        
-        if let uiLocales = uiLocales {
-            request.setParameter(name: OidcClient.Constants.ui_locales, value: uiLocales)
-        }
-        
         return request
     }
 }

--- a/Oidc/Oidc/OidcClient.swift
+++ b/Oidc/Oidc/OidcClient.swift
@@ -35,8 +35,9 @@ public class OidcClient {
             throw OidcError.networkError(message: "HTTP client not found")
         }
         var request = httpClient.request()
-        self.pkce = Pkce.generate()
-        request = config.populateRequest(request: request, pkce: pkce!, responseMode: OidcClient.Constants.query)
+        let generatedPkce = Pkce.generate()
+        self.pkce = generatedPkce
+        request = config.populateRequest(request: request, pkce: generatedPkce, responseMode: OidcClient.Constants.query)
         if let customParams = customParams {
             for parameter in customParams {
                 request.setParameter(name: parameter.key, value: parameter.value)
@@ -57,8 +58,9 @@ public class OidcClient {
             throw OidcError.networkError(message: "HTTP client not found")
         }
         var request = httpClient.request()
-        self.pkce = Pkce.generate()
-        request = try await config.populateRequest(request: request, pkce: pkce!, responseMode: OidcClient.Constants.query)
+        let generatedPkce = Pkce.generate()
+        self.pkce = generatedPkce
+        request = try await config.populateRequest(request: request, pkce: generatedPkce, responseMode: OidcClient.Constants.query)
         if let customParams = customParams {
             for parameter in customParams {
                 request.setParameter(name: parameter.key, value: parameter.value)

--- a/Oidc/Oidc/OidcClient.swift
+++ b/Oidc/Oidc/OidcClient.swift
@@ -28,8 +28,18 @@ public class OidcClient {
         self.logger = config.logger
     }
     
-    /// OidcClient generateAuthorizeUrl.
+    /// Generates an OIDC authorization URL synchronously.
+    ///
+    /// - Warning: This synchronous variant does **not** support Pushed
+    ///   Authorization Requests (PAR, RFC 9126). Even when
+    ///   `OidcClientConfig.par` is set to `true`, this method will fall back
+    ///   to the standard authorization flow and emit all parameters in the
+    ///   URL query string. To use PAR, call the `async` overload
+    ///   `generateAuthorizeUrl(customParams:) async throws -> URL` instead.
+    ///
     /// - Parameter customParams: Custom parameters to include in the authorization request.
+    /// - Returns: The fully-built authorization URL.
+    /// - Throws: `OidcError.networkError` if the HTTP client or URL cannot be resolved.
     public func generateAuthorizeUrl(customParams: [String: String]? = nil) throws -> URL {
         guard let httpClient = config.httpClient else {
             throw OidcError.networkError(message: "HTTP client not found")
@@ -37,7 +47,7 @@ public class OidcClient {
         var request = httpClient.request()
         let generatedPkce = Pkce.generate()
         self.pkce = generatedPkce
-        request = config.populateRequest(request: request, pkce: generatedPkce, responseMode: OidcClient.Constants.query)
+        request = config.populateStandardAuthorizeRequest(request: request, pkce: generatedPkce, responseMode: OidcClient.Constants.query)
         if let customParams = customParams {
             for parameter in customParams {
                 request.setParameter(name: parameter.key, value: parameter.value)
@@ -392,12 +402,14 @@ extension OidcClientConfig {
         }
     }
     
-    /// Populates an OIDC authorization request with the necessary parameters (synchronous, non-PAR).
-    /// This method is kept for backwards compatibility.
-    internal func populateRequest(
+    /// Builds a standard (non-PAR) OIDC authorization request by emitting all
+    /// parameters onto the request URL's query string. Shared by the sync
+    /// `OidcClient.generateAuthorizeUrl` and by the async `populateRequest`
+    /// fallback path when PAR is not enabled or unavailable.
+    internal func populateStandardAuthorizeRequest(
         request: Request,
         pkce: Pkce,
-        responseMode: String = OidcClient.Constants.piflow
+        responseMode: String
     ) -> Request {
         request.url = openId?.authorizationEndpoint ?? ""
         if !responseMode.isEmpty {
@@ -406,7 +418,6 @@ extension OidcClientConfig {
         buildAuthorizeParams(pkce: pkce) { key, value in
             request.setParameter(name: key, value: value)
         }
-        
         return request
     }
     
@@ -423,7 +434,7 @@ extension OidcClientConfig {
     public func populateRequest(
         request: Request,
         pkce: Pkce,
-        responseMode: String = "pi.flow"
+        responseMode: String = OidcClient.Constants.piflow
     ) async throws -> Request {
         if par, let parEndpoint = openId?.pushedAuthorizationRequestEndpoint {
             // PAR flow: POST all params to PAR endpoint
@@ -448,7 +459,10 @@ extension OidcClientConfig {
                 throw OidcError.apiError(code: response.status, message: "Failed to create PAR request: \(response.bodyAsString())")
             }
             
-            let json = try JSONSerialization.jsonObject(with: response.body ?? Data()) as? [String: Any] ?? [:]
+            guard let responseBody = response.body else {
+                throw OidcError.authorizeError(message: "PAR response body is empty")
+            }
+            let json = try JSONSerialization.jsonObject(with: responseBody) as? [String: Any] ?? [:]
             guard let requestUri = json[OidcClient.Constants.request_uri] as? String else {
                 throw OidcError.authorizeError(message: "PAR response missing required 'request_uri' field")
             }
@@ -462,20 +476,14 @@ extension OidcClientConfig {
             request.setParameter(name: OidcClient.Constants.client_id, value: clientId)
         } else {
             // Standard flow: all params on the authorization URL
-            request.url = openId?.authorizationEndpoint ?? ""
-            if !responseMode.isEmpty {
-                request.setParameter(name: OidcClient.Constants.response_mode, value: responseMode)
-            }
-            buildAuthorizeParams(pkce: pkce) { key, value in
-                request.setParameter(name: key, value: value)
-            }
+            _ = populateStandardAuthorizeRequest(request: request, pkce: pkce, responseMode: responseMode)
         }
         return request
     }
 }
 
 
-extension OidcClient.Constants {
+public extension OidcClient.Constants {
     static let response_mode = "response_mode"
     static let response_type = "response_type"
     static let scope = "scope"

--- a/Oidc/Oidc/OidcClientConfig.swift
+++ b/Oidc/Oidc/OidcClientConfig.swift
@@ -50,6 +50,9 @@ public class OidcClientConfig: @unchecked Sendable {
     public var acrValues: String?
     /// Additional parameters for OIDC.
     public var additionalParameters = [String: String]()
+    /// Enable PAR (Pushed Authorization Request) RFC 9126.
+    /// When enabled, authorization parameters are pushed to the server before authorization.
+    public var par: Bool = false
     /// HTTP client for making network requests.
     public var httpClient: (any HttpClientProtocol)?
     
@@ -136,6 +139,7 @@ public class OidcClientConfig: @unchecked Sendable {
         self.uiLocales = other.uiLocales
         self.acrValues = other.acrValues
         self.additionalParameters = other.additionalParameters
+        self.par = other.par
         self.httpClient = other.httpClient
     }
 }

--- a/Oidc/Oidc/OpenIdConfiguration.swift
+++ b/Oidc/Oidc/OpenIdConfiguration.swift
@@ -2,7 +2,7 @@
 //  OpenIdConfiguration.swift
 //  PingOidc
 //
-//  Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -25,6 +25,35 @@ public struct OpenIdConfiguration: Codable, Sendable {
     public let revocationEndpoint: String
     /// The URL of the end session endpoint.
     public let pingEndsessionEndpoint: String?
+    /// The URL of the pushed authorization request endpoint (PAR, RFC 9126).
+    public let pushedAuthorizationRequestEndpoint: String?
+    
+    /// Initializes a new `OpenIdConfiguration` instance.
+    /// - Parameters:
+    ///   - authorizationEndpoint: The URL of the authorization endpoint.
+    ///   - tokenEndpoint: The URL of the token endpoint.
+    ///   - userinfoEndpoint: The URL of the userinfo endpoint.
+    ///   - endSessionEndpoint: The URL of the end session endpoint.
+    ///   - revocationEndpoint: The URL of the revocation endpoint.
+    ///   - pingEndsessionEndpoint: The URL of the Ping end IDP session endpoint.
+    ///   - pushedAuthorizationRequestEndpoint: The URL of the PAR endpoint.
+    public init(
+        authorizationEndpoint: String,
+        tokenEndpoint: String,
+        userinfoEndpoint: String,
+        endSessionEndpoint: String,
+        revocationEndpoint: String,
+        pingEndsessionEndpoint: String? = nil,
+        pushedAuthorizationRequestEndpoint: String? = nil
+    ) {
+        self.authorizationEndpoint = authorizationEndpoint
+        self.tokenEndpoint = tokenEndpoint
+        self.userinfoEndpoint = userinfoEndpoint
+        self.endSessionEndpoint = endSessionEndpoint
+        self.revocationEndpoint = revocationEndpoint
+        self.pingEndsessionEndpoint = pingEndsessionEndpoint
+        self.pushedAuthorizationRequestEndpoint = pushedAuthorizationRequestEndpoint
+    }
     
     // Define CodingKeys enum to map serialized names to property names
     private enum CodingKeys: String, CodingKey {
@@ -34,5 +63,6 @@ public struct OpenIdConfiguration: Codable, Sendable {
         case endSessionEndpoint = "end_session_endpoint"
         case revocationEndpoint = "revocation_endpoint"
         case pingEndsessionEndpoint = "ping_end_idp_session_endpoint"
+        case pushedAuthorizationRequestEndpoint = "pushed_authorization_request_endpoint"
     }
 }

--- a/Oidc/OidcTests/OidcAdditionalTests.swift
+++ b/Oidc/OidcTests/OidcAdditionalTests.swift
@@ -74,6 +74,86 @@ final class OpenIdConfigurationTests: XCTestCase {
         XCTAssertEqual(decoded.endSessionEndpoint, config.endSessionEndpoint)
         XCTAssertEqual(decoded.revocationEndpoint, config.revocationEndpoint)
     }
+    
+    // MARK: - PAR (Pushed Authorization Request) Tests
+    
+    func testDecodingWithPAREndpoint() throws {
+        let json = """
+        {
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+            "userinfo_endpoint": "https://auth.example.com/userinfo",
+            "end_session_endpoint": "https://auth.example.com/logout",
+            "revocation_endpoint": "https://auth.example.com/revoke",
+            "pushed_authorization_request_endpoint": "https://auth.example.com/par"
+        }
+        """.data(using: .utf8)!
+        
+        let config = try JSONDecoder().decode(OpenIdConfiguration.self, from: json)
+        
+        XCTAssertEqual(config.pushedAuthorizationRequestEndpoint, "https://auth.example.com/par")
+        XCTAssertEqual(config.authorizationEndpoint, "https://auth.example.com/authorize")
+    }
+    
+    func testDecodingWithoutPAREndpointDefaultsToNil() throws {
+        let json = """
+        {
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+            "userinfo_endpoint": "https://auth.example.com/userinfo",
+            "end_session_endpoint": "https://auth.example.com/logout",
+            "revocation_endpoint": "https://auth.example.com/revoke"
+        }
+        """.data(using: .utf8)!
+        
+        let config = try JSONDecoder().decode(OpenIdConfiguration.self, from: json)
+        
+        XCTAssertNil(config.pushedAuthorizationRequestEndpoint)
+    }
+    
+    func testPAREndpointSurvivesEncodeDecode() throws {
+        let json = """
+        {
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+            "userinfo_endpoint": "https://auth.example.com/userinfo",
+            "end_session_endpoint": "https://auth.example.com/logout",
+            "revocation_endpoint": "https://auth.example.com/revoke",
+            "pushed_authorization_request_endpoint": "https://auth.example.com/par"
+        }
+        """.data(using: .utf8)!
+        
+        let config = try JSONDecoder().decode(OpenIdConfiguration.self, from: json)
+        let encoded = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(OpenIdConfiguration.self, from: encoded)
+        
+        XCTAssertEqual(decoded.pushedAuthorizationRequestEndpoint, "https://auth.example.com/par")
+    }
+    
+    func testExplicitInitWithPAREndpoint() {
+        let config = OpenIdConfiguration(
+            authorizationEndpoint: "https://auth.example.com/authorize",
+            tokenEndpoint: "https://auth.example.com/token",
+            userinfoEndpoint: "https://auth.example.com/userinfo",
+            endSessionEndpoint: "https://auth.example.com/logout",
+            revocationEndpoint: "https://auth.example.com/revoke",
+            pushedAuthorizationRequestEndpoint: "https://auth.example.com/par"
+        )
+        
+        XCTAssertEqual(config.pushedAuthorizationRequestEndpoint, "https://auth.example.com/par")
+    }
+    
+    func testExplicitInitWithoutPAREndpointDefaultsToNil() {
+        let config = OpenIdConfiguration(
+            authorizationEndpoint: "https://auth.example.com/authorize",
+            tokenEndpoint: "https://auth.example.com/token",
+            userinfoEndpoint: "https://auth.example.com/userinfo",
+            endSessionEndpoint: "https://auth.example.com/logout",
+            revocationEndpoint: "https://auth.example.com/revoke"
+        )
+        
+        XCTAssertNil(config.pushedAuthorizationRequestEndpoint)
+    }
 }
 
 // MARK: - DefaultAgent Tests

--- a/Oidc/OidcTests/OidcClientConfigTests.swift
+++ b/Oidc/OidcTests/OidcClientConfigTests.swift
@@ -53,6 +53,7 @@ final class OidcClientConfigTests: XCTestCase {
         XCTAssertNil(oidcClientConfig.uiLocales)
         XCTAssertNil(oidcClientConfig.acrValues)
         XCTAssertTrue(oidcClientConfig.additionalParameters.isEmpty)
+        XCTAssertFalse(oidcClientConfig.par)
         XCTAssertNil(oidcClientConfig.httpClient)
     }
     
@@ -121,6 +122,7 @@ final class OidcClientConfigTests: XCTestCase {
         oidcClientConfig.acrValues = "acrValues"
         oidcClientConfig.additionalParameters = ["param": "value"]
         oidcClientConfig.httpClient = MockURLProtocol.makeClient()
+        oidcClientConfig.par = true
         
         let clonedConfig = oidcClientConfig.clone()
         
@@ -139,6 +141,7 @@ final class OidcClientConfigTests: XCTestCase {
         XCTAssertEqual(oidcClientConfig.acrValues, clonedConfig.acrValues)
         XCTAssertEqual(oidcClientConfig.additionalParameters, clonedConfig.additionalParameters)
         XCTAssertEqual(oidcClientConfig.httpClient.debugDescription, clonedConfig.httpClient.debugDescription)
+        XCTAssertEqual(oidcClientConfig.par, clonedConfig.par)
     }
     
     // TestRailCase(24719)
@@ -159,6 +162,7 @@ final class OidcClientConfigTests: XCTestCase {
         otherConfig.acrValues = "acrValues"
         otherConfig.additionalParameters = ["param": "value"]
         otherConfig.httpClient = MockURLProtocol.makeClient()
+        otherConfig.par = true
         
         oidcClientConfig.update(with: otherConfig)
         
@@ -176,6 +180,7 @@ final class OidcClientConfigTests: XCTestCase {
         XCTAssertEqual(otherConfig.acrValues, oidcClientConfig.acrValues)
         XCTAssertEqual(otherConfig.additionalParameters, oidcClientConfig.additionalParameters)
         XCTAssertEqual(otherConfig.httpClient.debugDescription, oidcClientConfig.httpClient.debugDescription)
+        XCTAssertEqual(otherConfig.par, oidcClientConfig.par)
     }
 }
 

--- a/Oidc/OidcTests/OidcClientPARTests.swift
+++ b/Oidc/OidcTests/OidcClientPARTests.swift
@@ -1,0 +1,421 @@
+//
+//  OidcClientPARTests.swift
+//  OidcTests
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+@testable import PingOidc
+@testable import PingNetwork
+@testable import PingLogger
+@testable import PingStorage
+@testable import PingOrchestrate
+
+// MARK: - PAR (Pushed Authorization Request) Tests
+
+/// Helper to read httpBodyStream data from URLRequest (httpBody is nil when using URLSession with URLProtocol)
+private func bodyData(from request: URLRequest) -> Data {
+    if let body = request.httpBody {
+        return body
+    }
+    guard let stream = request.httpBodyStream else {
+        return Data()
+    }
+    stream.open()
+    defer { stream.close() }
+    var data = Data()
+    let bufferSize = 4096
+    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+    defer { buffer.deallocate() }
+    while stream.hasBytesAvailable {
+        let bytesRead = stream.read(buffer, maxLength: bufferSize)
+        if bytesRead > 0 {
+            data.append(buffer, count: bytesRead)
+        } else {
+            break
+        }
+    }
+    return data
+}
+
+final class OidcClientPARTests: XCTestCase {
+    
+    var oidcClientConfig: OidcClientConfig!
+    
+    static let parEndpointURL = URL(string: "\(MockAPIEndpoint.baseURL)/par")!
+    
+    /// OpenID configuration JSON that includes the PAR endpoint.
+    static var openIdConfigurationWithPAR: Data {
+        """
+        {
+          "authorization_endpoint" : "\(MockAPIEndpoint.authorization.url.absoluteString)",
+          "token_endpoint" : "\(MockAPIEndpoint.token.url.absoluteString)",
+          "userinfo_endpoint" : "\(MockAPIEndpoint.userinfo.url.absoluteString)",
+          "end_session_endpoint" : "\(MockAPIEndpoint.endSession.url.absoluteString)",
+          "revocation_endpoint" : "\(MockAPIEndpoint.revocation.url.absoluteString)",
+          "pushed_authorization_request_endpoint" : "\(parEndpointURL.absoluteString)"
+        }
+        """.data(using: .utf8)!
+    }
+    
+    /// Successful PAR response containing a request_uri.
+    static var parResponse: Data {
+        """
+        {
+          "request_uri" : "urn:ietf:params:oauth:request_uri:test-request-uri",
+          "expires_in" : 60
+        }
+        """.data(using: .utf8)!
+    }
+    
+    override func setUp() {
+        super.setUp()
+        oidcClientConfig = OidcClientConfig()
+        oidcClientConfig.clientId = "test-client"
+        oidcClientConfig.scopes = Set(["openid", "email"])
+        oidcClientConfig.redirectUri = "http://localhost:8080/callback"
+        oidcClientConfig.discoveryEndpoint = MockAPIEndpoint.discovery.url.absoluteString
+        oidcClientConfig.storage = MockStorage<Token>()
+        oidcClientConfig.httpClient = MockURLProtocol.makeClient()
+        MockURLProtocol.startInterceptingRequests()
+    }
+    
+    override func tearDown() {
+        oidcClientConfig = nil
+        MockURLProtocol.stopInterceptingRequests()
+        super.tearDown()
+    }
+    
+    // MARK: - populateRequest Tests
+    
+    func testPopulateRequestWithPAREnabled() async throws {
+        // Configure PAR
+        oidcClientConfig.par = true
+        
+        // Set up mock handler
+        MockURLProtocol.requestHandler = { request in
+            switch request.url!.path {
+            case MockAPIEndpoint.discovery.url.path:
+                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+            case OidcClientPARTests.parEndpointURL.path:
+                return (HTTPURLResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 201, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.parResponse)
+            default:
+                XCTFail("Unexpected request: \(request.url!.path)")
+                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+            }
+        }
+        
+        // Initialize OIDC to load the discovery document
+        try await oidcClientConfig.oidcInitialize()
+        
+        let pkce = Pkce.generate()
+        let httpClient = oidcClientConfig.httpClient!
+        var request = httpClient.request()
+        
+        request = try await oidcClientConfig.populateRequest(request: request, pkce: pkce, responseMode: "pi.flow")
+        
+        // Verify PAR request was made (request 0 = discovery, request 1 = PAR POST)
+        XCTAssertEqual(MockURLProtocol.requestHistory.count, 2)
+        
+        let parRequest = MockURLProtocol.requestHistory[1]
+        XCTAssertEqual(parRequest.url!.path, "/par")
+        XCTAssertEqual(parRequest.httpMethod, "POST")
+        
+        // Verify PAR POST body contains the expected form parameters
+        let parBody = String(data: bodyData(from: parRequest), encoding: .utf8) ?? ""
+        XCTAssertTrue(parBody.contains("client_id=test-client"), "PAR body should contain client_id")
+        XCTAssertTrue(parBody.contains("response_type=code"), "PAR body should contain response_type")
+        XCTAssertTrue(parBody.contains("code_challenge="), "PAR body should contain code_challenge")
+        XCTAssertTrue(parBody.contains("code_challenge_method=S256"), "PAR body should contain code_challenge_method")
+        XCTAssertTrue(parBody.contains("redirect_uri="), "PAR body should contain redirect_uri")
+        XCTAssertTrue(parBody.contains("response_mode=pi.flow"), "PAR body should contain response_mode")
+        
+        // Verify the resulting authorize request URL uses request_uri (not full params)
+        let authorizeUrl = request.url!
+        XCTAssertTrue(authorizeUrl.contains(MockAPIEndpoint.authorization.url.absoluteString), "Authorize URL should point to authorization endpoint")
+        XCTAssertTrue(authorizeUrl.contains("request_uri="), "Authorize URL should contain request_uri parameter")
+        XCTAssertTrue(authorizeUrl.contains("client_id=test-client"), "Authorize URL should contain client_id")
+        XCTAssertTrue(authorizeUrl.contains("response_mode=pi.flow"), "Authorize URL should contain response_mode")
+        
+        // Verify the authorize URL does NOT contain full OIDC params (they were sent via PAR)
+        XCTAssertFalse(authorizeUrl.contains("code_challenge="), "Authorize URL should NOT contain code_challenge when PAR is used")
+        XCTAssertFalse(authorizeUrl.contains("response_type="), "Authorize URL should NOT contain response_type when PAR is used")
+        XCTAssertFalse(authorizeUrl.contains("scope="), "Authorize URL should NOT contain scope when PAR is used")
+    }
+    
+    func testPopulateRequestWithPARDisabled() async throws {
+        // PAR is disabled by default
+        XCTAssertFalse(oidcClientConfig.par)
+        
+        MockURLProtocol.requestHandler = { request in
+            switch request.url!.path {
+            case MockAPIEndpoint.discovery.url.path:
+                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+            default:
+                XCTFail("Unexpected request: \(request.url!.path)")
+                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+            }
+        }
+        
+        try await oidcClientConfig.oidcInitialize()
+        
+        let pkce = Pkce.generate()
+        let httpClient = oidcClientConfig.httpClient!
+        var request = httpClient.request()
+        
+        request = try await oidcClientConfig.populateRequest(request: request, pkce: pkce, responseMode: "pi.flow")
+        
+        // Only discovery request should have been made (no PAR request)
+        XCTAssertEqual(MockURLProtocol.requestHistory.count, 1)
+        
+        // Verify the authorize URL contains full OIDC params (standard flow)
+        let authorizeUrl = request.url!
+        XCTAssertTrue(authorizeUrl.contains("client_id=test-client"))
+        XCTAssertTrue(authorizeUrl.contains("response_type=code"))
+        XCTAssertTrue(authorizeUrl.contains("code_challenge="))
+        XCTAssertTrue(authorizeUrl.contains("code_challenge_method=S256"))
+        XCTAssertTrue(authorizeUrl.contains("response_mode=pi.flow"))
+        XCTAssertFalse(authorizeUrl.contains("request_uri="), "Standard flow should NOT use request_uri")
+    }
+    
+    func testPopulateRequestPARWithEmptyResponseMode() async throws {
+        oidcClientConfig.par = true
+        
+        MockURLProtocol.requestHandler = { request in
+            switch request.url!.path {
+            case MockAPIEndpoint.discovery.url.path:
+                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+            case OidcClientPARTests.parEndpointURL.path:
+                return (HTTPURLResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 201, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.parResponse)
+            default:
+                XCTFail("Unexpected request: \(request.url!.path)")
+                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+            }
+        }
+        
+        try await oidcClientConfig.oidcInitialize()
+        
+        let pkce = Pkce.generate()
+        let httpClient = oidcClientConfig.httpClient!
+        var request = httpClient.request()
+        
+        // Empty responseMode (as used by Journey)
+        request = try await oidcClientConfig.populateRequest(request: request, pkce: pkce, responseMode: "")
+        
+        // Verify PAR body does NOT contain response_mode when empty
+        let parRequest = MockURLProtocol.requestHistory[1]
+        let parBody = String(data: bodyData(from: parRequest), encoding: .utf8) ?? ""
+        XCTAssertFalse(parBody.contains("response_mode"), "PAR body should NOT contain response_mode when empty")
+        
+        // Verify authorize URL does NOT contain response_mode when empty
+        let authorizeUrl = request.url!
+        XCTAssertFalse(authorizeUrl.contains("response_mode"), "Authorize URL should NOT contain response_mode when empty")
+        XCTAssertTrue(authorizeUrl.contains("request_uri="), "Authorize URL should contain request_uri")
+    }
+    
+    func testPopulateRequestPARFailure() async throws {
+        oidcClientConfig.par = true
+        
+        MockURLProtocol.requestHandler = { request in
+            switch request.url!.path {
+            case MockAPIEndpoint.discovery.url.path:
+                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+            case OidcClientPARTests.parEndpointURL.path:
+                // PAR endpoint returns 400 error
+                let errorResponse = """
+                {"error": "invalid_request", "error_description": "Invalid client"}
+                """.data(using: .utf8)!
+                return (HTTPURLResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 400, httpVersion: nil, headerFields: MockResponse.headers)!, errorResponse)
+            default:
+                XCTFail("Unexpected request: \(request.url!.path)")
+                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+            }
+        }
+        
+        try await oidcClientConfig.oidcInitialize()
+        
+        let pkce = Pkce.generate()
+        let httpClient = oidcClientConfig.httpClient!
+        var request = httpClient.request()
+        
+        do {
+            request = try await oidcClientConfig.populateRequest(request: request, pkce: pkce, responseMode: "pi.flow")
+            XCTFail("Should have thrown an error for PAR failure")
+        } catch let error as OidcError {
+            // Verify the error is an API error
+            if case .apiError(_, let message) = error {
+                XCTAssertTrue(message.contains("Failed to create PAR request"), "Error should mention PAR request failure")
+            } else {
+                XCTFail("Expected apiError, got: \(error)")
+            }
+        }
+    }
+    
+    func testPopulateRequestPARMissingRequestUri() async throws {
+        oidcClientConfig.par = true
+        
+        MockURLProtocol.requestHandler = { request in
+            switch request.url!.path {
+            case MockAPIEndpoint.discovery.url.path:
+                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+            case OidcClientPARTests.parEndpointURL.path:
+                // PAR endpoint returns 200 but without request_uri
+                let badResponse = """
+                {"expires_in": 60}
+                """.data(using: .utf8)!
+                return (HTTPURLResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, badResponse)
+            default:
+                XCTFail("Unexpected request: \(request.url!.path)")
+                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+            }
+        }
+        
+        try await oidcClientConfig.oidcInitialize()
+        
+        let pkce = Pkce.generate()
+        let httpClient = oidcClientConfig.httpClient!
+        var request = httpClient.request()
+        
+        do {
+            request = try await oidcClientConfig.populateRequest(request: request, pkce: pkce, responseMode: "pi.flow")
+            XCTFail("Should have thrown an error for missing request_uri")
+        } catch let error as OidcError {
+            if case .authorizeError(_, let message) = error {
+                XCTAssertTrue(message?.contains("request_uri") ?? false, "Error should mention missing request_uri")
+            } else {
+                XCTFail("Expected authorizeError, got: \(error)")
+            }
+        }
+    }
+    
+    func testPopulateRequestPARFallsBackWhenNoPAREndpoint() async throws {
+        // PAR is enabled but discovery does NOT include PAR endpoint
+        oidcClientConfig.par = true
+        
+        MockURLProtocol.requestHandler = { request in
+            switch request.url!.path {
+            case MockAPIEndpoint.discovery.url.path:
+                // Standard discovery without PAR endpoint
+                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, MockResponse.openIdConfiguration)
+            default:
+                XCTFail("Unexpected request: \(request.url!.path)")
+                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+            }
+        }
+        
+        try await oidcClientConfig.oidcInitialize()
+        
+        let pkce = Pkce.generate()
+        let httpClient = oidcClientConfig.httpClient!
+        var request = httpClient.request()
+        
+        request = try await oidcClientConfig.populateRequest(request: request, pkce: pkce, responseMode: "pi.flow")
+        
+        // Only discovery request - no PAR request since endpoint is missing
+        XCTAssertEqual(MockURLProtocol.requestHistory.count, 1)
+        
+        // Falls back to standard flow
+        let authorizeUrl = request.url!
+        XCTAssertTrue(authorizeUrl.contains("client_id=test-client"))
+        XCTAssertTrue(authorizeUrl.contains("response_type=code"))
+        XCTAssertTrue(authorizeUrl.contains("code_challenge="))
+        XCTAssertFalse(authorizeUrl.contains("request_uri="), "Should not use request_uri when PAR endpoint is missing")
+    }
+    
+    // MARK: - generateAuthorizeUrl Tests
+    
+    func testGenerateAuthorizeUrlWithPAR() async throws {
+        oidcClientConfig.par = true
+        
+        MockURLProtocol.requestHandler = { request in
+            switch request.url!.path {
+            case MockAPIEndpoint.discovery.url.path:
+                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+            case OidcClientPARTests.parEndpointURL.path:
+                return (HTTPURLResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 201, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.parResponse)
+            default:
+                XCTFail("Unexpected request: \(request.url!.path)")
+                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+            }
+        }
+        
+        try await oidcClientConfig.oidcInitialize()
+        
+        let oidcClient = OidcClient(config: oidcClientConfig)
+        let url = try await oidcClient.generateAuthorizeUrl()
+        
+        let urlString = url.absoluteString
+        XCTAssertTrue(urlString.contains("request_uri="), "Authorize URL should contain request_uri")
+        XCTAssertTrue(urlString.contains("client_id=test-client"), "Authorize URL should contain client_id")
+        XCTAssertFalse(urlString.contains("code_challenge="), "Authorize URL should NOT contain code_challenge")
+    }
+    
+    func testGenerateAuthorizeUrlWithPARAndCustomParams() async throws {
+        oidcClientConfig.par = true
+        
+        MockURLProtocol.requestHandler = { request in
+            switch request.url!.path {
+            case MockAPIEndpoint.discovery.url.path:
+                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+            case OidcClientPARTests.parEndpointURL.path:
+                return (HTTPURLResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 201, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.parResponse)
+            default:
+                XCTFail("Unexpected request: \(request.url!.path)")
+                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+            }
+        }
+        
+        try await oidcClientConfig.oidcInitialize()
+        
+        let oidcClient = OidcClient(config: oidcClientConfig)
+        let url = try await oidcClient.generateAuthorizeUrl(customParams: ["custom_key": "custom_value"])
+        
+        let urlString = url.absoluteString
+        XCTAssertTrue(urlString.contains("request_uri="), "Authorize URL should contain request_uri")
+        XCTAssertTrue(urlString.contains("custom_key=custom_value"), "Authorize URL should contain custom parameters")
+    }
+    
+    func testPopulateRequestPARWithAdditionalOidcParameters() async throws {
+        oidcClientConfig.par = true
+        oidcClientConfig.acrValues = "urn:acr:test"
+        oidcClientConfig.loginHint = "user@example.com"
+        oidcClientConfig.nonce = "test-nonce"
+        
+        MockURLProtocol.requestHandler = { request in
+            switch request.url!.path {
+            case MockAPIEndpoint.discovery.url.path:
+                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+            case OidcClientPARTests.parEndpointURL.path:
+                return (HTTPURLResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 201, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.parResponse)
+            default:
+                XCTFail("Unexpected request: \(request.url!.path)")
+                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+            }
+        }
+        
+        try await oidcClientConfig.oidcInitialize()
+        
+        let pkce = Pkce.generate()
+        let httpClient = oidcClientConfig.httpClient!
+        var request = httpClient.request()
+        
+        request = try await oidcClientConfig.populateRequest(request: request, pkce: pkce, responseMode: "pi.flow")
+        
+        // Verify additional OIDC params are sent in the PAR POST body (not on the URL)
+        let parRequest = MockURLProtocol.requestHistory[1]
+        let parBody = String(data: bodyData(from: parRequest), encoding: .utf8) ?? ""
+        XCTAssertTrue(parBody.contains("acr_values="), "PAR body should contain acr_values")
+        XCTAssertTrue(parBody.contains("login_hint="), "PAR body should contain login_hint")
+        XCTAssertTrue(parBody.contains("nonce=test-nonce"), "PAR body should contain nonce")
+        
+        // Verify the authorize URL only has the minimal params
+        let authorizeUrl = request.url!
+        XCTAssertFalse(authorizeUrl.contains("acr_values="), "Authorize URL should NOT contain acr_values when PAR is used")
+        XCTAssertFalse(authorizeUrl.contains("login_hint="), "Authorize URL should NOT contain login_hint when PAR is used")
+        XCTAssertFalse(authorizeUrl.contains("nonce="), "Authorize URL should NOT contain nonce when PAR is used")
+    }
+}

--- a/Oidc/OidcTests/OidcClientPARTests.swift
+++ b/Oidc/OidcTests/OidcClientPARTests.swift
@@ -418,4 +418,92 @@ final class OidcClientPARTests: XCTestCase {
         XCTAssertFalse(authorizeUrl.contains("login_hint="), "Authorize URL should NOT contain login_hint when PAR is used")
         XCTAssertFalse(authorizeUrl.contains("nonce="), "Authorize URL should NOT contain nonce when PAR is used")
     }
+    
+    // MARK: - state parameter behavior
+    
+    /// Standard (non-PAR) flow: `state` must be present on the authorize URL,
+    /// defaulting to the PKCE-generated state when the integrator did not set
+    /// `OidcClientConfig.state` explicitly.
+    func testStandardFlowAlwaysSendsStateDefaultingToPkceState() async throws {
+        MockURLProtocol.requestHandler = { request in
+            switch request.url!.path {
+            case MockAPIEndpoint.discovery.url.path:
+                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+            default:
+                XCTFail("Unexpected request: \(request.url!.path)")
+                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+            }
+        }
+        
+        try await oidcClientConfig.oidcInitialize()
+        
+        let pkce = Pkce.generate()
+        let httpClient = oidcClientConfig.httpClient!
+        var request = httpClient.request()
+        request = try await oidcClientConfig.populateRequest(request: request, pkce: pkce, responseMode: "pi.flow")
+        
+        let authorizeUrl = request.url!
+        XCTAssertTrue(authorizeUrl.contains("state=\(pkce.state)"), "Authorize URL should contain state=<pkce.state>")
+    }
+    
+    /// Standard (non-PAR) flow: an integrator-supplied `OidcClientConfig.state`
+    /// takes precedence over `pkce.state`.
+    func testStandardFlowConfigStateOverridesPkceState() async throws {
+        oidcClientConfig.state = "integrator-state"
+        
+        MockURLProtocol.requestHandler = { request in
+            switch request.url!.path {
+            case MockAPIEndpoint.discovery.url.path:
+                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+            default:
+                XCTFail("Unexpected request: \(request.url!.path)")
+                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+            }
+        }
+        
+        try await oidcClientConfig.oidcInitialize()
+        
+        let pkce = Pkce.generate()
+        let httpClient = oidcClientConfig.httpClient!
+        var request = httpClient.request()
+        request = try await oidcClientConfig.populateRequest(request: request, pkce: pkce, responseMode: "pi.flow")
+        
+        let authorizeUrl = request.url!
+        XCTAssertTrue(authorizeUrl.contains("state=integrator-state"), "Authorize URL should use integrator-supplied state")
+        XCTAssertFalse(authorizeUrl.contains("state=\(pkce.state)"), "Authorize URL should NOT fall back to pkce.state when config.state is set")
+    }
+    
+    /// PAR flow: `state` must be present in the PAR POST body, defaulting to
+    /// the PKCE-generated state.
+    func testPARFlowSendsStateInPARBodyDefaultingToPkceState() async throws {
+        oidcClientConfig.par = true
+        
+        MockURLProtocol.requestHandler = { request in
+            switch request.url!.path {
+            case MockAPIEndpoint.discovery.url.path:
+                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+            case OidcClientPARTests.parEndpointURL.path:
+                return (HTTPURLResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 201, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.parResponse)
+            default:
+                XCTFail("Unexpected request: \(request.url!.path)")
+                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+            }
+        }
+        
+        try await oidcClientConfig.oidcInitialize()
+        
+        let pkce = Pkce.generate()
+        let httpClient = oidcClientConfig.httpClient!
+        var request = httpClient.request()
+        request = try await oidcClientConfig.populateRequest(request: request, pkce: pkce, responseMode: "pi.flow")
+        
+        let parRequest = MockURLProtocol.requestHistory[1]
+        let parBody = String(data: bodyData(from: parRequest), encoding: .utf8) ?? ""
+        XCTAssertTrue(parBody.contains("state=\(pkce.state)"), "PAR body should contain state=<pkce.state>")
+        
+        // The authorize URL after PAR carries only request_uri/client_id/response_mode,
+        // so state should NOT leak into it.
+        let authorizeUrl = request.url!
+        XCTAssertFalse(authorizeUrl.contains("state="), "Authorize URL should NOT contain state when PAR is used")
+    }
 }

--- a/Oidc/OidcTests/OidcClientPARTests.swift
+++ b/Oidc/OidcTests/OidcClientPARTests.swift
@@ -90,6 +90,21 @@ final class OidcClientPARTests: XCTestCase {
         super.tearDown()
     }
     
+    /// Creates an `HTTPURLResponse` or throws, replacing force-unwrap (`!`) in mock handlers.
+    private func mockResponse(url: URL, statusCode: Int, headers: [String: String]? = nil) throws -> HTTPURLResponse {
+        guard let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: headers) else {
+            throw URLError(.badServerResponse)
+        }
+        return response
+    }
+    
+    /// Returns a 500 response for an unexpected request URL, falling back to the discovery URL
+    /// when the inbound request has no URL.
+    private func unexpectedResponse(for request: URLRequest) throws -> (HTTPURLResponse, Data) {
+        XCTFail("Unexpected request: \(request.url?.path ?? "<no url>")")
+        return (try mockResponse(url: request.url ?? MockAPIEndpoint.discovery.url, statusCode: 500), Data())
+    }
+    
     // MARK: - populateRequest Tests
     
     func testPopulateRequestWithPAREnabled() async throws {
@@ -97,15 +112,14 @@ final class OidcClientPARTests: XCTestCase {
         oidcClientConfig.par = true
         
         // Set up mock handler
-        MockURLProtocol.requestHandler = { request in
-            switch request.url!.path {
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
             case MockAPIEndpoint.discovery.url.path:
-                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+                return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, headers: MockResponse.headers), OidcClientPARTests.openIdConfigurationWithPAR)
             case OidcClientPARTests.parEndpointURL.path:
-                return (HTTPURLResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 201, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.parResponse)
+                return (try mockResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 201, headers: MockResponse.headers), OidcClientPARTests.parResponse)
             default:
-                XCTFail("Unexpected request: \(request.url!.path)")
-                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+                return try unexpectedResponse(for: request)
             }
         }
         
@@ -113,7 +127,7 @@ final class OidcClientPARTests: XCTestCase {
         try await oidcClientConfig.oidcInitialize()
         
         let pkce = Pkce.generate()
-        let httpClient = oidcClientConfig.httpClient!
+        let httpClient = try XCTUnwrap(oidcClientConfig.httpClient, "HTTP client should be configured")
         var request = httpClient.request()
         
         request = try await oidcClientConfig.populateRequest(request: request, pkce: pkce, responseMode: "pi.flow")
@@ -122,7 +136,8 @@ final class OidcClientPARTests: XCTestCase {
         XCTAssertEqual(MockURLProtocol.requestHistory.count, 2)
         
         let parRequest = MockURLProtocol.requestHistory[1]
-        XCTAssertEqual(parRequest.url!.path, "/par")
+        let parUrl = try XCTUnwrap(parRequest.url, "PAR request should have a URL")
+        XCTAssertEqual(parUrl.path, "/par")
         XCTAssertEqual(parRequest.httpMethod, "POST")
         
         // Verify PAR POST body contains the expected form parameters
@@ -135,7 +150,7 @@ final class OidcClientPARTests: XCTestCase {
         XCTAssertTrue(parBody.contains("response_mode=pi.flow"), "PAR body should contain response_mode")
         
         // Verify the resulting authorize request URL uses request_uri (not full params)
-        let authorizeUrl = request.url!
+        let authorizeUrl = try XCTUnwrap(request.url, "Populated request should have a URL")
         XCTAssertTrue(authorizeUrl.contains(MockAPIEndpoint.authorization.url.absoluteString), "Authorize URL should point to authorization endpoint")
         XCTAssertTrue(authorizeUrl.contains("request_uri="), "Authorize URL should contain request_uri parameter")
         XCTAssertTrue(authorizeUrl.contains("client_id=test-client"), "Authorize URL should contain client_id")
@@ -151,20 +166,19 @@ final class OidcClientPARTests: XCTestCase {
         // PAR is disabled by default
         XCTAssertFalse(oidcClientConfig.par)
         
-        MockURLProtocol.requestHandler = { request in
-            switch request.url!.path {
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
             case MockAPIEndpoint.discovery.url.path:
-                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+                return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, headers: MockResponse.headers), OidcClientPARTests.openIdConfigurationWithPAR)
             default:
-                XCTFail("Unexpected request: \(request.url!.path)")
-                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+                return try unexpectedResponse(for: request)
             }
         }
         
         try await oidcClientConfig.oidcInitialize()
         
         let pkce = Pkce.generate()
-        let httpClient = oidcClientConfig.httpClient!
+        let httpClient = try XCTUnwrap(oidcClientConfig.httpClient, "HTTP client should be configured")
         var request = httpClient.request()
         
         request = try await oidcClientConfig.populateRequest(request: request, pkce: pkce, responseMode: "pi.flow")
@@ -173,7 +187,7 @@ final class OidcClientPARTests: XCTestCase {
         XCTAssertEqual(MockURLProtocol.requestHistory.count, 1)
         
         // Verify the authorize URL contains full OIDC params (standard flow)
-        let authorizeUrl = request.url!
+        let authorizeUrl = try XCTUnwrap(request.url, "Populated request should have a URL")
         XCTAssertTrue(authorizeUrl.contains("client_id=test-client"))
         XCTAssertTrue(authorizeUrl.contains("response_type=code"))
         XCTAssertTrue(authorizeUrl.contains("code_challenge="))
@@ -185,22 +199,21 @@ final class OidcClientPARTests: XCTestCase {
     func testPopulateRequestPARWithEmptyResponseMode() async throws {
         oidcClientConfig.par = true
         
-        MockURLProtocol.requestHandler = { request in
-            switch request.url!.path {
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
             case MockAPIEndpoint.discovery.url.path:
-                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+                return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, headers: MockResponse.headers), OidcClientPARTests.openIdConfigurationWithPAR)
             case OidcClientPARTests.parEndpointURL.path:
-                return (HTTPURLResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 201, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.parResponse)
+                return (try mockResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 201, headers: MockResponse.headers), OidcClientPARTests.parResponse)
             default:
-                XCTFail("Unexpected request: \(request.url!.path)")
-                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+                return try unexpectedResponse(for: request)
             }
         }
         
         try await oidcClientConfig.oidcInitialize()
         
         let pkce = Pkce.generate()
-        let httpClient = oidcClientConfig.httpClient!
+        let httpClient = try XCTUnwrap(oidcClientConfig.httpClient, "HTTP client should be configured")
         var request = httpClient.request()
         
         // Empty responseMode (as used by Journey)
@@ -212,7 +225,7 @@ final class OidcClientPARTests: XCTestCase {
         XCTAssertFalse(parBody.contains("response_mode"), "PAR body should NOT contain response_mode when empty")
         
         // Verify authorize URL does NOT contain response_mode when empty
-        let authorizeUrl = request.url!
+        let authorizeUrl = try XCTUnwrap(request.url, "Populated request should have a URL")
         XCTAssertFalse(authorizeUrl.contains("response_mode"), "Authorize URL should NOT contain response_mode when empty")
         XCTAssertTrue(authorizeUrl.contains("request_uri="), "Authorize URL should contain request_uri")
     }
@@ -220,26 +233,25 @@ final class OidcClientPARTests: XCTestCase {
     func testPopulateRequestPARFailure() async throws {
         oidcClientConfig.par = true
         
-        MockURLProtocol.requestHandler = { request in
-            switch request.url!.path {
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
             case MockAPIEndpoint.discovery.url.path:
-                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+                return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, headers: MockResponse.headers), OidcClientPARTests.openIdConfigurationWithPAR)
             case OidcClientPARTests.parEndpointURL.path:
                 // PAR endpoint returns 400 error
-                let errorResponse = """
+                let errorResponse = Data("""
                 {"error": "invalid_request", "error_description": "Invalid client"}
-                """.data(using: .utf8)!
-                return (HTTPURLResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 400, httpVersion: nil, headerFields: MockResponse.headers)!, errorResponse)
+                """.utf8)
+                return (try mockResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 400, headers: MockResponse.headers), errorResponse)
             default:
-                XCTFail("Unexpected request: \(request.url!.path)")
-                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+                return try unexpectedResponse(for: request)
             }
         }
         
         try await oidcClientConfig.oidcInitialize()
         
         let pkce = Pkce.generate()
-        let httpClient = oidcClientConfig.httpClient!
+        let httpClient = try XCTUnwrap(oidcClientConfig.httpClient, "HTTP client should be configured")
         var request = httpClient.request()
         
         do {
@@ -258,26 +270,25 @@ final class OidcClientPARTests: XCTestCase {
     func testPopulateRequestPARMissingRequestUri() async throws {
         oidcClientConfig.par = true
         
-        MockURLProtocol.requestHandler = { request in
-            switch request.url!.path {
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
             case MockAPIEndpoint.discovery.url.path:
-                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+                return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, headers: MockResponse.headers), OidcClientPARTests.openIdConfigurationWithPAR)
             case OidcClientPARTests.parEndpointURL.path:
                 // PAR endpoint returns 200 but without request_uri
-                let badResponse = """
+                let badResponse = Data("""
                 {"expires_in": 60}
-                """.data(using: .utf8)!
-                return (HTTPURLResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, badResponse)
+                """.utf8)
+                return (try mockResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 200, headers: MockResponse.headers), badResponse)
             default:
-                XCTFail("Unexpected request: \(request.url!.path)")
-                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+                return try unexpectedResponse(for: request)
             }
         }
         
         try await oidcClientConfig.oidcInitialize()
         
         let pkce = Pkce.generate()
-        let httpClient = oidcClientConfig.httpClient!
+        let httpClient = try XCTUnwrap(oidcClientConfig.httpClient, "HTTP client should be configured")
         var request = httpClient.request()
         
         do {
@@ -296,21 +307,20 @@ final class OidcClientPARTests: XCTestCase {
         // PAR is enabled but discovery does NOT include PAR endpoint
         oidcClientConfig.par = true
         
-        MockURLProtocol.requestHandler = { request in
-            switch request.url!.path {
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
             case MockAPIEndpoint.discovery.url.path:
                 // Standard discovery without PAR endpoint
-                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, MockResponse.openIdConfiguration)
+                return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, headers: MockResponse.headers), MockResponse.openIdConfiguration)
             default:
-                XCTFail("Unexpected request: \(request.url!.path)")
-                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+                return try unexpectedResponse(for: request)
             }
         }
         
         try await oidcClientConfig.oidcInitialize()
         
         let pkce = Pkce.generate()
-        let httpClient = oidcClientConfig.httpClient!
+        let httpClient = try XCTUnwrap(oidcClientConfig.httpClient, "HTTP client should be configured")
         var request = httpClient.request()
         
         request = try await oidcClientConfig.populateRequest(request: request, pkce: pkce, responseMode: "pi.flow")
@@ -319,7 +329,7 @@ final class OidcClientPARTests: XCTestCase {
         XCTAssertEqual(MockURLProtocol.requestHistory.count, 1)
         
         // Falls back to standard flow
-        let authorizeUrl = request.url!
+        let authorizeUrl = try XCTUnwrap(request.url, "Populated request should have a URL")
         XCTAssertTrue(authorizeUrl.contains("client_id=test-client"))
         XCTAssertTrue(authorizeUrl.contains("response_type=code"))
         XCTAssertTrue(authorizeUrl.contains("code_challenge="))
@@ -331,15 +341,14 @@ final class OidcClientPARTests: XCTestCase {
     func testGenerateAuthorizeUrlWithPAR() async throws {
         oidcClientConfig.par = true
         
-        MockURLProtocol.requestHandler = { request in
-            switch request.url!.path {
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
             case MockAPIEndpoint.discovery.url.path:
-                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+                return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, headers: MockResponse.headers), OidcClientPARTests.openIdConfigurationWithPAR)
             case OidcClientPARTests.parEndpointURL.path:
-                return (HTTPURLResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 201, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.parResponse)
+                return (try mockResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 201, headers: MockResponse.headers), OidcClientPARTests.parResponse)
             default:
-                XCTFail("Unexpected request: \(request.url!.path)")
-                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+                return try unexpectedResponse(for: request)
             }
         }
         
@@ -357,15 +366,14 @@ final class OidcClientPARTests: XCTestCase {
     func testGenerateAuthorizeUrlWithPARAndCustomParams() async throws {
         oidcClientConfig.par = true
         
-        MockURLProtocol.requestHandler = { request in
-            switch request.url!.path {
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
             case MockAPIEndpoint.discovery.url.path:
-                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+                return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, headers: MockResponse.headers), OidcClientPARTests.openIdConfigurationWithPAR)
             case OidcClientPARTests.parEndpointURL.path:
-                return (HTTPURLResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 201, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.parResponse)
+                return (try mockResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 201, headers: MockResponse.headers), OidcClientPARTests.parResponse)
             default:
-                XCTFail("Unexpected request: \(request.url!.path)")
-                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+                return try unexpectedResponse(for: request)
             }
         }
         
@@ -385,22 +393,21 @@ final class OidcClientPARTests: XCTestCase {
         oidcClientConfig.loginHint = "user@example.com"
         oidcClientConfig.nonce = "test-nonce"
         
-        MockURLProtocol.requestHandler = { request in
-            switch request.url!.path {
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
             case MockAPIEndpoint.discovery.url.path:
-                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+                return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, headers: MockResponse.headers), OidcClientPARTests.openIdConfigurationWithPAR)
             case OidcClientPARTests.parEndpointURL.path:
-                return (HTTPURLResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 201, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.parResponse)
+                return (try mockResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 201, headers: MockResponse.headers), OidcClientPARTests.parResponse)
             default:
-                XCTFail("Unexpected request: \(request.url!.path)")
-                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+                return try unexpectedResponse(for: request)
             }
         }
         
         try await oidcClientConfig.oidcInitialize()
         
         let pkce = Pkce.generate()
-        let httpClient = oidcClientConfig.httpClient!
+        let httpClient = try XCTUnwrap(oidcClientConfig.httpClient, "HTTP client should be configured")
         var request = httpClient.request()
         
         request = try await oidcClientConfig.populateRequest(request: request, pkce: pkce, responseMode: "pi.flow")
@@ -413,7 +420,7 @@ final class OidcClientPARTests: XCTestCase {
         XCTAssertTrue(parBody.contains("nonce=test-nonce"), "PAR body should contain nonce")
         
         // Verify the authorize URL only has the minimal params
-        let authorizeUrl = request.url!
+        let authorizeUrl = try XCTUnwrap(request.url, "Populated request should have a URL")
         XCTAssertFalse(authorizeUrl.contains("acr_values="), "Authorize URL should NOT contain acr_values when PAR is used")
         XCTAssertFalse(authorizeUrl.contains("login_hint="), "Authorize URL should NOT contain login_hint when PAR is used")
         XCTAssertFalse(authorizeUrl.contains("nonce="), "Authorize URL should NOT contain nonce when PAR is used")
@@ -425,24 +432,23 @@ final class OidcClientPARTests: XCTestCase {
     /// defaulting to the PKCE-generated state when the integrator did not set
     /// `OidcClientConfig.state` explicitly.
     func testStandardFlowAlwaysSendsStateDefaultingToPkceState() async throws {
-        MockURLProtocol.requestHandler = { request in
-            switch request.url!.path {
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
             case MockAPIEndpoint.discovery.url.path:
-                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+                return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, headers: MockResponse.headers), OidcClientPARTests.openIdConfigurationWithPAR)
             default:
-                XCTFail("Unexpected request: \(request.url!.path)")
-                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+                return try unexpectedResponse(for: request)
             }
         }
         
         try await oidcClientConfig.oidcInitialize()
         
         let pkce = Pkce.generate()
-        let httpClient = oidcClientConfig.httpClient!
+        let httpClient = try XCTUnwrap(oidcClientConfig.httpClient, "HTTP client should be configured")
         var request = httpClient.request()
         request = try await oidcClientConfig.populateRequest(request: request, pkce: pkce, responseMode: "pi.flow")
         
-        let authorizeUrl = request.url!
+        let authorizeUrl = try XCTUnwrap(request.url, "Populated request should have a URL")
         XCTAssertTrue(authorizeUrl.contains("state=\(pkce.state)"), "Authorize URL should contain state=<pkce.state>")
     }
     
@@ -451,24 +457,23 @@ final class OidcClientPARTests: XCTestCase {
     func testStandardFlowConfigStateOverridesPkceState() async throws {
         oidcClientConfig.state = "integrator-state"
         
-        MockURLProtocol.requestHandler = { request in
-            switch request.url!.path {
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
             case MockAPIEndpoint.discovery.url.path:
-                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+                return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, headers: MockResponse.headers), OidcClientPARTests.openIdConfigurationWithPAR)
             default:
-                XCTFail("Unexpected request: \(request.url!.path)")
-                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+                return try unexpectedResponse(for: request)
             }
         }
         
         try await oidcClientConfig.oidcInitialize()
         
         let pkce = Pkce.generate()
-        let httpClient = oidcClientConfig.httpClient!
+        let httpClient = try XCTUnwrap(oidcClientConfig.httpClient, "HTTP client should be configured")
         var request = httpClient.request()
         request = try await oidcClientConfig.populateRequest(request: request, pkce: pkce, responseMode: "pi.flow")
         
-        let authorizeUrl = request.url!
+        let authorizeUrl = try XCTUnwrap(request.url, "Populated request should have a URL")
         XCTAssertTrue(authorizeUrl.contains("state=integrator-state"), "Authorize URL should use integrator-supplied state")
         XCTAssertFalse(authorizeUrl.contains("state=\(pkce.state)"), "Authorize URL should NOT fall back to pkce.state when config.state is set")
     }
@@ -478,22 +483,21 @@ final class OidcClientPARTests: XCTestCase {
     func testPARFlowSendsStateInPARBodyDefaultingToPkceState() async throws {
         oidcClientConfig.par = true
         
-        MockURLProtocol.requestHandler = { request in
-            switch request.url!.path {
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
             case MockAPIEndpoint.discovery.url.path:
-                return (HTTPURLResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.openIdConfigurationWithPAR)
+                return (try mockResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200, headers: MockResponse.headers), OidcClientPARTests.openIdConfigurationWithPAR)
             case OidcClientPARTests.parEndpointURL.path:
-                return (HTTPURLResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 201, httpVersion: nil, headerFields: MockResponse.headers)!, OidcClientPARTests.parResponse)
+                return (try mockResponse(url: OidcClientPARTests.parEndpointURL, statusCode: 201, headers: MockResponse.headers), OidcClientPARTests.parResponse)
             default:
-                XCTFail("Unexpected request: \(request.url!.path)")
-                return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+                return try unexpectedResponse(for: request)
             }
         }
         
         try await oidcClientConfig.oidcInitialize()
         
         let pkce = Pkce.generate()
-        let httpClient = oidcClientConfig.httpClient!
+        let httpClient = try XCTUnwrap(oidcClientConfig.httpClient, "HTTP client should be configured")
         var request = httpClient.request()
         request = try await oidcClientConfig.populateRequest(request: request, pkce: pkce, responseMode: "pi.flow")
         
@@ -503,7 +507,7 @@ final class OidcClientPARTests: XCTestCase {
         
         // The authorize URL after PAR carries only request_uri/client_id/response_mode,
         // so state should NOT leak into it.
-        let authorizeUrl = request.url!
+        let authorizeUrl = try XCTUnwrap(request.url, "Populated request should have a URL")
         XCTAssertFalse(authorizeUrl.contains("state="), "Authorize URL should NOT contain state when PAR is used")
     }
 }

--- a/Oidc/README.md
+++ b/Oidc/README.md
@@ -98,6 +98,28 @@ config.display = "test"
 let ping = OidcClient(config: config)
 ```
 
+## Pushed Authorization Requests (PAR)
+
+`PingOidc` supports [Pushed Authorization Requests (RFC 9126)](https://datatracker.ietf.org/doc/html/rfc9126). When PAR is enabled, authorization parameters are sent to the server via a POST request to the `pushed_authorization_request_endpoint` before the authorization redirect. The server returns a `request_uri` which is then used in the authorization URL instead of the full set of parameters.
+
+To enable PAR, set the `par` property to `true` in the OIDC configuration:
+
+```swift
+let oidcLogin = OidcWebClient.createOidcWebClient { config in
+    config.module(PingOidc.OidcModule.config) { oidcValue in
+        oidcValue.clientId = "ClientID"
+        oidcValue.scopes = ["openid", "email", "address", "profile", "phone"]
+        oidcValue.redirectUri = "org.forgerock.demo://oauth2redirect"
+        oidcValue.discoveryEndpoint = "https://example.com/.well-known/openid-configuration"
+        oidcValue.par = true // Enable Pushed Authorization Requests
+    }
+}
+```
+
+**Requirements:**
+- The server's OpenID configuration (discovery document) must include a `pushed_authorization_request_endpoint`.
+- If `par` is enabled but the discovery document does not include the PAR endpoint, the SDK falls back to the standard authorization flow automatically.
+
 ## Custom Agent
 
 You can also provide a custom agent to launch the authorization request.

--- a/Protect/Protect.xcodeproj/project.pbxproj
+++ b/Protect/Protect.xcodeproj/project.pbxproj
@@ -380,7 +380,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = "2.0.0";
+				MARKETING_VERSION = 2.0.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pingidentity.Protect;
@@ -416,7 +416,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = "2.0.0";
+				MARKETING_VERSION = 2.0.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pingidentity.Protect;
@@ -565,7 +565,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				MARKETING_VERSION = "2.0.0";
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pingidentity.ProtectTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -582,7 +582,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				MARKETING_VERSION = "2.0.0";
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pingidentity.ProtectTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;

--- a/SampleApps/PingExample/PingExample/ConfigurationEditorView.swift
+++ b/SampleApps/PingExample/PingExample/ConfigurationEditorView.swift
@@ -28,6 +28,7 @@ struct ConfigurationEditorView: View {
     @State private var serverUrl: String = ""
     @State private var realm: String = ""
     @State private var acrValues: String = ""
+    @State private var par: Bool = false
     
     @State private var showValidationError = false
     @State private var validationMessage = ""
@@ -137,6 +138,19 @@ struct ConfigurationEditorView: View {
                 // MARK: - Advanced
                 editorSection(header: "ADVANCED") {
                     labeledField("ACR Values", text: $acrValues, field: .acrValues)
+                    
+                    VStack(alignment: .leading, spacing: 6) {
+                        Toggle(isOn: $par) {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("PAR (Pushed Authorization Request)")
+                                    .font(.system(size: 14, weight: .medium))
+                                Text("RFC 9126 — Push authorization parameters to the server before authorization")
+                                    .font(.system(size: 11))
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        .tint(.blue)
+                    }
                 }
             }
             .padding(.horizontal, 20)
@@ -246,6 +260,7 @@ struct ConfigurationEditorView: View {
         serverUrl = config.serverUrl ?? ""
         realm = config.realm ?? ""
         acrValues = config.acrValues ?? ""
+        par = config.par ?? false
     }
     
     private func save() {
@@ -303,7 +318,8 @@ struct ConfigurationEditorView: View {
             cookieName: cookieName.isEmpty ? nil : cookieName.trimmingCharacters(in: .whitespaces),
             serverUrl: serverUrl.isEmpty ? nil : serverUrl.trimmingCharacters(in: .whitespaces),
             realm: realm.isEmpty ? nil : realm.trimmingCharacters(in: .whitespaces),
-            acrValues: acrValues.isEmpty ? nil : acrValues.trimmingCharacters(in: .whitespaces)
+            acrValues: acrValues.isEmpty ? nil : acrValues.trimmingCharacters(in: .whitespaces),
+            par: par
         )
         
         if let existing = editingConfig {

--- a/SampleApps/PingExample/PingExample/ConfigurationManager.swift
+++ b/SampleApps/PingExample/PingExample/ConfigurationManager.swift
@@ -210,6 +210,7 @@ class ConfigurationManager: ObservableObject {
                 oidcValue.discoveryEndpoint = config.discoveryEndpoint
                 oidcValue.storage = KeychainStorage<Token>(account: "ACCESS_TOKEN_STORAGE_JOURNEY")
                 oidcValue.logger = LogManager.standard
+                oidcValue.par = config.par ?? false
             }
         }
     }
@@ -224,6 +225,7 @@ class ConfigurationManager: ObservableObject {
                 oidcValue.discoveryEndpoint = config.discoveryEndpoint
                 oidcValue.acrValues = config.acrValues ?? ""
                 oidcValue.storage = KeychainStorage<Token>(account: "ACCESS_TOKEN_STORAGE_DAVINCI")
+                oidcValue.par = config.par ?? false
             }
         }
     }
@@ -240,6 +242,7 @@ class ConfigurationManager: ObservableObject {
                 oidcValue.discoveryEndpoint = config.discoveryEndpoint
                 oidcValue.acrValues = config.acrValues ?? ""
                 oidcValue.storage = KeychainStorage<Token>(account: "ACCESS_TOKEN_STORAGE_OIDCWEB")
+                oidcValue.par = config.par ?? false
             }
         }
     }

--- a/SampleApps/PingExample/PingExample/ConfigurationViewModel.swift
+++ b/SampleApps/PingExample/PingExample/ConfigurationViewModel.swift
@@ -32,6 +32,8 @@ struct Configuration: Codable, Sendable {
     var serverUrl: String?
     var realm: String?
     var acrValues: String?
+    /// Enable PAR (Pushed Authorization Request) RFC 9126.
+    var par: Bool?
     
     /// Whether this configuration is a bundled default (immutable in the UI).
     var isDefault: Bool {


### PR DESCRIPTION
# JIRA Ticket

[JIRA](https://bugster.forgerock.org/jira/browse/SDKS-4235) "Implementation of PAR"

# Description

## Overview
This PR introduces support for **Pushed Authorization Requests (PAR, RFC 9126)** across the OIDC, DaVinci, and Journey modules. 

When enabled, authorization parameters are securely pushed to the authorization server via a backend POST request rather than being exposed in the frontend redirect URI. This enhances security and prevents URL length issues for complex authorization requests.

## Key Changes
* **OIDC Module Core:** * Added `pushedAuthorizationRequestEndpoint` to `OpenIdConfiguration` parsing.
  * Introduced a `par: Bool` toggle in `OidcClientConfig` (defaults to `false`).
  * Refactored `OidcClient.swift` to support `buildAuthorizeParams`, allowing parameter sharing between standard and PAR flows.
  * Created an async `populateRequest` method that conditionally hits the PAR endpoint, retrieves the `request_uri`, and constructs a secure authorization URL.
* **DaVinci & Journey SDKs:** * Updated modules to seamlessly support the new async `populateRequest` flow.
* **Sample Apps (`PingExample`):** * Added a UI toggle in the Configuration Editor to easily test PAR flows.
* **Testing:** * Added comprehensive unit and integration tests (`DaVinciPARTests.swift`, `OidcClientPARTests.swift`, and additions to `OidcAdditionalTests.swift`) to verify happy paths, missing endpoints, and API failures.

## Fallback Behavior
If PAR is enabled in the configuration but the OpenID discovery document does not contain a `pushed_authorization_request_endpoint`, the SDK will gracefully fall back to the standard authorization flow.

## Reviewer Notes
* The legacy synchronous `populateRequest` remains intact for backward compatibility.

# Checklist:

- [X] I ran all unit tests and they pass
- [X] I added test case coverage for my changes
