### PR TITLE
SDKS-4924 Add Logger to FIDO module                 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,14 @@ SampleApps/PingExample/PingExample/ConfigurationManager_LOCAL_78086.swift
 SampleApps/PingExample/PingExample/ConfigurationManager_REMOTE_78086.swift
 /Android/
 GEMINI.MD
+
+# Local agent / planning artefacts (not shipped with the SDK)
+.claude/
+ai-tasks/
+CLAUDE.md
+AGENTS.md
+.github/copilot-instructions.md
+
+# Merge / Finder leftovers
+*.orig
+**/* copy.xcodeproj/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+#### Added
+- Routed FIDO ceremony logs through the workflow logger by adding a `logger:` parameter to `Fido.register` and `Fido.authenticate`. The DaVinci collectors and Journey callbacks pass the workflow's configured logger so FIDO ceremony state transitions and errors emit through the same logger as the surrounding flow [SDKS-4924]
+
 ## [2.0.0]
 #### Added
 - Added new `PingJourney` module [SDKS-3918]

--- a/Fido/Fido.xcodeproj/project.pbxproj
+++ b/Fido/Fido.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		EC5C81B42ECF6DE400C91570 /* PingDavinciPlugin.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EC5C81B22ECF6DE400C91570 /* PingDavinciPlugin.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		EC5C81F82ED0920300C91570 /* PingJourney.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC5C81F72ED0920300C91570 /* PingJourney.framework */; };
 		EC5C81F92ED0920300C91570 /* PingJourney.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EC5C81F72ED0920300C91570 /* PingJourney.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		ECD780722EA251010050E60F /* PingDavinci.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 955861222EB0657300DD55A6 /* PingDavinci.framework */; };
 		ECA2E7DE2ED740E000C32766 /* FidoRegistrationCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA2E7DD2ED740E000C32766 /* FidoRegistrationCollectorTests.swift */; };
 		ECA2E7DF2ED740E000C32766 /* FidoAuthenticationCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA2E7DC2ED740E000C32766 /* FidoAuthenticationCollectorTests.swift */; };
 		ECD5A2F72E8FE49C00A27205 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = ECD5A2F62E8FE49C00A27205 /* PrivacyInfo.xcprivacy */; };
@@ -126,6 +127,7 @@
 			files = (
 				ECD7804A2EA24F1B0050E60F /* PingFido.framework in Frameworks */,
 				EC5C81F82ED0920300C91570 /* PingJourney.framework in Frameworks */,
+				ECD780722EA251010050E60F /* PingDavinci.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Fido/Fido.xcodeproj/project.pbxproj
+++ b/Fido/Fido.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		ECD780602EA24FFA0050E60F /* FidoCallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD780512EA24FC40050E60F /* FidoCallbackTests.swift */; };
 		ECD780612EA24FFF0050E60F /* FidoCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD780522EA24FC40050E60F /* FidoCollectorTests.swift */; };
 		ECD780642EA2500E0050E60F /* Mocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD780552EA24FC40050E60F /* Mocks.swift */; };
+		ECD780712EA251000050E60F /* FidoLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD780702EA251000050E60F /* FidoLoggerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -105,6 +106,7 @@
 		ECD780522EA24FC40050E60F /* FidoCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FidoCollectorTests.swift; sourceTree = "<group>"; };
 		ECD780552EA24FC40050E60F /* Mocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mocks.swift; sourceTree = "<group>"; };
 		ECD780562EA24FC40050E60F /* PingFidoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PingFidoTests.swift; sourceTree = "<group>"; };
+		ECD780702EA251000050E60F /* FidoLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FidoLoggerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -208,6 +210,7 @@
 				ECA2E7DD2ED740E000C32766 /* FidoRegistrationCollectorTests.swift */,
 				ECD780512EA24FC40050E60F /* FidoCallbackTests.swift */,
 				ECD780522EA24FC40050E60F /* FidoCollectorTests.swift */,
+				ECD780702EA251000050E60F /* FidoLoggerTests.swift */,
 				ECD780552EA24FC40050E60F /* Mocks.swift */,
 				ECD780562EA24FC40050E60F /* PingFidoTests.swift */,
 			);
@@ -354,6 +357,7 @@
 				ECD780612EA24FFF0050E60F /* FidoCollectorTests.swift in Sources */,
 				ECD780602EA24FFA0050E60F /* FidoCallbackTests.swift in Sources */,
 				ECD780642EA2500E0050E60F /* Mocks.swift in Sources */,
+				ECD780712EA251000050E60F /* FidoLoggerTests.swift in Sources */,
 				ECA2E7DE2ED740E000C32766 /* FidoRegistrationCollectorTests.swift in Sources */,
 				ECA2E7DF2ED740E000C32766 /* FidoAuthenticationCollectorTests.swift in Sources */,
 			);

--- a/Fido/Fido/Davinci/AbstractFidoCollector.swift
+++ b/Fido/Fido/Davinci/AbstractFidoCollector.swift
@@ -2,7 +2,7 @@
 //  AbstractFidoCollector.swift
 //  Fido
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Fido/Fido/Davinci/AbstractFidoCollector.swift
+++ b/Fido/Fido/Davinci/AbstractFidoCollector.swift
@@ -54,8 +54,8 @@ public class AbstractFidoCollector: AnyFieldCollector, DaVinciAware, Submittable
     public var davinci: DaVinci?
     
     /// The logger for recording Fido related events.
-    public var logger: Logger? {
-        return davinci?.config.logger
+    public var logger: Logger {
+        return davinci?.config.logger ?? LogManager.logger
     }
     
     /// Private storage for the Fido instance
@@ -100,31 +100,31 @@ public class AbstractFidoCollector: AnyFieldCollector, DaVinciAware, Submittable
     /// - Parameter error: The error to handle and transform.
     /// - Returns: A transformed `FidoError` that is more human-readable and spec-compliant.
     public func handleError(error: Error) -> FidoError {
-        logger?.e("Handling FIDO error: \(error.localizedDescription)", error: error)
+        logger.e("Handling FIDO error: \(error.localizedDescription)", error: error)
         
         // Check if it's a FidoError first
         if let fidoError = error as? FidoError {
             switch fidoError {
             case .timeout:
-                logger?.d("FIDO operation timed out")
+                logger.d("FIDO operation timed out")
                 return .timeout
             case .unsupportedAction(let message):
-                logger?.d("FIDO ERROR NOT SUPPORTED: \(message)")
+                logger.d("FIDO ERROR NOT SUPPORTED: \(message)")
                 return .unsupportedAction(message)
             case .invalidResponse:
-                logger?.d("FIDO invalid response")
+                logger.d("FIDO invalid response")
                 return .invalidResponse
             case .invalidChallenge:
-                logger?.d("FIDO invalid challenge")
+                logger.d("FIDO invalid challenge")
                 return .invalidChallenge
             case .invalidWindow:
-                logger?.d("FIDO invalid window")
+                logger.d("FIDO invalid window")
                 return .invalidWindow
             case .invalidAction:
-                logger?.d("FIDO invalid action")
+                logger.d("FIDO invalid action")
                 return .invalidAction
             case .missingParameters(let message):
-                logger?.d("FIDO missing parameters: \(message)")
+                logger.d("FIDO missing parameters: \(message)")
                 return .missingParameters(message)
             }
         }
@@ -135,23 +135,23 @@ public class AbstractFidoCollector: AnyFieldCollector, DaVinciAware, Submittable
         case ASAuthorizationError.errorDomain:
             switch nsError.code {
             case ASAuthorizationError.canceled.rawValue:
-                logger?.d("Credential operation cancelled")
+                logger.d("Credential operation cancelled")
                 return .unsupportedAction(FidoConstants.ERROR_NOT_ALLOWED_MESSAGE)
             case ASAuthorizationError.invalidResponse.rawValue:
-                logger?.d("DOM exception occurred: InvalidStateError")
+                logger.d("DOM exception occurred: InvalidStateError")
                 return .invalidResponse
             case ASAuthorizationError.notHandled.rawValue:
-                logger?.d("DOM exception occurred: NotSupportedError")
+                logger.d("DOM exception occurred: NotSupportedError")
                 return .unsupportedAction("Operation not supported")
             case ASAuthorizationError.unknown.rawValue:
-                logger?.d("Unknown error occurred")
+                logger.d("Unknown error occurred")
                 return .unsupportedAction("Unknown error: \(error.localizedDescription)")
             default:
-                logger?.d("Unknown authorization error occurred")
+                logger.d("Unknown authorization error occurred")
                 return .unsupportedAction("Unknown error: \(error.localizedDescription)")
             }
         default:
-            logger?.d("Unknown error occurred")
+            logger.d("Unknown error occurred")
             return .unsupportedAction("Unknown error: \(error.localizedDescription)")
         }
     }

