### PR TITLE
SDKS-5015 Fixing PIN verification

### DIFF
--- a/Binding/Binding/Authenticator/AppPinAuthenticator.swift
+++ b/Binding/Binding/Authenticator/AppPinAuthenticator.swift
@@ -88,9 +88,20 @@ public class AppPinAuthenticator: DefaultDeviceAuthenticator {
             
             var item: CFTypeRef?
             let status = SecItemCopyMatching(query as CFDictionary, &item)
-            
+
             if status == errSecSuccess, let keyItem = item {
-                return .success(keyItem as! SecKey)
+                // SecItemCopyMatching only returns a key reference — the .applicationPassword
+                // ACL is evaluated lazily when the key is used. Force that evaluation here by
+                // performing a throwaway signature with the user-supplied PIN context, so a
+                // wrong PIN fails immediately instead of appearing to succeed.
+                let key = keyItem as! SecKey
+                var sigError: Unmanaged<CFError>?
+                let probe = Data("verify".utf8) as CFData
+                if SecKeyCreateSignature(key, .ecdsaSignatureMessageX962SHA256, probe, &sigError) != nil {
+                    return .success(key)
+                }
+                config.logger?.w("PIN verification failed for key \(keyTag). Retrying...",
+                                 error: sigError?.takeRetainedValue() as? Error)
             } else {
                 config.logger?.w("Failed to retrieve key with tag \(keyTag). Retrying...", error: nil)
             }

--- a/Binding/Binding/PingBinding.swift
+++ b/Binding/Binding/PingBinding.swift
@@ -57,17 +57,21 @@ class Binding {
         // Generate a new key pair and authenticate the user.
         let keyPair = try await deviceAuthenticator.register()
         let authResult = await deviceAuthenticator.authenticate(keyTag: keyPair.keyTag)
-        
+
         switch authResult {
         case .success:
             // Capture biometric domain state for biometricAllowFallback authenticators
             let biometricState: Data? = (deviceAuthenticator as? BiometricDeviceCredentialAuthenticator)?.biometricDomainState()
-            
+
             // Store the new user key.
             let newUserKey = UserKey(keyTag: keyPair.keyTag, userId: callback.userId, username: callback.userName, kid: keyPair.keyTag, authType: callback.deviceBindingAuthenticationType, biometricDomainState: biometricState)
-            
+
             try await userKeyStorage.save(userKey: newUserKey)
         case .failure(let error):
+            // The key-pair was created by register() but post-register authentication
+            // failed (e.g. a mismatched PIN on the verify prompt). Delete the orphan
+            // Keychain entry so repeated failed attempts don't accumulate.
+            try? CryptoKey(keyTag: keyPair.keyTag).deleteKeyPair()
             throw error
         }
         


### PR DESCRIPTION
# JIRA Ticket

[JIRA](https://bugster.forgerock.org/jira/browse/SDKS-5015) "When registering a new PIN for device binding the second (verify) prompt accepts any PIN entered"

# Description

// SecItemCopyMatching only returns a key reference — the .applicationPassword
                // ACL is evaluated lazily when the key is used. Force that evaluation here by
                // performing a throwaway signature with the user-supplied PIN context, so a
                // wrong PIN fails immediately instead of appearing to succeed.

# Checklist:

- [X] I ran all unit tests and they pass
- [X] I added test case coverage for my changes