--- a/Fido/Fido/Davinci/FidoAuthenticationCollector.swift
+++ b/Fido/Fido/Davinci/FidoAuthenticationCollector.swift
@@ -73,7 +73,9 @@ public class FidoAuthenticationCollector: AbstractFidoCollector, Closeable, @unc
             // 1. Wrap the closure-based fido.authenticate in a continuation
             //    This still throws internally within the 'do' block if the continuation resumes with an error.
             let response: [String: Any] = try await withUnsafeThrowingContinuation { continuation in
-                // Assuming 'fido' instance is accessible
+                // Propagate the workflow logger into the FIDO instance so the underlying
+                // ASAuthorization ceremony emits log messages through the same logger.
+                fido.logger = logger
                 fido.authenticate(options: publicKeyCredentialRequestOptions, window: window) { [continuation] result in
                     Task {
                         await MainActor.run {

--- a/Fido/Fido/Davinci/FidoAuthenticationCollector.swift
+++ b/Fido/Fido/Davinci/FidoAuthenticationCollector.swift
@@ -73,10 +73,9 @@ public class FidoAuthenticationCollector: AbstractFidoCollector, Closeable, @unc
             // 1. Wrap the closure-based fido.authenticate in a continuation
             //    This still throws internally within the 'do' block if the continuation resumes with an error.
             let response: [String: Any] = try await withUnsafeThrowingContinuation { continuation in
-                // Propagate the workflow logger into the FIDO instance so the underlying
-                // ASAuthorization ceremony emits log messages through the same logger.
-                fido.logger = logger
-                fido.authenticate(options: publicKeyCredentialRequestOptions, window: window) { [continuation] result in
+                // Pass the workflow logger so the underlying ASAuthorization ceremony
+                // emits log messages through the same logger as the surrounding flow.
+                fido.authenticate(options: publicKeyCredentialRequestOptions, window: window, logger: logger) { [continuation] result in
                     Task {
                         await MainActor.run {
                             nonisolated(unsafe) let sendableResult = result

--- a/Fido/Fido/Davinci/FidoAuthenticationCollector.swift
+++ b/Fido/Fido/Davinci/FidoAuthenticationCollector.swift
@@ -36,13 +36,13 @@ public class FidoAuthenticationCollector: AbstractFidoCollector, Closeable, @unc
     /// - Throws: An error if the required `publicKeyCredentialRequestOptions` parameter is missing from the JSON.
     required public init(with json: [String : Any]) {
         super.init(with: json)
-        logger?.d("Initializing Fido authentication collector")
+        logger.d("Initializing Fido authentication collector")
         guard let options = json[FidoConstants.FIELD_PUBLIC_KEY_CREDENTIAL_REQUEST_OPTIONS] as? [String: Any] else {
-            logger?.e("Missing \(FidoConstants.FIELD_PUBLIC_KEY_CREDENTIAL_REQUEST_OPTIONS)", error: nil)
+            logger.e("Missing \(FidoConstants.FIELD_PUBLIC_KEY_CREDENTIAL_REQUEST_OPTIONS)", error: nil)
             return
         }
         self.publicKeyCredentialRequestOptions = self.transform(options)
-        logger?.d("Fido authentication collector initialized with request options")
+        logger.d("Fido authentication collector initialized with request options")
     }
     
     /// The payload to be sent to the DaVinci server.
@@ -50,10 +50,10 @@ public class FidoAuthenticationCollector: AbstractFidoCollector, Closeable, @unc
     /// - Returns: A dictionary containing the assertion value, or `nil` if authentication has not been completed.
     override public func payload() -> [String: Any]? {
         guard let assertionValue = assertionValue else {
-            logger?.d("No assertion value available, returning null payload")
+            logger.d("No assertion value available, returning null payload")
             return nil
         }
-        logger?.d("Returning assertion payload for Fido authentication")
+        logger.d("Returning assertion payload for Fido authentication")
         return [FidoConstants.FIELD_ASSERTION_VALUE: assertionValue]
     }
     
@@ -67,7 +67,7 @@ public class FidoAuthenticationCollector: AbstractFidoCollector, Closeable, @unc
     /// - Throws: An error if the authentication process fails or the response is invalid.
     @MainActor
     public func authenticate(window: ASPresentationAnchor) async -> Result<[String: Any], Error> {
-        logger?.d("Starting FIDO authentication (async Result)")
+        logger.d("Starting FIDO authentication (async Result)")
         
         do {
             // 1. Wrap the closure-based fido.authenticate in a continuation
@@ -86,7 +86,7 @@ public class FidoAuthenticationCollector: AbstractFidoCollector, Closeable, @unc
             }
             
             // 2. Process the successful response data extraction
-            logger?.d("FIDO authentication successful, building assertionValue object...")
+            logger.d("FIDO authentication successful, building assertionValue object...")
             
             guard let signatureData = response[FidoConstants.FIELD_SIGNATURE] as? Data,
                   let clientData = response[FidoConstants.FIELD_CLIENT_DATA_JSON] as? Data,
@@ -95,7 +95,7 @@ public class FidoAuthenticationCollector: AbstractFidoCollector, Closeable, @unc
                   let userHandleData = response[FidoConstants.FIELD_USER_HANDLE] as? Data else {
                 
                 let error = FidoError.invalidResponse
-                logger?.e(error.localizedDescription, error: error)
+                logger.e(error.localizedDescription, error: error)
                 let transformedError = self.handleError(error: error)
                 return .failure(transformedError) // Return failure with transformed error
             }
@@ -115,7 +115,7 @@ public class FidoAuthenticationCollector: AbstractFidoCollector, Closeable, @unc
                 ]
             ]
             
-            logger?.d("assertionValue object created successfully")
+            logger.d("assertionValue object created successfully")
             self.assertionValue = newAssertionValue // Store the value (side effect)
             
             // 4. Return success with the constructed assertionValue
@@ -123,7 +123,7 @@ public class FidoAuthenticationCollector: AbstractFidoCollector, Closeable, @unc
             
         } catch {
             // 5. Handle any error caught from the continuation
-            logger?.e("FIDO authentication failed", error: error)
+            logger.e("FIDO authentication failed", error: error)
             let transformedError = self.handleError(error: error)
             return .failure(transformedError) // Return failure with transformed error
         }
@@ -135,7 +135,7 @@ public class FidoAuthenticationCollector: AbstractFidoCollector, Closeable, @unc
     /// - Parameter input: The dictionary of options received from the server.
     /// - Returns: A transformed dictionary of options.
     private func transform(_ input: [String: Any]) -> [String: Any] {
-        logger?.d("Transforming FIDO authentication request options")
+        logger.d("Transforming FIDO authentication request options")
         var output = input
         
         if let challenge = output[FidoConstants.FIELD_CHALLENGE] as? [Int] {
@@ -160,7 +160,7 @@ public class FidoAuthenticationCollector: AbstractFidoCollector, Closeable, @unc
             output[FidoConstants.FIELD_ALLOW_CREDENTIALS] = updatedCredentials
         }
         
-        logger?.d("FIDO authentication request options transformed successfully")
+        logger.d("FIDO authentication request options transformed successfully")
         return output
     }
 }

--- a/Fido/Fido/Davinci/FidoRegistrationCollector.swift
+++ b/Fido/Fido/Davinci/FidoRegistrationCollector.swift
@@ -72,10 +72,9 @@ public class FidoRegistrationCollector: AbstractFidoCollector, Closeable, @unche
             // 1. Wrap the closure-based fido.register in a continuation
             //    This still throws internally within the 'do' block if the continuation resumes with an error.
             let response: [String: Any] = try await withUnsafeThrowingContinuation { continuation in
-                // Propagate the workflow logger into the FIDO instance so the underlying
-                // ASAuthorization ceremony emits log messages through the same logger.
-                fido.logger = logger
-                fido.register(options: publicKeyCredentialCreationOptions, window: window) { [continuation] result in
+                // Pass the workflow logger so the underlying ASAuthorization ceremony
+                // emits log messages through the same logger as the surrounding flow.
+                fido.register(options: publicKeyCredentialCreationOptions, window: window, logger: logger) { [continuation] result in
                     Task {
                         await MainActor.run {
                             nonisolated(unsafe) let sendableResult = result

--- a/Fido/Fido/Davinci/FidoRegistrationCollector.swift
+++ b/Fido/Fido/Davinci/FidoRegistrationCollector.swift
@@ -35,13 +35,13 @@ public class FidoRegistrationCollector: AbstractFidoCollector, Closeable, @unche
     /// - Throws: An error if the required `publicKeyCredentialCreationOptions` parameter is missing from the JSON.
     required public init(with json: [String : Any]) {
         super.init(with: json)
-        logger?.d("Initializing FIDO registration collector")
+        logger.d("Initializing FIDO registration collector")
         guard let options = json[FidoConstants.FIELD_PUBLIC_KEY_CREDENTIAL_CREATION_OPTIONS] as? [String: Any] else {
-            logger?.e("Missing \(FidoConstants.FIELD_PUBLIC_KEY_CREDENTIAL_CREATION_OPTIONS)", error: nil)
+            logger.e("Missing \(FidoConstants.FIELD_PUBLIC_KEY_CREDENTIAL_CREATION_OPTIONS)", error: nil)
             return
         }
         self.publicKeyCredentialCreationOptions = self.transform(options)
-        logger?.d("FIDO registration collector initialized with creation options")
+        logger.d("FIDO registration collector initialized with creation options")
     }
     
     /// The payload to be sent to the DaVinci server.
@@ -49,10 +49,10 @@ public class FidoRegistrationCollector: AbstractFidoCollector, Closeable, @unche
     /// - Returns: A dictionary containing the attestation value, or `nil` if registration has not been completed.
     override public func payload() -> [String: Any]? {
         guard let attestationValue = attestationValue else {
-            logger?.d("No attestation value available, returning null payload")
+            logger.d("No attestation value available, returning null payload")
             return nil
         }
-        logger?.d("Returning attestation payload for FIDO registration")
+        logger.d("Returning attestation payload for FIDO registration")
         return [FidoConstants.FIELD_ATTESTATION_VALUE: attestationValue]
     }
     
@@ -66,7 +66,7 @@ public class FidoRegistrationCollector: AbstractFidoCollector, Closeable, @unche
     /// - Throws: An error if the registration process fails or the response is invalid.
     @MainActor
     public func register(window: ASPresentationAnchor) async -> Result<[String: Any], Error> {
-        logger?.d("Starting FIDO registration (async Result)")
+        logger.d("Starting FIDO registration (async Result)")
         
         do {
             // 1. Wrap the closure-based fido.register in a continuation
@@ -85,14 +85,14 @@ public class FidoRegistrationCollector: AbstractFidoCollector, Closeable, @unche
             }
             
             // 2. Process the successful response data extraction
-            logger?.d("FIDO registration successful, building attestationValue object...")
+            logger.d("FIDO registration successful, building attestationValue object...")
             
             guard let rawIdData = response[FidoConstants.FIELD_RAW_ID] as? Data,
                   let clientDataJSONData = response[FidoConstants.FIELD_CLIENT_DATA_JSON] as? Data,
                   let attestationObjectData = response[FidoConstants.FIELD_ATTESTATION_OBJECT] as? Data else {
                 
                 let error = FidoError.invalidResponse
-                logger?.e(error.localizedDescription, error: error)
+                logger.e(error.localizedDescription, error: error)
                 let transformedError = self.handleError(error: error)
                 return .failure(transformedError) // Return failure with transformed error
             }
@@ -110,7 +110,7 @@ public class FidoRegistrationCollector: AbstractFidoCollector, Closeable, @unche
                 ]
             ]
             
-            logger?.d("attestationValue object created successfully")
+            logger.d("attestationValue object created successfully")
             self.attestationValue = newAttestationValue // Store the value (side effect)
             
             // 4. Return success with the constructed attestationValue
@@ -118,7 +118,7 @@ public class FidoRegistrationCollector: AbstractFidoCollector, Closeable, @unche
             
         } catch {
             // 5. Handle any error caught from the continuation
-            logger?.e("FIDO registration failed", error: error)
+            logger.e("FIDO registration failed", error: error)
             let transformedError = self.handleError(error: error)
             return .failure(transformedError) // Return failure with transformed error
         }
@@ -132,11 +132,11 @@ public class FidoRegistrationCollector: AbstractFidoCollector, Closeable, @unche
     /// - Parameter input: The dictionary of options received from the server.
     /// - Returns: A transformed dictionary of options.
     private func transform(_ input: [String: Any]) -> [String: Any] {
-        logger?.d("Transforming FIDO registration creation options")
+        logger.d("Transforming FIDO registration creation options")
         var output = input
         
         if let user = output[FidoConstants.FIELD_USER] as? [String: Any] {
-            logger?.d("User: \(user)")
+            logger.d("User: \(user)")
             if let userId = user[FidoConstants.FIELD_ID] as? [Int] {
                 var newUser = user
                 let data = Data(userId.map { UInt8(bitPattern: Int8($0)) })
@@ -146,7 +146,7 @@ public class FidoRegistrationCollector: AbstractFidoCollector, Closeable, @unche
         }
         
         if let challenge = output[FidoConstants.FIELD_CHALLENGE] as? [Int] {
-            logger?.d("Challenge: \(challenge)")
+            logger.d("Challenge: \(challenge)")
             let data = Data(challenge.map { UInt8(bitPattern: Int8($0)) })
             output[FidoConstants.FIELD_CHALLENGE] = data.base64EncodedString()
         }
@@ -159,7 +159,7 @@ public class FidoRegistrationCollector: AbstractFidoCollector, Closeable, @unche
         }
         
         if let excludeCredentials = output[FidoConstants.FIELD_EXCLUDE_CREDENTIALS] as? [[String: Any]] {
-            logger?.d("Exclude credentials: \(excludeCredentials)")
+            logger.d("Exclude credentials: \(excludeCredentials)")
             let updatedCredentials = excludeCredentials.map { credential -> [String: Any] in
                 var newCredential = credential
                 if let id = newCredential[FidoConstants.FIELD_ID] as? [Int] {
@@ -171,7 +171,7 @@ public class FidoRegistrationCollector: AbstractFidoCollector, Closeable, @unche
             output[FidoConstants.FIELD_EXCLUDE_CREDENTIALS] = updatedCredentials
         }
         
-        logger?.d("FIDO registration creation options transformed successfully")
+        logger.d("FIDO registration creation options transformed successfully")
         return output
     }
 }

--- a/Fido/Fido/Davinci/FidoRegistrationCollector.swift
+++ b/Fido/Fido/Davinci/FidoRegistrationCollector.swift
@@ -72,7 +72,9 @@ public class FidoRegistrationCollector: AbstractFidoCollector, Closeable, @unche
             // 1. Wrap the closure-based fido.register in a continuation
             //    This still throws internally within the 'do' block if the continuation resumes with an error.
             let response: [String: Any] = try await withUnsafeThrowingContinuation { continuation in
-                // Assuming 'fido' instance is accessible
+                // Propagate the workflow logger into the FIDO instance so the underlying
+                // ASAuthorization ceremony emits log messages through the same logger.
+                fido.logger = logger
                 fido.register(options: publicKeyCredentialCreationOptions, window: window) { [continuation] result in
                     Task {
                         await MainActor.run {

--- a/Fido/Fido/Fido.swift
+++ b/Fido/Fido/Fido.swift
@@ -14,21 +14,26 @@ import UIKit
 import PingLogger
 
 /// Fido is a class that provides FIDO registration and authentication functionalities.
+///
+/// `Fido` is single-flight: a registration or authentication ceremony retains state on the
+/// instance (window, completion handler, logger, timeout task) until the underlying
+/// `ASAuthorization` delegate callback or timeout fires. Concurrent ceremonies on the same
+/// instance will overwrite each other, which is why callers consume it through the
+/// `Fido.shared` singleton serialized by the surrounding workflow.
 public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
 
     /// The shared singleton FIDO instance.
     @MainActor
     public static let shared = Fido()
 
-    /// Logger instance used for debugging and monitoring FIDO operations.
-    /// Callers (e.g. the DaVinci collector or Journey callback) inject the logger
-    /// from their workflow configuration before invoking `register` or `authenticate`.
-    public var logger: Logger?
-
     var window: ASPresentationAnchor?
     var completion: ((Result<[String: Any], Error>) -> Void)?
     var timeoutTask: Task<Void, Never>?
     var authorizationController: ASAuthorizationController?
+
+    /// Logger for the in-flight ceremony. Set by `register`/`authenticate` and cleared in
+    /// `cleanup()`, so each ceremony uses its caller's workflow logger and nothing else.
+    var logger: Logger?
     
     func makeAuthorizationController(requests: [ASAuthorizationRequest]) -> ASAuthorizationController {
         let authorizationController = ASAuthorizationController(authorizationRequests: requests)
@@ -43,8 +48,13 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
     /// - Parameters:
     ///   - options: A dictionary containing the registration options.
     ///   - window: The window to present the registration UI in.
+    ///   - logger: Optional logger for ceremony state transitions and errors. Pass the
+    ///     workflow logger (e.g. `davinci?.config.logger`); when `nil` no log output is
+    ///     produced. Scoped to this call only — overwritten by subsequent ceremonies and
+    ///     cleared in `cleanup()`.
     ///   - completion: A closure to be called with the registration result.
-    public func register(options: [String: Any], window: ASPresentationAnchor, completion: @escaping (Result<[String: Any], Error>) -> Void) {
+    public func register(options: [String: Any], window: ASPresentationAnchor, logger: Logger? = nil, completion: @escaping (Result<[String: Any], Error>) -> Void) {
+        self.logger = logger
         logger?.d("Fido: Starting registration")
         self.window = window
         self.completion = completion
@@ -115,8 +125,13 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
     /// - Parameters:
     ///   - options: A dictionary containing the authentication options.
     ///   - window: The window to present the authentication UI in.
+    ///   - logger: Optional logger for ceremony state transitions and errors. Pass the
+    ///     workflow logger (e.g. `journey?.config.logger`); when `nil` no log output is
+    ///     produced. Scoped to this call only — overwritten by subsequent ceremonies and
+    ///     cleared in `cleanup()`.
     ///   - completion: A closure to be called with the authentication result.
-    public func authenticate(options: [String: Any], window: ASPresentationAnchor, completion: @escaping (Result<[String: Any], Error>) -> Void) {
+    public func authenticate(options: [String: Any], window: ASPresentationAnchor, logger: Logger? = nil, completion: @escaping (Result<[String: Any], Error>) -> Void) {
+        self.logger = logger
         logger?.d("Fido: Starting authentication")
         self.window = window
         self.completion = completion
@@ -245,6 +260,7 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
         authorizationController = nil
         window = nil
         completion = nil
+        logger = nil
         cancelTimeout()
     }
     

--- a/Fido/Fido/Fido.swift
+++ b/Fido/Fido/Fido.swift
@@ -33,7 +33,7 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
 
     /// Logger for the in-flight ceremony. Set by `register`/`authenticate` and cleared in
     /// `cleanup()`, so each ceremony uses its caller's workflow logger and nothing else.
-    var logger: Logger?
+    private var logger: Logger?
     
     func makeAuthorizationController(requests: [ASAuthorizationRequest]) -> ASAuthorizationController {
         let authorizationController = ASAuthorizationController(authorizationRequests: requests)
@@ -68,6 +68,7 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
             guard let challengeData = Data(base64Encoded: registrationOptions.challenge, options: .ignoreUnknownCharacters) else {
                 logger?.e("Fido: Registration failed - invalid challenge", error: nil)
                 completion(.failure(FidoError.invalidChallenge))
+                cleanup()
                 return
             }
             let userID = Data(registrationOptions.user.id.utf8)
@@ -103,6 +104,7 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
             if requests.isEmpty {
                 logger?.e("Fido: Registration failed - no suitable authentication methods available", error: nil)
                 completion(.failure(FidoError.unsupportedAction("No suitable authentication methods available")))
+                cleanup()
             } else {
                 // 4. Start timeout if specified
                 if let timeout = registrationOptions.timeout, timeout > 0 {
@@ -145,6 +147,7 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
             guard let challengeData = Data(base64Encoded: authenticationOptions.challenge, options: .ignoreUnknownCharacters) else {
                 logger?.e("Fido: Authentication failed - invalid challenge", error: nil)
                 completion(.failure(FidoError.invalidChallenge))
+                cleanup()
                 return
             }
             let assertionRequest = platformProvider.createCredentialAssertionRequest(challenge: challengeData)
@@ -223,9 +226,10 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
     private func startTimeout(milliseconds: Int) {
         // Cancel any existing timeout
         cancelTimeout()
-        
+
         let timeoutSeconds = Double(milliseconds) / 1000.0
-        
+        let capturedLogger = logger
+
         timeoutTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
 
@@ -234,7 +238,7 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
             await MainActor.run { [weak self] in
                 guard let self = self else { return }
 
-                logger?.d("Fido: Operation timed out after \(Int(timeoutSeconds))s")
+                capturedLogger?.d("Fido: Operation timed out after \(Int(timeoutSeconds))s")
 
                 // Cancel the authorization controller if still active
                 self.authorizationController?.cancel()

--- a/Fido/Fido/Fido.swift
+++ b/Fido/Fido/Fido.swift
@@ -11,14 +11,20 @@
 import Foundation
 import AuthenticationServices
 import UIKit
+import PingLogger
 
 /// Fido is a class that provides FIDO registration and authentication functionalities.
 public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
-    
+
     /// The shared singleton FIDO instance.
     @MainActor
     public static let shared = Fido()
-    
+
+    /// Logger instance used for debugging and monitoring FIDO operations.
+    /// Callers (e.g. the DaVinci collector or Journey callback) inject the logger
+    /// from their workflow configuration before invoking `register` or `authenticate`.
+    public var logger: Logger?
+
     var window: ASPresentationAnchor?
     var completion: ((Result<[String: Any], Error>) -> Void)?
     var timeoutTask: Task<Void, Never>?
@@ -39,21 +45,23 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
     ///   - window: The window to present the registration UI in.
     ///   - completion: A closure to be called with the registration result.
     public func register(options: [String: Any], window: ASPresentationAnchor, completion: @escaping (Result<[String: Any], Error>) -> Void) {
+        logger?.d("Fido: Starting registration")
         self.window = window
         self.completion = completion
-        
+
         do {
             // 1. Decode options
             let jsonData = try JSONSerialization.data(withJSONObject: options, options: [])
             let registrationOptions = try JSONDecoder().decode(PublicKeyCredentialCreationOptions.self, from: jsonData)
-            
+
             // 2. Prepare common parameters
             guard let challengeData = Data(base64Encoded: registrationOptions.challenge, options: .ignoreUnknownCharacters) else {
+                logger?.e("Fido: Registration failed - invalid challenge", error: nil)
                 completion(.failure(FidoError.invalidChallenge))
                 return
             }
             let userID = Data(registrationOptions.user.id.utf8)
-            
+
             // 3. Determine which requests to create based on selection criteria
             var requests: [ASAuthorizationRequest] = []
             let attachment = registrationOptions.authenticatorSelection?.authenticatorAttachment
@@ -70,7 +78,7 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
                 )
                 requests.append(platformRequest)
             }
-            
+
             // Add security key request if:
             // - Attachment is .crossPlatform OR nil (no preference)
             if attachment != .platform {
@@ -81,20 +89,23 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
                 )
                 requests.append(securityKeyRequest)
             }
-            
+
             if requests.isEmpty {
+                logger?.e("Fido: Registration failed - no suitable authentication methods available", error: nil)
                 completion(.failure(FidoError.unsupportedAction("No suitable authentication methods available")))
             } else {
                 // 4. Start timeout if specified
                 if let timeout = registrationOptions.timeout, timeout > 0 {
                     startTimeout(milliseconds: timeout)
                 }
-                
+
                 // 5. Perform requests
+                logger?.d("Fido: Performing registration requests (\(requests.count) request(s))")
                 let authorizationController = makeAuthorizationController(requests: requests)
                 authorizationController.performRequests()
             }
         } catch {
+            logger?.e("Fido: Registration failed", error: error)
             completion(.failure(error))
         }
     }
@@ -106,24 +117,26 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
     ///   - window: The window to present the authentication UI in.
     ///   - completion: A closure to be called with the authentication result.
     public func authenticate(options: [String: Any], window: ASPresentationAnchor, completion: @escaping (Result<[String: Any], Error>) -> Void) {
+        logger?.d("Fido: Starting authentication")
         self.window = window
         self.completion = completion
-        
+
         do {
             let jsonData = try JSONSerialization.data(withJSONObject: options, options: [])
             let authenticationOptions = try JSONDecoder().decode(PublicKeyCredentialRequestOptions.self, from: jsonData)
-            
+
             let platformProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: authenticationOptions.rpId ?? "")
-            
+
             guard let challengeData = Data(base64Encoded: authenticationOptions.challenge, options: .ignoreUnknownCharacters) else {
+                logger?.e("Fido: Authentication failed - invalid challenge", error: nil)
                 completion(.failure(FidoError.invalidChallenge))
                 return
             }
             let assertionRequest = platformProvider.createCredentialAssertionRequest(challenge: challengeData)
             assertionRequest.userVerificationPreference = ASAuthorizationPublicKeyCredentialUserVerificationPreference(rawValue: authenticationOptions.userVerification?.rawValue ?? "preferred")
-            
+
             var requests: [ASAuthorizationRequest] = [assertionRequest]
-            
+
             if let allowCredentials = authenticationOptions.allowCredentials, !allowCredentials.isEmpty {
                 let securityKeyProvider = ASAuthorizationSecurityKeyPublicKeyCredentialProvider(relyingPartyIdentifier: authenticationOptions.rpId ?? "")
                 let securityKeyRequest = securityKeyProvider.createCredentialAssertionRequest(challenge: challengeData)
@@ -132,20 +145,22 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
                     guard let idData = Data(base64Encoded: cred.id) else {
                         return nil
                     }
-                    
+
                     return ASAuthorizationSecurityKeyPublicKeyCredentialDescriptor(credentialID: idData, transports: [])
                 }
                 requests.append(securityKeyRequest)
             }
-            
+
             // Start timeout if specified
             if let timeout = authenticationOptions.timeout, timeout > 0 {
                 startTimeout(milliseconds: timeout)
             }
-            
+
+            logger?.d("Fido: Performing authentication requests (\(requests.count) request(s))")
             let authorizationController = makeAuthorizationController(requests: requests)
             authorizationController.performRequests()
         } catch {
+            logger?.e("Fido: Authentication failed", error: error)
             completion(.failure(error))
         }
     }
@@ -168,16 +183,18 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
     ///   - controller: The authorization controller.
     ///   - authorization: The authorization object containing the credential.
     public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        logger?.d("Fido: Authorization completed successfully")
         cancelTimeout()
         didComplete(with: authorization.credential)
     }
-    
+
     /// Handles the completion of an authorization request with an error.
     ///
     /// - Parameters:
     ///   - controller: The authorization controller.
     ///   - error: The error that occurred.
     public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        logger?.e("Fido: Authorization failed", error: error)
         cancelTimeout()
         completion?(.failure(error))
         cleanup()
@@ -196,19 +213,21 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
         
         timeoutTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
-            
+
             guard !Task.isCancelled else { return }
-            
+
             await MainActor.run { [weak self] in
                 guard let self = self else { return }
-                
+
+                logger?.d("Fido: Operation timed out after \(Int(timeoutSeconds))s")
+
                 // Cancel the authorization controller if still active
                 self.authorizationController?.cancel()
-                
+
                 // Call completion with timeout error
                 let timeoutError = FidoError.timeout
                 self.completion?(.failure(timeoutError))
-                
+
                 // Clean up
                 self.cleanup()
             }
@@ -321,6 +340,7 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
     func didComplete(with credential: ASAuthorizationCredential) {
         switch credential {
         case let credential as ASAuthorizationPublicKeyCredentialRegistration:
+            logger?.d("Fido: Processing registration credential")
             // Determine authenticator attachment type
             var attachmentValue: String = FidoConstants.FIELD_AUTHENTICATOR_ATTACHMENT_PLATFORM
             if let registrationCredential = credential as? ASAuthorizationPlatformPublicKeyCredentialRegistration {
@@ -344,6 +364,7 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
             completion?(.success(result))
             cleanup()
         case let credential as ASAuthorizationPublicKeyCredentialAssertion:
+            logger?.d("Fido: Processing authentication credential")
             // Determine authenticator attachment type for assertion
             var attachmentValue: String = FidoConstants.FIELD_AUTHENTICATOR_ATTACHMENT_PLATFORM
             if let assertionCredential = credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion {

--- a/Fido/Fido/Journey/FidoAuthenticationCallback.swift
+++ b/Fido/Fido/Journey/FidoAuthenticationCallback.swift
@@ -49,10 +49,9 @@ public class FidoAuthenticationCallback: FidoCallback, @unchecked Sendable {
             // 1. Wrap the closure-based fido.authenticate in a continuation
             //    This still throws internally within the 'do' block if the continuation resumes with an error.
             let response: [String: Any] = try await withUnsafeThrowingContinuation { continuation in
-                // Propagate the workflow logger into the FIDO instance so the underlying
-                // ASAuthorization ceremony emits log messages through the same logger.
-                fido.logger = logger
-                fido.authenticate(options: publicKeyCredentialRequestOptions, window: window) { [continuation] result in
+                // Pass the workflow logger so the underlying ASAuthorization ceremony
+                // emits log messages through the same logger as the surrounding flow.
+                fido.authenticate(options: publicKeyCredentialRequestOptions, window: window, logger: logger) { [continuation] result in
                     Task {
                         await MainActor.run {
                             nonisolated(unsafe) let sendableResult = result

--- a/Fido/Fido/Journey/FidoAuthenticationCallback.swift
+++ b/Fido/Fido/Journey/FidoAuthenticationCallback.swift
@@ -30,10 +30,10 @@ public class FidoAuthenticationCallback: FidoCallback, @unchecked Sendable {
     ///   - value: The value of the property.
     public override func initValue(name: String, value: Any) {
         if name == FidoConstants.FIELD_DATA, let data = value as? [String: Any] {
-            logger?.d("Processing FIDO authentication data")
+            logger.d("Processing FIDO authentication data")
             supportsJsonResponse = data[FidoConstants.FIELD_SUPPORTS_JSON_RESPONSE] as? Bool ?? false
             publicKeyCredentialRequestOptions = transform(data)
-            logger?.d("FIDO authentication callback initialized successfully")
+            logger.d("FIDO authentication callback initialized successfully")
         }
     }
     
@@ -43,7 +43,7 @@ public class FidoAuthenticationCallback: FidoCallback, @unchecked Sendable {
     /// - Throws: An error if the authentication process fails.
     @MainActor
     public func authenticate(window: ASPresentationAnchor) async -> Result<[String: Any], Error> {
-        logger?.d("Starting FIDO authentication (async Result)")
+        logger.d("Starting FIDO authentication (async Result)")
         
         do {
             // 1. Wrap the closure-based fido.authenticate in a continuation
@@ -62,7 +62,7 @@ public class FidoAuthenticationCallback: FidoCallback, @unchecked Sendable {
             }
             
             // 2. Handle the successful response data extraction
-            self.logger?.d("FIDO authentication successful, processing response...")
+            self.logger.d("FIDO authentication successful, processing response...")
             
             guard let signatureData = response[FidoConstants.FIELD_SIGNATURE] as? Data,
                   let clientData = response[FidoConstants.FIELD_CLIENT_DATA_JSON] as? Data,
@@ -71,7 +71,7 @@ public class FidoAuthenticationCallback: FidoCallback, @unchecked Sendable {
                   let userHandleData = response[FidoConstants.FIELD_USER_HANDLE] as? Data else {
                 
                 let error = FidoError.invalidResponse // Define your error type
-                self.logger?.e(error.localizedDescription, error: error)
+                self.logger.e(error.localizedDescription, error: error)
                 self.handleError(error: error) // Keep existing error handling side-effect
                 return .failure(error) // Return failure
             }
@@ -99,13 +99,13 @@ public class FidoAuthenticationCallback: FidoCallback, @unchecked Sendable {
                 } else {
                     // Handle potential JSON serialization error if needed
                     callbackValue = ""
-                    logger?.w("Failed to serialize FIDO JSON response", error: nil)
+                    logger.w("Failed to serialize FIDO JSON response", error: nil)
                 }
             } else {
                 callbackValue = legacyData
             }
             
-            self.logger?.d("Setting authentication callback value")
+            self.logger.d("Setting authentication callback value")
             self.valueCallback(value: callbackValue) // Perform side effect
             
             // 4. Return success with the original response dictionary
@@ -113,7 +113,7 @@ public class FidoAuthenticationCallback: FidoCallback, @unchecked Sendable {
             
         } catch {
             // 5. Handle any error caught from the continuation
-            self.logger?.e("FIDO authentication failed", error: error)
+            self.logger.e("FIDO authentication failed", error: error)
             self.handleError(error: error) // Keep existing error handling side-effect
             return .failure(error) // Return failure
         }
@@ -126,7 +126,7 @@ public class FidoAuthenticationCallback: FidoCallback, @unchecked Sendable {
     /// - Parameter input: The input dictionary containing FIDO authentication options.
     /// - Returns: A transformed dictionary suitable for FIDO authentication.
     func transform(_ input: [String: Any]) -> [String: Any] {
-        logger?.d("Transforming FIDO authentication request options")
+        logger.d("Transforming FIDO authentication request options")
         var output: [String: Any] = [:]
         
         if let challenge = input[FidoConstants.FIELD_CHALLENGE] as? String {

--- a/Fido/Fido/Journey/FidoAuthenticationCallback.swift
+++ b/Fido/Fido/Journey/FidoAuthenticationCallback.swift
@@ -49,7 +49,9 @@ public class FidoAuthenticationCallback: FidoCallback, @unchecked Sendable {
             // 1. Wrap the closure-based fido.authenticate in a continuation
             //    This still throws internally within the 'do' block if the continuation resumes with an error.
             let response: [String: Any] = try await withUnsafeThrowingContinuation { continuation in
-                // Assuming 'fido' instance is accessible
+                // Propagate the workflow logger into the FIDO instance so the underlying
+                // ASAuthorization ceremony emits log messages through the same logger.
+                fido.logger = logger
                 fido.authenticate(options: publicKeyCredentialRequestOptions, window: window) { [continuation] result in
                     Task {
                         await MainActor.run {

--- a/Fido/Fido/Journey/FidoCallback.swift
+++ b/Fido/Fido/Journey/FidoCallback.swift
@@ -28,8 +28,8 @@ public class FidoCallback: AbstractCallback, JourneyAware, ContinueNodeAware, @u
     public var journey: Journey?
     
     /// Logger instance for this callback, obtained from the workflow configuration.
-    public var logger: Logger? {
-        return journey?.config.logger
+    public var logger: Logger {
+        return journey?.config.logger ?? LogManager.logger
     }
     
     /// Private storage for the Fido instance
@@ -51,11 +51,11 @@ public class FidoCallback: AbstractCallback, JourneyAware, ContinueNodeAware, @u
     ///
     /// - Parameter value: The value to set for the WebAuthn outcome.
     public func valueCallback(value: String) {
-        logger?.d("Setting WebAuthn outcome value")
+        logger.d("Setting WebAuthn outcome value")
         if let valueCallback = continueNode?.callbacks.first(where: { ($0 as? ValueCallbackProtocol)?.valueId == FidoConstants.WEB_AUTHN_OUTCOME }) as? ValueCallbackProtocol {
             valueCallback.setValue(value)
         } else {
-            logger?.w("WebAuthn outcome callback not found", error: nil)
+            logger.w("WebAuthn outcome callback not found", error: nil)
         }
     }
     
@@ -64,17 +64,17 @@ public class FidoCallback: AbstractCallback, JourneyAware, ContinueNodeAware, @u
     /// This method converts `ASAuthorizationError` codes into error messages that the Journey server can process.
     /// - Parameter error: The error to handle and convert.
     public func handleError(error: Error) {
-        logger?.e("Handling FIDO error: \(error.localizedDescription)", error: error)
+        logger.e("Handling FIDO error: \(error.localizedDescription)", error: error)
         
         // Check if it's a FidoError first
         if let fidoError = error as? FidoError {
             switch fidoError {
             case .timeout:
-                logger?.d("FIDO operation timed out")
+                logger.d("FIDO operation timed out")
                 setError(error: FidoConstants.ERROR_TIMEOUT, message: "Operation timedout")
                 return
             case .unsupportedAction(let message):
-                logger?.d("FIDO ERROR NOT SUPPORTED: \(message)")
+                logger.d("FIDO ERROR NOT SUPPORTED: \(message)")
                 setError(error: FidoConstants.ERROR_NOT_SUPPORTED, message: message)
                 return
             default:
@@ -88,23 +88,23 @@ public class FidoCallback: AbstractCallback, JourneyAware, ContinueNodeAware, @u
         case ASAuthorizationError.errorDomain:
             switch nsError.code {
             case ASAuthorizationError.canceled.rawValue:
-                logger?.d("Credential creation cancelled")
+                logger.d("Credential creation cancelled")
                 setError(error: FidoConstants.ERROR_NOT_ALLOWED, message: FidoConstants.ERROR_NOT_ALLOWED_MESSAGE)
             case ASAuthorizationError.invalidResponse.rawValue:
-                logger?.d("DOM exception occurred: InvalidStateError")
+                logger.d("DOM exception occurred: InvalidStateError")
                 setError(error: FidoConstants.ERROR_INVALID_STATE, message: error.localizedDescription)
             case ASAuthorizationError.notHandled.rawValue:
-                logger?.d("DOM exception occurred: NotSupportedError")
+                logger.d("DOM exception occurred: NotSupportedError")
                 setError(error: FidoConstants.ERROR_NOT_SUPPORTED, message: error.localizedDescription)
             case ASAuthorizationError.unknown.rawValue:
-                logger?.d("Unknown error occurred")
+                logger.d("Unknown error occurred")
                 setError(error: FidoConstants.ERROR_UNKNOWN, message: error.localizedDescription)
             default:
-                logger?.d("Unknown error occurred")
+                logger.d("Unknown error occurred")
                 setError(error: FidoConstants.ERROR_UNKNOWN, message: error.localizedDescription)
             }
         default:
-            logger?.d("Unknown error occurred")
+            logger.d("Unknown error occurred")
             setError(error: FidoConstants.ERROR_UNKNOWN, message: error.localizedDescription)
         }
     }
@@ -115,13 +115,13 @@ public class FidoCallback: AbstractCallback, JourneyAware, ContinueNodeAware, @u
     ///  - error: The error type or code.
     ///  - message: A descriptive message about the error.
     private func setError(error: String?, message: String?) {
-        logger?.d("Setting error - type: \(error ?? "nil"), message: \(message ?? "nil")")
+        logger.d("Setting error - type: \(error ?? "nil"), message: \(message ?? "nil")")
         if let valueCallback = continueNode?.callbacks.first(where: { ($0 as? ValueCallbackProtocol)?.valueId == FidoConstants.WEB_AUTHN_OUTCOME }) as? ValueCallbackProtocol {
             let errorValue = "\(FidoConstants.ERROR_PREFIX)\(error ?? ""):\(message ?? "")"
-            logger?.d("Setting error value: \(errorValue)")
+            logger.d("Setting error value: \(errorValue)")
             valueCallback.setValue(errorValue)
         } else {
-            logger?.e("WebAuthn outcome callback not found for error setting", error: nil)
+            logger.e("WebAuthn outcome callback not found for error setting", error: nil)
         }
     }
 }

--- a/Fido/Fido/Journey/FidoCallback.swift
+++ b/Fido/Fido/Journey/FidoCallback.swift
@@ -2,7 +2,7 @@
 //  FidoCallback.swift
 //  Fido
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/Fido/Fido/Journey/FidoRegistrationCallback.swift
+++ b/Fido/Fido/Journey/FidoRegistrationCallback.swift
@@ -30,10 +30,10 @@ public class FidoRegistrationCallback: FidoCallback, @unchecked Sendable {
     ///   - value: The value of the property.
     public override func initValue(name: String, value: Any) {
         if name == FidoConstants.FIELD_DATA, let data = value as? [String: Any] {
-            logger?.d("Processing FIDO registration data")
+            logger.d("Processing FIDO registration data")
             supportsJsonResponse = data[FidoConstants.FIELD_SUPPORTS_JSON_RESPONSE] as? Bool ?? false
             publicKeyCredentialCreationOptions = transform(data)
-            logger?.d("FIDO registration callback initialized successfully")
+            logger.d("FIDO registration callback initialized successfully")
         }
     }
     
@@ -45,7 +45,7 @@ public class FidoRegistrationCallback: FidoCallback, @unchecked Sendable {
     /// - Throws: An error if the registration process fails.
     @MainActor
     public func register(deviceName: String? = nil, window: ASPresentationAnchor) async -> Result<[String: Any], Error> {
-        logger?.d("Starting FIDO registration with device name: \(deviceName ?? "nil") (async Result)")
+        logger.d("Starting FIDO registration with device name: \(deviceName ?? "nil") (async Result)")
         
         do {
             // 1. Wrap the closure-based fido.register in a continuation
@@ -64,13 +64,13 @@ public class FidoRegistrationCallback: FidoCallback, @unchecked Sendable {
             }
             
             // 2. Handle the successful response data extraction
-            self.logger?.d("FIDO registration successful, processing response...")
+            self.logger.d("FIDO registration successful, processing response...")
             guard let rawAttestationObject = response[FidoConstants.FIELD_ATTESTATION_OBJECT] as? Data,
                   let rawClientDataJSON = response[FidoConstants.FIELD_CLIENT_DATA_JSON] as? Data,
                   let rawIdData = response[FidoConstants.FIELD_RAW_ID] as? Data else {
                 
                 let error = FidoError.invalidResponse // Define your error type
-                self.logger?.e(error.localizedDescription, error: error)
+                self.logger.e(error.localizedDescription, error: error)
                 self.handleError(error: error) // Keep existing error handling side-effect
                 return .failure(error) // Return failure
             }
@@ -101,13 +101,13 @@ public class FidoRegistrationCallback: FidoCallback, @unchecked Sendable {
                     // Handle potential JSON serialization error if needed, maybe return failure?
                     // For now, setting empty string as before.
                     callbackValue = ""
-                    logger?.w("Failed to serialize FIDO JSON response", error: nil)
+                    logger.w("Failed to serialize FIDO JSON response", error: nil)
                 }
             } else {
                 callbackValue = finalData
             }
             
-            self.logger?.d("Setting registration callback value")
+            self.logger.d("Setting registration callback value")
             self.valueCallback(value: callbackValue) // Perform side effect
             
             // 4. Return success with the original response dictionary
@@ -115,7 +115,7 @@ public class FidoRegistrationCallback: FidoCallback, @unchecked Sendable {
             
         } catch {
             // 5. Handle any error caught from the continuation
-            self.logger?.e("FIDO registration failed", error: error)
+            self.logger.e("FIDO registration failed", error: error)
             self.handleError(error: error) // Keep existing error handling side-effect
             return .failure(error) // Return failure
         }
@@ -128,7 +128,7 @@ public class FidoRegistrationCallback: FidoCallback, @unchecked Sendable {
     /// - Parameter input: The input dictionary containing FIDO registration options.
     /// - Returns: A transformed dictionary suitable for FIDO registration.
     func transform(_ input: [String: Any]) -> [String: Any] {
-        logger?.d("Transforming FIDO registration creation options")
+        logger.d("Transforming FIDO registration creation options")
         var output: [String: Any] = [:]
         
         if let challenge = input[FidoConstants.FIELD_CHALLENGE] as? String {

--- a/Fido/Fido/Journey/FidoRegistrationCallback.swift
+++ b/Fido/Fido/Journey/FidoRegistrationCallback.swift
@@ -51,10 +51,9 @@ public class FidoRegistrationCallback: FidoCallback, @unchecked Sendable {
             // 1. Wrap the closure-based fido.register in a continuation
             //    This still throws internally within the 'do' block if the continuation resumes with an error.
             let response: [String: Any] = try await withUnsafeThrowingContinuation { continuation in
-                // Propagate the workflow logger into the FIDO instance so the underlying
-                // ASAuthorization ceremony emits log messages through the same logger.
-                fido.logger = logger
-                fido.register(options: publicKeyCredentialCreationOptions, window: window) { [continuation] result in
+                // Pass the workflow logger so the underlying ASAuthorization ceremony
+                // emits log messages through the same logger as the surrounding flow.
+                fido.register(options: publicKeyCredentialCreationOptions, window: window, logger: logger) { [continuation] result in
                     Task {
                         await MainActor.run {
                             nonisolated(unsafe) let safeResult = result

--- a/Fido/Fido/Journey/FidoRegistrationCallback.swift
+++ b/Fido/Fido/Journey/FidoRegistrationCallback.swift
@@ -51,7 +51,9 @@ public class FidoRegistrationCallback: FidoCallback, @unchecked Sendable {
             // 1. Wrap the closure-based fido.register in a continuation
             //    This still throws internally within the 'do' block if the continuation resumes with an error.
             let response: [String: Any] = try await withUnsafeThrowingContinuation { continuation in
-                // Assuming 'fido' instance is accessible
+                // Propagate the workflow logger into the FIDO instance so the underlying
+                // ASAuthorization ceremony emits log messages through the same logger.
+                fido.logger = logger
                 fido.register(options: publicKeyCredentialCreationOptions, window: window) { [continuation] result in
                     Task {
                         await MainActor.run {

--- a/Fido/PingFidoTests/FidoLoggerTests.swift
+++ b/Fido/PingFidoTests/FidoLoggerTests.swift
@@ -25,12 +25,11 @@ final class FidoLoggerTests: XCTestCase {
         let mockLogger = MockFidoLogger()
         let fido = Fido()
 
-        // The challenge below contains '!' characters that are non-base64. Combined with
-        // .ignoreUnknownCharacters this still leaves an odd-length input that cannot be
-        // decoded, so the invalid-challenge guard fires and `register` returns
-        // synchronously without launching an ASAuthorization ceremony.
+        // "a" is a single valid base64 character. After stripping unknown characters,
+        // the length (1) has remainder 1 mod 4, which Data(base64Encoded:) cannot decode
+        // — it returns nil, causing the invalidChallenge guard to fire synchronously.
         let options: [String: Any] = [
-            "challenge": "!!!not-valid-base64!!!",
+            "challenge": "a",
             "rp": ["id": "example.com", "name": "Example"],
             "user": ["id": "userId", "name": "user", "displayName": "User"],
             "pubKeyCredParams": [["type": "public-key", "alg": -7]]
@@ -51,7 +50,7 @@ final class FidoLoggerTests: XCTestCase {
 
         // See note in testRegisterRoutesLogsThroughInjectedLogger about the challenge string.
         let options: [String: Any] = [
-            "challenge": "!!!not-valid-base64!!!",
+            "challenge": "a",
             "rpId": "example.com",
             "userVerification": "preferred"
         ]
@@ -66,9 +65,10 @@ final class FidoLoggerTests: XCTestCase {
     }
 
     func testNoLoggerInjectedDoesNotCrash() {
+        let mockLogger = MockFidoLogger()
         let fido = Fido()
         let options: [String: Any] = [
-            "challenge": "!!!not-valid-base64!!!",
+            "challenge": "a",
             "rpId": "example.com"
         ]
         let exp = expectation(description: "completion called")
@@ -76,6 +76,8 @@ final class FidoLoggerTests: XCTestCase {
             exp.fulfill()
         }
         wait(for: [exp], timeout: 1.0)
+
+        XCTAssertFalse(mockLogger.hasMessages, "No logger injected — mock logger should have received no calls")
     }
 
     // MARK: - Collector / Callback propagation
@@ -99,7 +101,7 @@ final class FidoLoggerTests: XCTestCase {
 
         _ = await collector.register(window: MockASPresentationAnchor())
 
-        XCTAssertTrue(mockFido.capturedLogger as AnyObject? === mockLogger,
+        XCTAssertTrue(mockFido.capturedLogger as? MockFidoLogger === mockLogger,
                       "Collector must pass the DaVinci config logger to fido.register")
     }
 
@@ -119,7 +121,7 @@ final class FidoLoggerTests: XCTestCase {
 
         _ = await collector.authenticate(window: MockASPresentationAnchor())
 
-        XCTAssertTrue(mockFido.capturedLogger as AnyObject? === mockLogger,
+        XCTAssertTrue(mockFido.capturedLogger as? MockFidoLogger === mockLogger,
                       "Collector must pass the DaVinci config logger to fido.authenticate")
     }
 
@@ -140,7 +142,7 @@ final class FidoLoggerTests: XCTestCase {
 
         _ = await callback.register(window: MockASPresentationAnchor())
 
-        XCTAssertTrue(mockFido.capturedLogger as AnyObject? === mockLogger,
+        XCTAssertTrue(mockFido.capturedLogger as? MockFidoLogger === mockLogger,
                       "Callback must pass the Journey config logger to fido.register")
     }
 
@@ -161,7 +163,7 @@ final class FidoLoggerTests: XCTestCase {
 
         _ = await callback.authenticate(window: MockASPresentationAnchor())
 
-        XCTAssertTrue(mockFido.capturedLogger as AnyObject? === mockLogger,
+        XCTAssertTrue(mockFido.capturedLogger as? MockFidoLogger === mockLogger,
                       "Callback must pass the Journey config logger to fido.authenticate")
     }
 }

--- a/Fido/PingFidoTests/FidoLoggerTests.swift
+++ b/Fido/PingFidoTests/FidoLoggerTests.swift
@@ -1,0 +1,101 @@
+//
+//  FidoLoggerTests.swift
+//  PingFidoTests
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+@testable import PingFido
+@testable import PingLogger
+
+final class FidoLoggerTests: XCTestCase {
+
+    func testLoggerDefaultsToNil() {
+        let fido = Fido()
+        XCTAssertNil(fido.logger, "Fido.logger should default to nil so callers opt in")
+    }
+
+    func testRegisterRoutesLogsThroughInjectedLogger() {
+        let mockLogger = MockFidoLogger()
+        let fido = Fido()
+        fido.logger = mockLogger
+
+        let options: [String: Any] = [
+            "challenge": "!!!not-valid-base64!!!",
+            "rp": ["id": "example.com", "name": "Example"],
+            "user": ["id": "userId", "name": "user", "displayName": "User"],
+            "pubKeyCredParams": [["type": "public-key", "alg": -7]]
+        ]
+        let exp = expectation(description: "completion called")
+        fido.register(options: options, window: MockASPresentationAnchor()) { _ in
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+
+        XCTAssertTrue(mockLogger.hasMessages, "Expected register to emit log messages through the injected logger")
+        XCTAssertTrue(mockLogger.messages.contains { $0.level == "e" }, "Expected an error-level log for the invalid challenge")
+    }
+
+    func testAuthenticateRoutesLogsThroughInjectedLogger() {
+        let mockLogger = MockFidoLogger()
+        let fido = Fido()
+        fido.logger = mockLogger
+
+        let options: [String: Any] = [
+            "challenge": "!!!not-valid-base64!!!",
+            "rpId": "example.com",
+            "userVerification": "preferred"
+        ]
+        let exp = expectation(description: "completion called")
+        fido.authenticate(options: options, window: MockASPresentationAnchor()) { _ in
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+
+        XCTAssertTrue(mockLogger.hasMessages, "Expected authenticate to emit log messages through the injected logger")
+        XCTAssertTrue(mockLogger.messages.contains { $0.level == "e" }, "Expected an error-level log for the invalid challenge")
+    }
+
+    func testNoLoggerInjectedDoesNotCrash() {
+        let fido = Fido()
+        XCTAssertNil(fido.logger)
+
+        let options: [String: Any] = [
+            "challenge": "!!!not-valid-base64!!!",
+            "rpId": "example.com"
+        ]
+        let exp = expectation(description: "completion called")
+        fido.authenticate(options: options, window: MockASPresentationAnchor()) { _ in
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+    }
+}
+
+final class MockFidoLogger: Logger, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _messages: [(level: String, message: String)] = []
+
+    var messages: [(level: String, message: String)] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _messages
+    }
+
+    var hasMessages: Bool { !messages.isEmpty }
+
+    private func append(_ level: String, _ message: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        _messages.append((level: level, message: message))
+    }
+
+    func i(_ message: String) { append("i", message) }
+    func d(_ message: String) { append("d", message) }
+    func w(_ message: String, error: Error?) { append("w", message) }
+    func e(_ message: String, error: Error?) { append("e", message) }
+}

--- a/Fido/PingFidoTests/FidoLoggerTests.swift
+++ b/Fido/PingFidoTests/FidoLoggerTests.swift
@@ -11,19 +11,24 @@
 import XCTest
 @testable import PingFido
 @testable import PingLogger
+@testable import PingJourneyPlugin
+@testable import PingJourney
+@testable import PingDavinci
+@testable import PingOrchestrate
+internal import PingCommons
 
 final class FidoLoggerTests: XCTestCase {
 
-    func testLoggerDefaultsToNil() {
-        let fido = Fido()
-        XCTAssertNil(fido.logger, "Fido.logger should default to nil so callers opt in")
-    }
+    // MARK: - Fido direct API
 
     func testRegisterRoutesLogsThroughInjectedLogger() {
         let mockLogger = MockFidoLogger()
         let fido = Fido()
-        fido.logger = mockLogger
 
+        // The challenge below contains '!' characters that are non-base64. Combined with
+        // .ignoreUnknownCharacters this still leaves an odd-length input that cannot be
+        // decoded, so the invalid-challenge guard fires and `register` returns
+        // synchronously without launching an ASAuthorization ceremony.
         let options: [String: Any] = [
             "challenge": "!!!not-valid-base64!!!",
             "rp": ["id": "example.com", "name": "Example"],
@@ -31,7 +36,7 @@ final class FidoLoggerTests: XCTestCase {
             "pubKeyCredParams": [["type": "public-key", "alg": -7]]
         ]
         let exp = expectation(description: "completion called")
-        fido.register(options: options, window: MockASPresentationAnchor()) { _ in
+        fido.register(options: options, window: MockASPresentationAnchor(), logger: mockLogger) { _ in
             exp.fulfill()
         }
         wait(for: [exp], timeout: 1.0)
@@ -43,15 +48,15 @@ final class FidoLoggerTests: XCTestCase {
     func testAuthenticateRoutesLogsThroughInjectedLogger() {
         let mockLogger = MockFidoLogger()
         let fido = Fido()
-        fido.logger = mockLogger
 
+        // See note in testRegisterRoutesLogsThroughInjectedLogger about the challenge string.
         let options: [String: Any] = [
             "challenge": "!!!not-valid-base64!!!",
             "rpId": "example.com",
             "userVerification": "preferred"
         ]
         let exp = expectation(description: "completion called")
-        fido.authenticate(options: options, window: MockASPresentationAnchor()) { _ in
+        fido.authenticate(options: options, window: MockASPresentationAnchor(), logger: mockLogger) { _ in
             exp.fulfill()
         }
         wait(for: [exp], timeout: 1.0)
@@ -62,8 +67,6 @@ final class FidoLoggerTests: XCTestCase {
 
     func testNoLoggerInjectedDoesNotCrash() {
         let fido = Fido()
-        XCTAssertNil(fido.logger)
-
         let options: [String: Any] = [
             "challenge": "!!!not-valid-base64!!!",
             "rpId": "example.com"
@@ -73,6 +76,93 @@ final class FidoLoggerTests: XCTestCase {
             exp.fulfill()
         }
         wait(for: [exp], timeout: 1.0)
+    }
+
+    // MARK: - Collector / Callback propagation
+    //
+    // These tests guard the four call sites that pass `logger:` into the underlying Fido
+    // instance. Removing the propagation in any of them must fail a test here.
+
+    @MainActor
+    func testFidoRegistrationCollectorPropagatesWorkflowLoggerToFido() async {
+        let mockLogger = MockFidoLogger()
+        let mockFido = MockFido()
+        let davinci = DaVinci.createDaVinci { config in
+            config.logger = mockLogger
+        }
+        let collector = FidoRegistrationCollector(with: [
+            FidoConstants.FIELD_PUBLIC_KEY_CREDENTIAL_CREATION_OPTIONS: ["rp": ["name": "test"]]
+        ])
+        collector.davinci = davinci
+        collector.fido = mockFido
+        mockFido.registrationResult = .failure(FidoError.invalidChallenge)
+
+        _ = await collector.register(window: MockASPresentationAnchor())
+
+        XCTAssertTrue(mockFido.capturedLogger as AnyObject? === mockLogger,
+                      "Collector must pass the DaVinci config logger to fido.register")
+    }
+
+    @MainActor
+    func testFidoAuthenticationCollectorPropagatesWorkflowLoggerToFido() async {
+        let mockLogger = MockFidoLogger()
+        let mockFido = MockFido()
+        let davinci = DaVinci.createDaVinci { config in
+            config.logger = mockLogger
+        }
+        let collector = FidoAuthenticationCollector(with: [
+            FidoConstants.FIELD_PUBLIC_KEY_CREDENTIAL_REQUEST_OPTIONS: ["challenge": "test"]
+        ])
+        collector.davinci = davinci
+        collector.fido = mockFido
+        mockFido.authenticationResult = .failure(FidoError.invalidChallenge)
+
+        _ = await collector.authenticate(window: MockASPresentationAnchor())
+
+        XCTAssertTrue(mockFido.capturedLogger as AnyObject? === mockLogger,
+                      "Collector must pass the DaVinci config logger to fido.authenticate")
+    }
+
+    @MainActor
+    func testFidoRegistrationCallbackPropagatesWorkflowLoggerToFido() async {
+        let mockLogger = MockFidoLogger()
+        let mockFido = MockFido()
+        let journey = Journey.createJourney { config in
+            config.logger = mockLogger
+        }
+        let callback = FidoRegistrationCallback()
+        let hiddenValueCallback = HiddenValueCallback()
+        hiddenValueCallback.initValue(name: JourneyConstants.id, value: FidoConstants.WEB_AUTHN_OUTCOME)
+        callback.journey = journey
+        callback.continueNode = MockContinueNode(callbacks: Callbacks([hiddenValueCallback]))
+        callback.fido = mockFido
+        mockFido.registrationResult = .failure(FidoError.invalidChallenge)
+
+        _ = await callback.register(window: MockASPresentationAnchor())
+
+        XCTAssertTrue(mockFido.capturedLogger as AnyObject? === mockLogger,
+                      "Callback must pass the Journey config logger to fido.register")
+    }
+
+    @MainActor
+    func testFidoAuthenticationCallbackPropagatesWorkflowLoggerToFido() async {
+        let mockLogger = MockFidoLogger()
+        let mockFido = MockFido()
+        let journey = Journey.createJourney { config in
+            config.logger = mockLogger
+        }
+        let callback = FidoAuthenticationCallback()
+        let hiddenValueCallback = HiddenValueCallback()
+        hiddenValueCallback.initValue(name: JourneyConstants.id, value: FidoConstants.WEB_AUTHN_OUTCOME)
+        callback.journey = journey
+        callback.continueNode = MockContinueNode(callbacks: Callbacks([hiddenValueCallback]))
+        callback.fido = mockFido
+        mockFido.authenticationResult = .failure(FidoError.invalidChallenge)
+
+        _ = await callback.authenticate(window: MockASPresentationAnchor())
+
+        XCTAssertTrue(mockFido.capturedLogger as AnyObject? === mockLogger,
+                      "Callback must pass the Journey config logger to fido.authenticate")
     }
 }
 
@@ -86,7 +176,11 @@ final class MockFidoLogger: Logger, @unchecked Sendable {
         return _messages
     }
 
-    var hasMessages: Bool { !messages.isEmpty }
+    var hasMessages: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !_messages.isEmpty
+    }
 
     private func append(_ level: String, _ message: String) {
         lock.lock()

--- a/Fido/PingFidoTests/Mocks.swift
+++ b/Fido/PingFidoTests/Mocks.swift
@@ -1,9 +1,20 @@
+//
+//  Mocks.swift
+//  PingFidoTests
+//
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
 import Foundation
 import AuthenticationServices
 @testable import PingFido
 @testable import PingJourneyPlugin
 @testable import PingJourney
 @testable import PingOrchestrate
+@testable import PingLogger
 
 class MockASAuthorizationController: ASAuthorizationController {
     var performRequestsCalled = false
@@ -60,14 +71,19 @@ class MockContinueNode: ContinueNode, @unchecked Sendable {
 class MockFido: Fido, @unchecked Sendable {
     var registrationResult: Result<[String: Any], Error>?
     var authenticationResult: Result<[String: Any], Error>?
-    
-    override func register(options: [String : Any], window: ASPresentationAnchor, completion: @escaping (Result<[String : Any], Error>) -> Void) {
+    /// Captures the `logger` parameter passed to the most recent call to `register` or
+    /// `authenticate`, so tests can assert callers propagate the workflow logger.
+    var capturedLogger: Logger?
+
+    override func register(options: [String : Any], window: ASPresentationAnchor, logger: Logger? = nil, completion: @escaping (Result<[String : Any], Error>) -> Void) {
+        capturedLogger = logger
         if let result = registrationResult {
             completion(result)
         }
     }
-    
-    override func authenticate(options: [String : Any], window: ASPresentationAnchor, completion: @escaping (Result<[String : Any], Error>) -> Void) {
+
+    override func authenticate(options: [String : Any], window: ASPresentationAnchor, logger: Logger? = nil, completion: @escaping (Result<[String : Any], Error>) -> Void) {
+        capturedLogger = logger
         if let result = authenticationResult {
             completion(result)
         }

--- a/Package.swift
+++ b/Package.swift
@@ -266,6 +266,7 @@ let package = Package(
         .target(
             name: "PingFido",
             dependencies: [
+                "PingLogger",
                 "PingCommons",
                 "PingDavinciPlugin",
                 "PingJourneyPlugin"

--- a/PingFido.podspec
+++ b/PingFido.podspec
@@ -33,6 +33,7 @@ Pod::Spec.new do |s|
     'Fido' => [base_dir + '/*.xcprivacy']
   }
   
+  s.ios.dependency 'PingLogger', '~> 2.0.0'
   s.ios.dependency 'PingCommons', '~> 2.0.0'
   s.ios.dependency 'PingDavinciPlugin', '~> 2.0.0'
   s.ios.dependency 'PingJourneyPlugin', '~> 2.0.0'


### PR DESCRIPTION
# JIRA Ticket

[JIRA](https://bugster.forgerock.org/jira/browse/SDKS-4924) "Add Logger to FIDO module                 "

# Description

- Adds `PingLogger` as a direct SPM dependency of `PingFido` (the `.podspec` already declared it; this brings SPM into parity).
  - Routes FIDO ceremony logs through the workflow logger by adding a `logger:` parameter to `Fido.register` and `Fido.authenticate`. Per-call parameter (not a stored property) so concurrent ceremonies on the shared `Fido.shared` instance do not clobber each other's logger.                                                                                                                                                                  
  - The four DaVinci collectors and Journey callbacks (`FidoRegistrationCollector`, `FidoAuthenticationCollector`, `FidoRegistrationCallback`, `FidoAuthenticationCallback`) pass their workflow logger (`davinci?.config.logger` / `journey?.config.logger`) into `Fido` so registration/authentication state transitions and errors emit through the same logger as the surrounding flow.
  - No credential bytes, key material, or challenge data are logged — only state transitions, request counts, and error descriptions.      

# Checklist:

- [X] I ran all unit tests and they pass
- [X] I added test case coverage for my changes
