### PR TITLE
Implement OAuth 2.0 Device Authorization Grant (RFC 8628) support

### DIFF
--- a/Browser/Browser/BrowserLauncher.swift
+++ b/Browser/Browser/BrowserLauncher.swift
@@ -285,7 +285,9 @@ public final class BrowserLauncher: NSObject, BrowserLauncherProtocol {
             throw BrowserError.externalUserAgentFailure
         }
         var presentingVC = root
-        while let presented = presentingVC.presentedViewController {
+        while let presented = presentingVC.presentedViewController,
+              !presented.isBeingDismissed,
+              !(presented is UIAlertController) {
             presentingVC = presented
         }
         

--- a/Browser/Browser/BrowserLauncher.swift
+++ b/Browser/Browser/BrowserLauncher.swift
@@ -279,10 +279,14 @@ public final class BrowserLauncher: NSObject, BrowserLauncherProtocol {
         safariVC.modalPresentationStyle = .fullScreen
         
         guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-              let presentingVC = windowScene.windows.first(where: { $0.isKeyWindow })?.rootViewController else {
+              let root = windowScene.windows.first(where: { $0.isKeyWindow })?.rootViewController else {
             logger.e("Fail to launch SFSafariViewController; missing presenting ViewController", error: nil)
             state = .idle
             throw BrowserError.externalUserAgentFailure
+        }
+        var presentingVC = root
+        while let presented = presentingVC.presentedViewController {
+            presentingVC = presented
         }
         
         // We set state BEFORE presenting to prevent race conditions

--- a/Davinci/Davinci.xcodeproj/project.pbxproj
+++ b/Davinci/Davinci.xcodeproj/project.pbxproj
@@ -8,11 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		3A203D7F2BDB136C0020C995 /* DaVinci.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A203D7E2BDB136C0020C995 /* DaVinci.swift */; };
+		AA4785011F0000000000AA01 /* DaVinci+Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4785001F0000000000AA01 /* DaVinci+Device.swift */; };
 		3A203D972BDB2CD70020C995 /* Oidc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A203D962BDB2CD70020C995 /* Oidc.swift */; };
 		3A203D9B2BDE155D0020C995 /* Transform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A203D9A2BDE155D0020C995 /* Transform.swift */; };
 		3A292C822BF58462006977EF /* Agent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A292C812BF58462006977EF /* Agent.swift */; };
 		3A5441AA2BCDF20700385131 /* PingDavinci.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A5441A12BCDF20700385131 /* PingDavinci.framework */; };
 		3A5441AF2BCDF20700385131 /* DaVinciTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5441AE2BCDF20700385131 /* DaVinciTests.swift */; };
+		AA4785031F0000000000AA01 /* DaVinciDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4785021F0000000000AA01 /* DaVinciDeviceTests.swift */; };
 		25554859C34DBAACE79ABA36 /* DaVinciPARTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AD0544A9787573F4A02A278 /* DaVinciPARTests.swift */; };
 		3A5441B02BCDF20700385131 /* Davinci.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A5441A42BCDF20700385131 /* Davinci.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3A57CB622C44D68C001EC9A0 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A57CB612C44D688001EC9A0 /* User.swift */; };
@@ -105,6 +107,7 @@
 
 /* Begin PBXFileReference section */
 		3A203D7E2BDB136C0020C995 /* DaVinci.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinci.swift; sourceTree = "<group>"; };
+		AA4785001F0000000000AA01 /* DaVinci+Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DaVinci+Device.swift"; sourceTree = "<group>"; };
 		3A203D962BDB2CD70020C995 /* Oidc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Oidc.swift; sourceTree = "<group>"; };
 		3A203D9A2BDE155D0020C995 /* Transform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transform.swift; sourceTree = "<group>"; };
 		3A292C812BF58462006977EF /* Agent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Agent.swift; sourceTree = "<group>"; };
@@ -112,6 +115,7 @@
 		3A5441A42BCDF20700385131 /* Davinci.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Davinci.h; sourceTree = "<group>"; };
 		3A5441A92BCDF20700385131 /* DavinciTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DavinciTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A5441AE2BCDF20700385131 /* DaVinciTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinciTests.swift; sourceTree = "<group>"; };
+		AA4785021F0000000000AA01 /* DaVinciDeviceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinciDeviceTests.swift; sourceTree = "<group>"; };
 		2AD0544A9787573F4A02A278 /* DaVinciPARTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinciPARTests.swift; sourceTree = "<group>"; };
 		3A57CB612C44D688001EC9A0 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		3AC13E312C3FFF1000DEF23A /* Connector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Connector.swift; sourceTree = "<group>"; };
@@ -236,6 +240,7 @@
 				A51D4CE12C62C53400FE09E0 /* module */,
 				3A292C812BF58462006977EF /* Agent.swift */,
 				3A203D7E2BDB136C0020C995 /* DaVinci.swift */,
+				AA4785001F0000000000AA01 /* DaVinci+Device.swift */,
 				3A57CB612C44D688001EC9A0 /* User.swift */,
 			);
 			path = Davinci;
@@ -253,6 +258,7 @@
 				EC7279B32DF9B289005D9E28 /* DaVinciBaseTests.swift */,
 				3A5441AE2BCDF20700385131 /* DaVinciTests.swift */,
 				2AD0544A9787573F4A02A278 /* DaVinciPARTests.swift */,
+				AA4785021F0000000000AA01 /* DaVinciDeviceTests.swift */,
 				EC92B3A22DA52DA200E4246D /* DeviceAuthenticatorCollectorTests.swift */,
 				BB4928022F0900000000BB01 /* ReadOnlyTextCollectorTests.swift */,
 				EC92B3A42DA52DC900E4246D /* DeviceRegistrationCollectorTests.swift */,
@@ -486,6 +492,7 @@
 				A5E9AEB42D2F2256000533ED /* LabelCollector.swift in Sources */,
 				A5E9AEBA2D2F2731000533ED /* ValidatedCollector.swift in Sources */,
 				3A203D7F2BDB136C0020C995 /* DaVinci.swift in Sources */,
+				AA4785011F0000000000AA01 /* DaVinci+Device.swift in Sources */,
 				AA1A00022F0000000000AA01 /* PollingCollector.swift in Sources */,
 				AA1A00062F0000000000AA01 /* QRCodeCollector.swift in Sources */,
 			);
@@ -518,6 +525,7 @@
 				A51D4CF82C65978300FE09E0 /* DaVinciIntegrationTests.swift in Sources */,
 				3A5441AF2BCDF20700385131 /* DaVinciTests.swift in Sources */,
 				25554859C34DBAACE79ABA36 /* DaVinciPARTests.swift in Sources */,
+				AA4785031F0000000000AA01 /* DaVinciDeviceTests.swift in Sources */,
 				A51D4CF22C65729A00FE09E0 /* DaVinciErrorTests.swift in Sources */,
 				A5EFAA102D3F50A700F771FE /* SingleSelectCollectorTests.swift in Sources */,
 				95C256792DF22BFB004266AB /* MFADeviceTests.swift in Sources */,

--- a/Davinci/Davinci/DaVinci+Device.swift
+++ b/Davinci/Davinci/DaVinci+Device.swift
@@ -1,0 +1,61 @@
+//
+//  DaVinci+Device.swift
+//  PingDavinci
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import Foundation
+import PingOrchestrate
+
+/// Options used to supply caller inputs before the DaVinci flow begins.
+///
+/// Currently used for the RFC 8628 Device Authorization Grant (approving-device side).
+/// When `verificationUriComplete` is set, `OidcModule.setup.start` extracts the `user_code`
+/// query parameter from the URL and includes it in the outgoing authorization request so the
+/// authorization server can approve the requesting device.
+public struct DaVinciOptions: Sendable {
+    /// The `verificationUriComplete` URL from an RFC 8628 device authorization response.
+    ///
+    /// When set, the DaVinci `OidcModule` will extract the `user_code` query parameter from
+    /// this URL and include it in the device-flow verification request, approving the
+    /// requesting device.
+    public var verificationUriComplete: URL? = nil
+}
+
+public extension DaVinci {
+
+    /// Starts the DaVinci flow after applying caller-supplied device-flow inputs.
+    ///
+    /// Use this overload when the current device is acting as the approving device in an
+    /// RFC 8628 Device Authorization Grant flow:
+    ///
+    /// ```swift
+    /// let node = await daVinci.start { options in
+    ///     options.verificationUriComplete = URL(string: verificationUriCompleteString)
+    /// }
+    /// ```
+    ///
+    /// The supplied URL is stored in `sharedContext` under
+    /// `SharedContext.Keys.daVinciVerificationUriCompleteKey` and consumed during the
+    /// `start` phase of `OidcModule`. Passing `nil` clears any previously stored value,
+    /// so a subsequent plain `start()` does not include a `user_code` parameter.
+    ///
+    /// - Parameter configure: Closure that populates a `DaVinciOptions` with caller inputs.
+    /// - Returns: The first `Node` produced by the DaVinci flow.
+    func start(_ configure: @Sendable (inout DaVinciOptions) -> Void) async -> Node {
+        var options = DaVinciOptions()
+        configure(&options)
+        
+        if let uri = options.verificationUriComplete {
+            sharedContext.set(key: SharedContext.Keys.daVinciVerificationUriCompleteKey, value: uri.absoluteString)
+        } else {
+            _ = sharedContext.removeValue(forKey: SharedContext.Keys.daVinciVerificationUriCompleteKey)
+        }
+        
+        return await start()
+    }
+}

--- a/Davinci/Davinci/module/Oidc.swift
+++ b/Davinci/Davinci/module/Oidc.swift
@@ -48,9 +48,12 @@ public class OidcModule {
                let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
                let userCode = components.queryItems?.first(where: { $0.name == "user_code" })?.value,
                !userCode.isEmpty {
+                // Move key from sharedContext (workflow-scoped) into flowContext (this invocation only)
+                // so success can detect the device-flow path, and a subsequent start() is unaffected.
                 _ = daVinciFlow.sharedContext.removeValue(forKey: SharedContext.Keys.daVinciVerificationUriCompleteKey)
+                context.flowContext.set(key: SharedContext.Keys.daVinciVerificationUriCompleteKey, value: uriString)
                 config.logger.d( "Oidc: device code completion flow detected, skipping authorization request")
-                return config.populateDeviceFlowVerificationRequest(request: request, userCode: userCode)
+                return try config.populateDeviceFlowVerificationRequest(request: request, userCode: userCode)
             }
             
             
@@ -66,8 +69,9 @@ public class OidcModule {
         setup.success { @Sendable context, success in
             
             // Device-code completion flow: token exchange already handled externally, skip.
-            if let uriString = daVinciFlow.sharedContext.get(key: SharedContext.Keys.daVinciVerificationUriCompleteKey) as? String {
-               return SuccessNode(input: success.input, session: success.session)
+            // The key was moved into flowContext by start; sharedContext key was already consumed there.
+            if context.flowContext.get(key: SharedContext.Keys.daVinciVerificationUriCompleteKey) != nil {
+                return SuccessNode(input: success.input, session: success.session)
             }
             
             let cloneConfig: OidcClientConfig = config.clone()

--- a/Davinci/Davinci/module/Oidc.swift
+++ b/Davinci/Davinci/module/Oidc.swift
@@ -46,7 +46,7 @@ public class OidcModule {
             if let uriString = daVinciFlow.sharedContext.get(key: SharedContext.Keys.daVinciVerificationUriCompleteKey) as? String,
                let url = URL(string: uriString),
                let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-               let userCode = components.queryItems?.first(where: { $0.name == "user_code" })?.value,
+               let userCode = components.queryItems?.first(where: { $0.name == OidcClient.Constants.userCodeSnake })?.value,
                !userCode.isEmpty {
                 // Move key from sharedContext (workflow-scoped) into flowContext (this invocation only)
                 // so success can detect the device-flow path, and a subsequent start() is unaffected.

--- a/Davinci/Davinci/module/Oidc.swift
+++ b/Davinci/Davinci/module/Oidc.swift
@@ -13,6 +13,7 @@ import Foundation
 import PingOidc
 import PingOrchestrate
 import PingNetwork
+import PingLogger
 
 /// A module that integrates OIDC capabilities into the DaVinci workflow.
 public class OidcModule {
@@ -40,6 +41,19 @@ public class OidcModule {
         
         // Starts the module.
         setup.start { @Sendable context, request in
+            
+            // Check for Device Flow
+            if let uriString = daVinciFlow.sharedContext.get(key: SharedContext.Keys.daVinciVerificationUriCompleteKey) as? String,
+               let url = URL(string: uriString),
+               let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+               let userCode = components.queryItems?.first(where: { $0.name == "user_code" })?.value,
+               !userCode.isEmpty {
+                _ = daVinciFlow.sharedContext.removeValue(forKey: SharedContext.Keys.daVinciVerificationUriCompleteKey)
+                config.logger.d( "Oidc: device code completion flow detected, skipping authorization request")
+                return config.populateDeviceFlowVerificationRequest(request: request, userCode: userCode)
+            }
+            
+            
             // When user starts the flow again, revoke previous token if exists
             await daVinciFlow.daVinciUser()?.revoke()
             
@@ -50,6 +64,12 @@ public class OidcModule {
         
         // Handles success of the module.
         setup.success { @Sendable context, success in
+            
+            // Device-code completion flow: token exchange already handled externally, skip.
+            if let uriString = daVinciFlow.sharedContext.get(key: SharedContext.Keys.daVinciVerificationUriCompleteKey) as? String {
+               return SuccessNode(input: success.input, session: success.session)
+            }
+            
             let cloneConfig: OidcClientConfig = config.clone()
             
             let flowPkce = context.flowContext.get(key: SharedContext.Keys.pkceKey) as? Pkce
@@ -87,4 +107,8 @@ extension SharedContext.Keys {
     
     /// The key used to store the OIDC client configuration in the shared context.
     public static let oidcClientConfigKey = "com.pingidentity.davinci.OidcClientConfig"
+    
+    /// The shared context key under which the `verificationUriComplete` URL string is stored
+    /// for the DaVinci device authorization flow.
+    public static let daVinciVerificationUriCompleteKey = "com.pingidentity.davinci.VerificationUriComplete"
 }

--- a/Davinci/Davinci/module/Request.swift
+++ b/Davinci/Davinci/module/Request.swift
@@ -54,19 +54,14 @@ extension OidcClientConfig {
         }
 
         // Strip "/as/device_authorization" to obtain the tenant-scoped base URL.
-        let baseUrl = deviceAuthEndpoint.hasSuffix(Constants.asDeviceAuthorizationPath)
-            ? String(deviceAuthEndpoint.dropLast(Constants.asDeviceAuthorizationPath.count))
+        let baseUrl = deviceAuthEndpoint.hasSuffix(OidcClient.Constants.asDeviceAuthorizationPath)
+            ? String(deviceAuthEndpoint.dropLast(OidcClient.Constants.asDeviceAuthorizationPath.count))
             : deviceAuthEndpoint
 
         request.url = "\(baseUrl)/applications/\(clientId)/deviceFlow"
-        request.setParameter(name: Constants.userCodeCamel, value: userCode)
+        request.setParameter(name: OidcClient.Constants.userCodeCamel, value: userCode)
 
         return request
-    }
-
-    private enum Constants {
-        static let asDeviceAuthorizationPath = "/as/device_authorization"
-        static let userCodeCamel = "userCode"
     }
 }
 

--- a/Davinci/Davinci/module/Request.swift
+++ b/Davinci/Davinci/module/Request.swift
@@ -24,5 +24,46 @@ extension OidcClientConfig {
     ) async throws -> Request {
         return try await populateRequest(request: request, pkce: pkce, responseMode: OidcClient.Constants.piflow)
     }
+    
+    /// Populates a request to verify a user code in the Device Authorization Grant flow (RFC 8628).
+    ///
+    /// Constructs the device-flow verification URL from
+    /// `OpenIdConfiguration.deviceAuthorizationEndpoint` by stripping the trailing
+    /// `/as/device_authorization` segment to obtain the tenant-scoped base URL, then appending
+    /// `/applications/{clientId}/deviceFlow`. The user code is sent as a `userCode` query parameter
+    /// (PingOne format).
+    ///
+    /// **Example**
+    /// - Endpoint: `https://auth.pingone.ca/{tenantId}/as/device_authorization`
+    /// - Result:   `https://auth.pingone.ca/{tenantId}/applications/{clientId}/deviceFlow?userCode={userCode}`
+    ///
+    /// - Parameters:
+    ///   - request: The request to populate.
+    ///   - userCode: The user code obtained from the device authorization response that needs to be verified.
+    /// - Returns: The populated `Request` ready for execution.
+    internal func populateDeviceFlowVerificationRequest(
+        request: Request,
+        userCode: String
+    ) -> Request {
+        let deviceAuthEndpoint = openId?.deviceAuthorizationEndpoint ?? ""
+
+        // Strip "/as/device_authorization" to obtain the tenant-scoped base URL.
+        let baseUrl: String
+        if deviceAuthEndpoint.hasSuffix(Constants.asDeviceAuthorizationPath) {
+            baseUrl = String(deviceAuthEndpoint.dropLast(Constants.asDeviceAuthorizationPath.count))
+        } else {
+            baseUrl = deviceAuthEndpoint
+        }
+
+        request.url = "\(baseUrl)/applications/\(clientId)/deviceFlow"
+        request.setParameter(name: Constants.userCodeCamel, value: userCode)
+
+        return request
+    }
+
+    private enum Constants {
+        static let asDeviceAuthorizationPath = "/as/device_authorization"
+        static let userCodeCamel = "userCode"
+    }
 }
 

--- a/Davinci/Davinci/module/Request.swift
+++ b/Davinci/Davinci/module/Request.swift
@@ -33,6 +33,9 @@ extension OidcClientConfig {
     /// `/applications/{clientId}/deviceFlow`. The user code is sent as a `userCode` query parameter
     /// (PingOne format).
     ///
+    /// PingOne format paths look like `/{tenantId}/as/device_authorization`, whereas
+    /// custom-domain paths look like `/as/device_authorization`.
+    ///
     /// **Example**
     /// - Endpoint: `https://auth.pingone.ca/{tenantId}/as/device_authorization`
     /// - Result:   `https://auth.pingone.ca/{tenantId}/applications/{clientId}/deviceFlow?userCode={userCode}`
@@ -41,19 +44,19 @@ extension OidcClientConfig {
     ///   - request: The request to populate.
     ///   - userCode: The user code obtained from the device authorization response that needs to be verified.
     /// - Returns: The populated `Request` ready for execution.
+    /// - Throws: `OidcError.unknown` if the device authorization endpoint is not available.
     internal func populateDeviceFlowVerificationRequest(
         request: Request,
         userCode: String
-    ) -> Request {
-        let deviceAuthEndpoint = openId?.deviceAuthorizationEndpoint ?? ""
+    ) throws -> Request {
+        guard let deviceAuthEndpoint = openId?.deviceAuthorizationEndpoint, !deviceAuthEndpoint.isEmpty else {
+            throw OidcError.unknown(message: "Device authorization endpoint not available")
+        }
 
         // Strip "/as/device_authorization" to obtain the tenant-scoped base URL.
-        let baseUrl: String
-        if deviceAuthEndpoint.hasSuffix(Constants.asDeviceAuthorizationPath) {
-            baseUrl = String(deviceAuthEndpoint.dropLast(Constants.asDeviceAuthorizationPath.count))
-        } else {
-            baseUrl = deviceAuthEndpoint
-        }
+        let baseUrl = deviceAuthEndpoint.hasSuffix(Constants.asDeviceAuthorizationPath)
+            ? String(deviceAuthEndpoint.dropLast(Constants.asDeviceAuthorizationPath.count))
+            : deviceAuthEndpoint
 
         request.url = "\(baseUrl)/applications/\(clientId)/deviceFlow"
         request.setParameter(name: Constants.userCodeCamel, value: userCode)

--- a/Davinci/DavinciTests/DaVinciDeviceTests.swift
+++ b/Davinci/DavinciTests/DaVinciDeviceTests.swift
@@ -1,0 +1,227 @@
+//
+//  DaVinciDeviceTests.swift
+//  DavinciTests
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+@testable import PingOrchestrate
+@testable import PingLogger
+@testable import PingOidc
+@testable import PingStorage
+@testable import PingDavinci
+@testable import PingNetwork
+
+// MARK: - populateDeviceFlowVerificationRequest tests
+
+/// Tests for `OidcClientConfig.populateDeviceFlowVerificationRequest`.
+final class PopulateDeviceFlowVerificationRequestTests: XCTestCase {
+
+    private func makeConfig(deviceAuthEndpoint: String, clientId: String = "my-client") -> OidcClientConfig {
+        let config = OidcClientConfig()
+        config.clientId = clientId
+        config.openId = OpenIdConfiguration(
+            authorizationEndpoint: "https://auth.example.com/authorize",
+            tokenEndpoint: "https://auth.example.com/token",
+            userinfoEndpoint: "https://auth.example.com/userinfo",
+            endSessionEndpoint: "https://auth.example.com/signoff",
+            revocationEndpoint: "https://auth.example.com/revoke",
+            deviceAuthorizationEndpoint: deviceAuthEndpoint
+        )
+        return config
+    }
+
+    // MARK: - Standard PingOne endpoint strips /as/device_authorization suffix
+
+    func testStripsAsDeviceAuthorizationSuffix() {
+        let endpoint = "https://auth.pingone.ca/tenant123/as/device_authorization"
+        let config = makeConfig(deviceAuthEndpoint: endpoint)
+        let request = URLSessionHttpRequest()
+
+        let populated = config.populateDeviceFlowVerificationRequest(request: request, userCode: "ABCD-1234")
+
+        XCTAssertEqual(populated.url,
+                       "https://auth.pingone.ca/tenant123/applications/my-client/deviceFlow?userCode=ABCD-1234",
+                       "URL should drop /as/device_authorization and append /applications/{clientId}/deviceFlow")
+    }
+
+    // MARK: - Custom-domain endpoint without the standard suffix uses endpoint as base
+
+    func testFallbackBaseWhenSuffixAbsent() {
+        let endpoint = "https://custom.example.com/device_authorization"
+        let config = makeConfig(deviceAuthEndpoint: endpoint)
+        let request = URLSessionHttpRequest()
+
+        let populated = config.populateDeviceFlowVerificationRequest(request: request, userCode: "WXYZ-5678")
+
+        XCTAssertEqual(populated.url,
+                       "https://custom.example.com/device_authorization/applications/my-client/deviceFlow?userCode=WXYZ-5678",
+                       "URL should use full endpoint as base when /as/device_authorization suffix is absent")
+    }
+
+    // MARK: - clientId is correctly embedded in URL path
+
+    func testClientIdIsEmbeddedInPath() {
+        let endpoint = "https://auth.pingone.eu/tenant-abc/as/device_authorization"
+        let config = makeConfig(deviceAuthEndpoint: endpoint, clientId: "special-client-id")
+        let request = URLSessionHttpRequest()
+
+        let populated = config.populateDeviceFlowVerificationRequest(request: request, userCode: "TEST-0000")
+
+        XCTAssertTrue(populated.url?.contains("/applications/special-client-id/deviceFlow") == true,
+                      "clientId must appear in the applications path segment")
+    }
+
+    // MARK: - userCode is sent as camelCase query param
+
+    func testUserCodeSentAsCamelCase() {
+        let endpoint = "https://auth.pingone.ca/tenant123/as/device_authorization"
+        let config = makeConfig(deviceAuthEndpoint: endpoint)
+        let request = URLSessionHttpRequest()
+
+        let populated = config.populateDeviceFlowVerificationRequest(request: request, userCode: "MY-CODE")
+
+        let url = populated.url ?? ""
+        XCTAssertTrue(url.contains("userCode=MY-CODE"),
+                      "userCode must be sent as camelCase query param, got: \(url)")
+        XCTAssertFalse(url.contains("user_code="),
+                       "snake_case user_code must NOT appear in the URL, got: \(url)")
+    }
+
+    // MARK: - Empty deviceAuthorizationEndpoint produces a well-formed (if empty-base) URL
+
+    func testEmptyEndpointProducesApplicationsPath() {
+        let config = makeConfig(deviceAuthEndpoint: "", clientId: "c1")
+        let request = URLSessionHttpRequest()
+
+        let populated = config.populateDeviceFlowVerificationRequest(request: request, userCode: "XX")
+
+        XCTAssertTrue(populated.url?.contains("/applications/c1/deviceFlow") == true,
+                      "Even with an empty endpoint the applications path should be appended")
+    }
+}
+
+// MARK: - DaVinci device flow start overload tests
+
+/// Tests for the DaVinci device flow start overload (`DaVinci.start { $0[.verificationUriComplete] = url }`).
+final class DaVinciDeviceTests: XCTestCase, @unchecked Sendable {
+
+    let testClientId = "test"
+    let testScopes = ["openid", "email"]
+    let testRedirectUri = "http://localhost:8080"
+    let testDiscoveryEndpoint = "http://localhost/.well-known/openid-configuration"
+
+    private func mockHTTPResponse(url: URL, statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: MockResponse.headers)!
+    }
+
+    private func makeDaVinci() -> DaVinci {
+        DaVinci.createDaVinci { config in
+            config.httpClient = MockURLProtocol.makeClient()
+            config.module(PingDavinci.OidcModule.config) { oidcValue in
+                oidcValue.clientId = self.testClientId
+                oidcValue.scopes = Set(self.testScopes)
+                oidcValue.redirectUri = self.testRedirectUri
+                oidcValue.discoveryEndpoint = self.testDiscoveryEndpoint
+                oidcValue.storage = MemoryStorage()
+                oidcValue.logger = LogManager.standard
+            }
+        }
+    }
+
+    override func setUp() {
+        super.setUp()
+        MockURLProtocol.startInterceptingRequests()
+
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
+            case MockAPIEndpoint.discovery.url.path:
+                return (mockHTTPResponse(url: MockAPIEndpoint.discovery.url, statusCode: 200),
+                        MockResponse.openIdConfigurationWithDeviceEndpointResponse)
+            case MockAPIEndpoint.authorization.url.path:
+                return (mockHTTPResponse(url: MockAPIEndpoint.authorization.url, statusCode: 200),
+                        MockResponse.authorizeResponse)
+            case MockAPIEndpoint.deviceFlow.url.path:
+                return (mockHTTPResponse(url: MockAPIEndpoint.deviceFlow.url, statusCode: 200), Data())
+            default:
+                return (mockHTTPResponse(url: MockAPIEndpoint.discovery.url, statusCode: 500), Data())
+            }
+        }
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        MockURLProtocol.stopInterceptingRequests()
+    }
+
+    // MARK: - Test 1: user_code included when verificationUriComplete is set
+
+    /// Test: `user_code` query parameter is appended to the authorization request when
+    /// `verificationUriComplete` is set via the device-flow start overload.
+    func testVerificationUriCompleteAddsUserCodeToAuthorizeRequest() async throws {
+        let daVinci = makeDaVinci()
+
+        _ = await daVinci.start { options in
+            options.verificationUriComplete = URL(string: "https://example.com/activate?user_code=XYZW-1234")
+        }
+
+        // When verificationUriComplete is set, OidcModule bypasses the authorization endpoint
+        // and instead POSTs to /applications/{clientId}/deviceFlow with userCode as a query param.
+        let deviceFlowRequest = MockURLProtocol.requestHistory.first {
+            $0.url?.path == MockAPIEndpoint.deviceFlow.url.path
+        }
+        XCTAssertNotNil(deviceFlowRequest, "Expected a request to the deviceFlow endpoint")
+        let query = deviceFlowRequest?.url?.query ?? ""
+        XCTAssertTrue(query.contains("userCode=XYZW-1234"),
+                      "deviceFlow request should contain userCode=XYZW-1234, got: \(query)")
+    }
+
+    // MARK: - Test 2: user_code absent when verificationUriComplete is not set
+
+    /// Test: When no `verificationUriComplete` is provided, the authorization request does not
+    /// include a `user_code` parameter, and the existing flow is unaffected.
+    func testNoVerificationUriCompleteDoesNotAddUserCode() async throws {
+        let daVinci = makeDaVinci()
+
+        _ = await daVinci.start()
+
+        let authorizeRequest = MockURLProtocol.requestHistory.first {
+            $0.url?.path == MockAPIEndpoint.authorization.url.path
+        }
+        XCTAssertNotNil(authorizeRequest, "Expected an authorization request")
+        let query = authorizeRequest?.url?.query ?? ""
+        XCTAssertFalse(query.contains("user_code="),
+                       "Authorization request should NOT contain user_code when flow is not device flow, got: \(query)")
+    }
+
+    // MARK: - Test 3: key is consumed — subsequent start() does not resend user_code
+
+    /// Test: After a device-flow start, the `verificationUriComplete` key is consumed.
+    /// A subsequent plain `start()` on the same DaVinci instance must NOT include `user_code`.
+    func testVerificationUriCompleteKeyIsConsumedAfterFirstStart() async throws {
+        let daVinci = makeDaVinci()
+
+        _ = await daVinci.start { options in
+            options.verificationUriComplete = URL(string: "https://example.com/activate?user_code=ABCD-9876")
+        }
+
+        MockURLProtocol.requestHistory.removeAll()
+
+        _ = await daVinci.start()
+
+        // After the device-flow start consumed the key, a plain start() must go to the
+        // authorization endpoint — not the deviceFlow endpoint.
+        let authRequest = MockURLProtocol.requestHistory.first {
+            $0.url?.path == MockAPIEndpoint.authorization.url.path
+        }
+        let deviceFlowRequest = MockURLProtocol.requestHistory.first {
+            $0.url?.path == MockAPIEndpoint.deviceFlow.url.path
+        }
+        XCTAssertNotNil(authRequest, "Second start() should reach the authorization endpoint")
+        XCTAssertNil(deviceFlowRequest, "Second start() must NOT reach the deviceFlow endpoint — key should have been consumed")
+    }
+}

--- a/Davinci/DavinciTests/DaVinciDeviceTests.swift
+++ b/Davinci/DavinciTests/DaVinciDeviceTests.swift
@@ -50,17 +50,21 @@ final class PopulateDeviceFlowVerificationRequestTests: XCTestCase {
     }
 
     // MARK: - Custom-domain endpoint without the standard suffix uses endpoint as base
-
-    func testFallbackBaseWhenSuffixAbsent() throws {
+    //
+    // NOTE: The PingOne-specific `/applications/{clientId}/deviceFlow` segment is appended
+    // unconditionally. On a non-PingOne AS this will produce a URL that 404s server-side —
+    // that's the intended fail-loud behavior (handled by the server, not locally suppressed).
+    // We only assert the function does not throw and produces a non-empty URL; the exact
+    // shape is not a contract we want callers to rely on for non-PingOne deployments.
+    func testFallbackBaseWhenSuffixAbsentDoesNotThrow() throws {
         let endpoint = "https://custom.example.com/device_authorization"
         let config = makeConfig(deviceAuthEndpoint: endpoint)
         let request = URLSessionHttpRequest()
 
         let populated = try config.populateDeviceFlowVerificationRequest(request: request, userCode: "WXYZ-5678")
 
-        XCTAssertEqual(populated.url,
-                       "https://custom.example.com/device_authorization/applications/my-client/deviceFlow?userCode=WXYZ-5678",
-                       "URL should use full endpoint as base when /as/device_authorization suffix is absent")
+        XCTAssertNotNil(populated.url, "Function must not throw when suffix is absent; server is responsible for rejecting non-PingOne URLs")
+        XCTAssertFalse(populated.url?.isEmpty ?? true)
     }
 
     // MARK: - clientId is correctly embedded in URL path

--- a/Davinci/DavinciTests/DaVinciDeviceTests.swift
+++ b/Davinci/DavinciTests/DaVinciDeviceTests.swift
@@ -37,12 +37,12 @@ final class PopulateDeviceFlowVerificationRequestTests: XCTestCase {
 
     // MARK: - Standard PingOne endpoint strips /as/device_authorization suffix
 
-    func testStripsAsDeviceAuthorizationSuffix() {
+    func testStripsAsDeviceAuthorizationSuffix() throws {
         let endpoint = "https://auth.pingone.ca/tenant123/as/device_authorization"
         let config = makeConfig(deviceAuthEndpoint: endpoint)
         let request = URLSessionHttpRequest()
 
-        let populated = config.populateDeviceFlowVerificationRequest(request: request, userCode: "ABCD-1234")
+        let populated = try config.populateDeviceFlowVerificationRequest(request: request, userCode: "ABCD-1234")
 
         XCTAssertEqual(populated.url,
                        "https://auth.pingone.ca/tenant123/applications/my-client/deviceFlow?userCode=ABCD-1234",
@@ -51,12 +51,12 @@ final class PopulateDeviceFlowVerificationRequestTests: XCTestCase {
 
     // MARK: - Custom-domain endpoint without the standard suffix uses endpoint as base
 
-    func testFallbackBaseWhenSuffixAbsent() {
+    func testFallbackBaseWhenSuffixAbsent() throws {
         let endpoint = "https://custom.example.com/device_authorization"
         let config = makeConfig(deviceAuthEndpoint: endpoint)
         let request = URLSessionHttpRequest()
 
-        let populated = config.populateDeviceFlowVerificationRequest(request: request, userCode: "WXYZ-5678")
+        let populated = try config.populateDeviceFlowVerificationRequest(request: request, userCode: "WXYZ-5678")
 
         XCTAssertEqual(populated.url,
                        "https://custom.example.com/device_authorization/applications/my-client/deviceFlow?userCode=WXYZ-5678",
@@ -65,12 +65,12 @@ final class PopulateDeviceFlowVerificationRequestTests: XCTestCase {
 
     // MARK: - clientId is correctly embedded in URL path
 
-    func testClientIdIsEmbeddedInPath() {
+    func testClientIdIsEmbeddedInPath() throws {
         let endpoint = "https://auth.pingone.eu/tenant-abc/as/device_authorization"
         let config = makeConfig(deviceAuthEndpoint: endpoint, clientId: "special-client-id")
         let request = URLSessionHttpRequest()
 
-        let populated = config.populateDeviceFlowVerificationRequest(request: request, userCode: "TEST-0000")
+        let populated = try config.populateDeviceFlowVerificationRequest(request: request, userCode: "TEST-0000")
 
         XCTAssertTrue(populated.url?.contains("/applications/special-client-id/deviceFlow") == true,
                       "clientId must appear in the applications path segment")
@@ -78,12 +78,12 @@ final class PopulateDeviceFlowVerificationRequestTests: XCTestCase {
 
     // MARK: - userCode is sent as camelCase query param
 
-    func testUserCodeSentAsCamelCase() {
+    func testUserCodeSentAsCamelCase() throws {
         let endpoint = "https://auth.pingone.ca/tenant123/as/device_authorization"
         let config = makeConfig(deviceAuthEndpoint: endpoint)
         let request = URLSessionHttpRequest()
 
-        let populated = config.populateDeviceFlowVerificationRequest(request: request, userCode: "MY-CODE")
+        let populated = try config.populateDeviceFlowVerificationRequest(request: request, userCode: "MY-CODE")
 
         let url = populated.url ?? ""
         XCTAssertTrue(url.contains("userCode=MY-CODE"),
@@ -92,16 +92,34 @@ final class PopulateDeviceFlowVerificationRequestTests: XCTestCase {
                        "snake_case user_code must NOT appear in the URL, got: \(url)")
     }
 
-    // MARK: - Empty deviceAuthorizationEndpoint produces a well-formed (if empty-base) URL
+    // MARK: - Missing deviceAuthorizationEndpoint throws
 
-    func testEmptyEndpointProducesApplicationsPath() {
+    func testEmptyEndpointThrows() {
         let config = makeConfig(deviceAuthEndpoint: "", clientId: "c1")
         let request = URLSessionHttpRequest()
 
-        let populated = config.populateDeviceFlowVerificationRequest(request: request, userCode: "XX")
+        XCTAssertThrowsError(try config.populateDeviceFlowVerificationRequest(request: request, userCode: "XX")) { error in
+            guard case OidcError.unknown = error else {
+                XCTFail("Expected OidcError.unknown, got \(error)")
+                return
+            }
+        }
+    }
 
-        XCTAssertTrue(populated.url?.contains("/applications/c1/deviceFlow") == true,
-                      "Even with an empty endpoint the applications path should be appended")
+    // MARK: - Nil deviceAuthorizationEndpoint throws
+
+    func testNilEndpointThrows() {
+        let config = OidcClientConfig()
+        config.clientId = "c1"
+        // openId is nil — no endpoint available
+        let request = URLSessionHttpRequest()
+
+        XCTAssertThrowsError(try config.populateDeviceFlowVerificationRequest(request: request, userCode: "XX")) { error in
+            guard case OidcError.unknown = error else {
+                XCTFail("Expected OidcError.unknown, got \(error)")
+                return
+            }
+        }
     }
 }
 

--- a/Davinci/DavinciTests/mock/MockAPIEndpoint.swift
+++ b/Davinci/DavinciTests/mock/MockAPIEndpoint.swift
@@ -2,7 +2,7 @@
 //  MockAPIEndpoint.swift
 //  DavinciTests
 //
-//  Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -22,6 +22,7 @@ enum MockAPIEndpoint {
     case discovery
     case customHTMLTemplate
     case par
+    case deviceFlow
     
     var url: URL {
         switch self {
@@ -41,6 +42,9 @@ enum MockAPIEndpoint {
             return URL(string: "\(MockAPIEndpoint.baseURL)/customHTMLTemplate")!
         case .par:
             return URL(string: "\(MockAPIEndpoint.baseURL)/par")!
+        case .deviceFlow:
+            // Matches /applications/{clientId}/deviceFlow — clientId "test" used in DaVinciDeviceTests
+            return URL(string: "\(MockAPIEndpoint.baseURL)/applications/test/deviceFlow")!
         }
     }
 }

--- a/Davinci/DavinciTests/mock/MockResponse.swift
+++ b/Davinci/DavinciTests/mock/MockResponse.swift
@@ -27,6 +27,20 @@ struct MockResponse {
         """.data(using: .utf8)!
     }
     
+    // Return the OpenID configuration response with device_authorization_endpoint as Data
+    static var openIdConfigurationWithDeviceEndpointResponse: Data {
+        return """
+        {
+            "authorization_endpoint" : "http://auth.test-one-pingone.com/authorize",
+            "token_endpoint" : "https://auth.test-one-pingone.com/token",
+            "userinfo_endpoint" : "https://auth.test-one-pingone.com/userinfo",
+            "end_session_endpoint" : "https://auth.test-one-pingone.com/signoff",
+            "revocation_endpoint" : "https://auth.test-one-pingone.com/revoke",
+            "device_authorization_endpoint" : "https://auth.test-one-pingone.com/as/device_authorization"
+        }
+        """.data(using: .utf8)!
+    }
+
     // Return the OpenID configuration response with PAR endpoint as Data
     static var openIdConfigurationWithPARResponse: Data {
         return """

--- a/Davinci/README.md
+++ b/Davinci/README.md
@@ -124,6 +124,20 @@ let daVinci = DaVinci.createDaVinci { config in
 The PAR endpoint is discovered automatically from the OpenID configuration. If the server does not advertise a `pushed_authorization_request_endpoint`, the SDK falls back to the standard authorization flow.
 
 
+### Device Authorization Grant — approving device (RFC 8628)
+
+When this device is acting as the *approving* device for an [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628) device-flow request initiated elsewhere (e.g., a smart TV), pass the `verificationUriComplete` URL into `start(_:)`. The DaVinci `OidcModule` extracts the `user_code` query parameter and routes the start request to the device-flow verification endpoint, approving the requesting device after the user authenticates.
+
+```swift
+let node = await daVinci.start { options in
+    options.verificationUriComplete = URL(string: verificationUriCompleteString)
+}
+```
+
+`verificationUriComplete` is the URL returned in the `verification_uri_complete` field of the requesting device's `DeviceAuthorizationResponse` — typically scanned from a QR code or pasted by the user. The flow then proceeds normally (the user authenticates via the DaVinci flow); on success, the requesting device receives its access token via its own polling loop.
+
+The supplied URL is consumed after the first `start()` — a subsequent plain `start()` reverts to the standard authorization flow. Pass `nil` to clear any previously stored value.
+
 ### Navigate the authentication Flow
 
 ```swift

--- a/Journey/Journey.xcodeproj/project.pbxproj
+++ b/Journey/Journey.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		ECD562AC2E0C494200F0B5A9 /* MockResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD562A92E0C494200F0B5A9 /* MockResponse.swift */; };
 		ECEFDC282ED4B0AC00B56E87 /* MetadataCallbackSpecializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEFDC242ED4AF3C00B56E87 /* MetadataCallbackSpecializationTests.swift */; };
 		ECEFDC292ED4B10E00B56E87 /* MetadataCallbackInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEFDC262ED4AF8500B56E87 /* MetadataCallbackInjectionTests.swift */; };
+		AA4785041F0000000000AA04 /* OidcDeviceApprovalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4785051F0000000000AA05 /* OidcDeviceApprovalTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -229,6 +230,7 @@
 		ECD562AA2E0C494200F0B5A9 /* MockAPIEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAPIEndpoint.swift; sourceTree = "<group>"; };
 		ECEFDC242ED4AF3C00B56E87 /* MetadataCallbackSpecializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataCallbackSpecializationTests.swift; sourceTree = "<group>"; };
 		ECEFDC262ED4AF8500B56E87 /* MetadataCallbackInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataCallbackInjectionTests.swift; sourceTree = "<group>"; };
+		AA4785051F0000000000AA05 /* OidcDeviceApprovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcDeviceApprovalTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -355,6 +357,7 @@
 				ECEFDC242ED4AF3C00B56E87 /* MetadataCallbackSpecializationTests.swift */,
 				EC727A5E2E019258005D9E28 /* JourneyTests.swift */,
 				EC2326A52E0D744A00634A50 /* JourneyUserTests.swift */,
+				AA4785051F0000000000AA05 /* OidcDeviceApprovalTests.swift */,
 				A5CFC86A2E42920A00CBFC3B /* Callbacks */,
 				ECD562AD2E0C494B00F0B5A9 /* Mock */,
 			);
@@ -632,6 +635,7 @@
 				EC2326A82E0D7C7900634A50 /* AgentTests.swift in Sources */,
 				A5CFC8742E4392D900CBFC3B /* ConsentMappingCallbackTests.swift in Sources */,
 				ECEFDC292ED4B10E00B56E87 /* MetadataCallbackInjectionTests.swift in Sources */,
+				AA4785041F0000000000AA04 /* OidcDeviceApprovalTests.swift in Sources */,
 				ECD562AB2E0C494200F0B5A9 /* MockAPIEndpoint.swift in Sources */,
 				A5CFC87C2E439A9B00CBFC3B /* PollingWaitCallbackTests.swift in Sources */,
 				EC2326A42E0D671700634A50 /* JourneyContinueNodeTests.swift in Sources */,

--- a/Journey/Journey/Journey.swift
+++ b/Journey/Journey/Journey.swift
@@ -24,11 +24,22 @@ public typealias Journey = Workflow
 ///
 /// - forceAuth: Forces authentication even if a valid session exists.
 /// - noSession: Allows the journey to complete without creating a session.
+/// - verificationUriComplete: The `verificationUriComplete` URL from an RFC 8628 device
+///   authorization response. Set this when the current device is acting as the approving device.
+///   `OidcModule` reads this value from the workflow's shared context and uses it to extract
+///   the `user_code` and POST approval to the verification URL after a successful
+///   Journey authentication.
 public struct Options: Sendable {
     /// Whether to force authentication even when a valid session exists.
     public var forceAuth: Bool = false
     /// Whether to allow completion without generating a session.
     public var noSession: Bool = false
+    /// The `verificationUriComplete` URL from an RFC 8628 device authorization response.
+    ///
+    /// When set, `OidcModule` extracts the `user_code` query parameter from this URL and
+    /// POSTs it (with `decision=allow` and the SSO token as cookie) to the verification URL
+    /// after the user authenticates, thereby approving the requesting device.
+    public var verificationUriComplete: URL? = nil
 }
 
 /// Configuration for Journey workflows.
@@ -137,7 +148,12 @@ public extension Journey {
         
         self.sharedContext.set(key: JourneyConstants.forceAuth, value: options.forceAuth)
         self.sharedContext.set(key: JourneyConstants.noSession, value: options.noSession)
-        
+        if let uri = options.verificationUriComplete {
+            self.sharedContext.set(key: SharedContext.Keys.journeyVerificationUriCompleteKey, value: uri.absoluteString)
+        } else {
+            _ = self.sharedContext.removeValue(forKey: SharedContext.Keys.journeyVerificationUriCompleteKey)
+        }
+
         let request = config.httpClient.request()
         request.populateRequest(authIndexValue: journeyName, journeyConfig: journeyConfig, options: options)
         

--- a/Journey/Journey/Module/Oidc.swift
+++ b/Journey/Journey/Module/Oidc.swift
@@ -46,21 +46,20 @@ public class OidcModule {
             // No-op when the key is absent.
             if let uriString = journeyFlow.sharedContext.get(key: SharedContext.Keys.journeyVerificationUriCompleteKey) as? String,
                !uriString.isEmpty {
-                // Align with Android: always attempt the POST; fall back to success.session if journeyFlow.session() is nil.
-                let resolvedSession = await success.session.value.isEmpty ? (journeyFlow.session() ?? success.session) : success.session
-                if let ssoToken = resolvedSession as? SSOToken,
-                   let url = URL(string: uriString),
+                // The session value may be empty due to NoSession or re-run existing Journey
+                let existingSession: Session = !success.session.value.isEmpty ? success.session : (await journeyFlow.session() ?? success.session)
+                if let url = URL(string: uriString),
                    let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
                    let userCode = components.queryItems?.first(where: { $0.name == JourneyConstants.userCode })?.value,
                    !userCode.isEmpty {
                     let approvalConfig: JourneyConfig? = journeyFlow.config as? JourneyConfig
                     let response = try await journeyFlow.config.httpClient.request { request in
                         request.url = uriString
-                        request.setHeader(name: approvalConfig?.cookie ?? JourneyConstants.cookie, value: ssoToken.value)
+                        request.setHeader(name: approvalConfig?.cookie ?? JourneyConstants.cookie, value: existingSession.value)
                         request.form(parameters: [
                             JourneyConstants.userCode: userCode,
                             JourneyConstants.decision: JourneyConstants.decisionAllow,
-                            JourneyConstants.csrf: ssoToken.value
+                            JourneyConstants.csrf: existingSession.value
                         ])
                     }
                     guard response.status.isSuccess() else {

--- a/Journey/Journey/Module/Oidc.swift
+++ b/Journey/Journey/Module/Oidc.swift
@@ -46,27 +46,28 @@ public class OidcModule {
             // No-op when the key is absent.
             if let uriString = journeyFlow.sharedContext.get(key: SharedContext.Keys.journeyVerificationUriCompleteKey) as? String,
                !uriString.isEmpty {
-                let existingSsoToken = await !success.session.value.isEmpty ? success.session : journeyFlow.session()
-                if let ssoToken = existingSsoToken as? SSOToken,
+                // Align with Android: always attempt the POST; fall back to success.session if journeyFlow.session() is nil.
+                let resolvedSession = await success.session.value.isEmpty ? (journeyFlow.session() ?? success.session) : success.session
+                if let ssoToken = resolvedSession as? SSOToken,
                    let url = URL(string: uriString),
                    let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
                    let userCode = components.queryItems?.first(where: { $0.name == JourneyConstants.userCode })?.value,
                    !userCode.isEmpty {
                     let approvalConfig: JourneyConfig? = journeyFlow.config as? JourneyConfig
-                    do {
-                        let response = try await journeyFlow.config.httpClient.request { request in
-                            request.url = uriString
-                            request.setHeader(name: approvalConfig?.cookie ?? JourneyConstants.cookie, value: ssoToken.value)
-                            request.form(parameters: [
-                                JourneyConstants.userCode: userCode,
-                                JourneyConstants.decision: JourneyConstants.decisionAllow,
-                                JourneyConstants.csrf: ssoToken.value
-                            ])
-                        }
-                        journeyFlow.config.logger.i("Oidc: device approval response status: \(response.status)")
-                    } catch {
-                        journeyFlow.config.logger.e("Oidc: failed to submit approval to AM device endpoint", error: error)
+                    let response = try await journeyFlow.config.httpClient.request { request in
+                        request.url = uriString
+                        request.setHeader(name: approvalConfig?.cookie ?? JourneyConstants.cookie, value: ssoToken.value)
+                        request.form(parameters: [
+                            JourneyConstants.userCode: userCode,
+                            JourneyConstants.decision: JourneyConstants.decisionAllow,
+                            JourneyConstants.csrf: ssoToken.value
+                        ])
                     }
+                    guard response.status.isSuccess() else {
+                        journeyFlow.config.logger.w("Oidc: device approval POST returned non-2xx status: \(response.status)", error: nil)
+                        throw OidcError.apiError(code: response.status, message: response.bodyAsString())
+                    }
+                    journeyFlow.config.logger.i("Oidc: device approval response status: \(response.status)")
                 }
             }
 

--- a/Journey/Journey/Module/Oidc.swift
+++ b/Journey/Journey/Module/Oidc.swift
@@ -8,10 +8,12 @@
 //  of the MIT license. See the LICENSE file for details.
 //
 
+import Foundation
 import PingOidc
 import PingOrchestrate
 import PingJourneyPlugin
 import PingNetwork
+import PingLogger
 
 /// A module that integrates OIDC capabilities into the Journey workflow.
 public class OidcModule {
@@ -39,16 +41,45 @@ public class OidcModule {
         
         // Handles success of the module.
         setup.success { @Sendable context, success in
+            // RFC 8628 approving-device: when Journey.start was given a verificationUriComplete,
+            // POST user_code + decision=allow back to that URL with the SSO token as cookie.
+            // No-op when the key is absent.
+            if let uriString = journeyFlow.sharedContext.get(key: SharedContext.Keys.journeyVerificationUriCompleteKey) as? String,
+               !uriString.isEmpty {
+                let existingSsoToken = await !success.session.value.isEmpty ? success.session : journeyFlow.session()
+                if let ssoToken = existingSsoToken as? SSOToken,
+                   let url = URL(string: uriString),
+                   let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+                   let userCode = components.queryItems?.first(where: { $0.name == JourneyConstants.userCode })?.value,
+                   !userCode.isEmpty {
+                    let approvalConfig: JourneyConfig? = journeyFlow.config as? JourneyConfig
+                    do {
+                        let response = try await journeyFlow.config.httpClient.request { request in
+                            request.url = uriString
+                            request.setHeader(name: approvalConfig?.cookie ?? JourneyConstants.cookie, value: ssoToken.value)
+                            request.form(parameters: [
+                                JourneyConstants.userCode: userCode,
+                                JourneyConstants.decision: JourneyConstants.decisionAllow,
+                                JourneyConstants.csrf: ssoToken.value
+                            ])
+                        }
+                        journeyFlow.config.logger.i("Oidc: device approval response status: \(response.status)")
+                    } catch {
+                        journeyFlow.config.logger.e("Oidc: failed to submit approval to AM device endpoint", error: error)
+                    }
+                }
+            }
+
             let cloneConfig: OidcClientConfig = config.clone()
             let journeyConfig: JourneyConfig? = journeyFlow.config as? JourneyConfig
             let flowPkce = context.flowContext.get(key: SharedContext.Keys.pkceKey) as? Pkce
             let agent = CreateAgent(session: success.session, pkce: flowPkce, cookieName: journeyConfig?.cookie ?? JourneyConstants.cookie)
             cloneConfig.updateAgent(agent)
-            
+
             let oidcuser: User = OidcUser(config: cloneConfig)
             let prepareUser = UserDelegate(journey: journeyFlow, user: oidcuser, session: success.session)
             journeyFlow.sharedContext.set(key: SharedContext.Keys.userKey, value: prepareUser)
-            
+
             return SuccessNode(input: success.input, session: success.session)
         }
         
@@ -72,4 +103,9 @@ extension SharedContext.Keys {
     
     /// The key used to store the OIDC client configuration in the shared context.
     static let oidcClientConfigKey = "com.pingidentity.journey.OidcClientConfig"
+    
+    /// The shared context key under which `Journey.start` stores the `verificationUriComplete`
+    /// URL string. When set, `OidcModule.setup.success` posts approval to that URL after the
+    /// user authenticates, completing the RFC 8628 device authorization flow.
+    public static let journeyVerificationUriCompleteKey = "com.pingidentity.journey.VerificationUriComplete"
 }

--- a/Journey/JourneyTests/OidcDeviceApprovalTests.swift
+++ b/Journey/JourneyTests/OidcDeviceApprovalTests.swift
@@ -78,28 +78,31 @@ final class OidcDeviceApprovalTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(result.session.value, makeSSOToken().value)
     }
 
-    // MARK: - No-op when session is not SSOToken
+    // MARK: - Non-SSOToken session still POSTs (server-side rejection, not silent local success)
 
-    func testNoOpWhenSessionIsNotSSOToken() async throws {
+    /// Aligns with Android: when `verificationUriComplete` is set, the approval POST is always
+    /// attempted using the session's `value` regardless of concrete session type. A bad/empty
+    /// token surfaces as a server-side error rather than a silent local no-op.
+    func testNonSSOTokenSessionStillPostsApproval() async throws {
         let journey = makeJourney()
+        let verificationUri = "https://openam.example.com/activate?user_code=ABCD-1234"
         journey.sharedContext.set(
             key: SharedContext.Keys.journeyVerificationUriCompleteKey,
-            value: "https://openam.example.com/activate?user_code=ABCD-1234"
+            value: verificationUri
         )
 
-        var deviceUserRequestMade = false
+        var approvalRequestMade = false
         MockURLProtocol.requestHandler = { request in
-            if request.url?.path.contains("device/user") == true {
-                deviceUserRequestMade = true
+            if request.url?.absoluteString == verificationUri {
+                approvalRequestMade = true
             }
             return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data())
         }
 
-        // MockSession is not an SSOToken — the module's guard should short-circuit
         let nonSsoSession = MockSession(value: "non-sso")
         _ = try await driveSuccessHandlers(journey: journey, session: nonSsoSession)
 
-        XCTAssertFalse(deviceUserRequestMade, "No device/user POST should be made when session is not SSOToken")
+        XCTAssertTrue(approvalRequestMade, "Approval POST should be attempted even when session is not an SSOToken")
     }
 
     // MARK: - AM POST with correct parameters
@@ -257,7 +260,9 @@ final class OidcDeviceApprovalTests: XCTestCase, @unchecked Sendable {
             _ = try await driveSuccessHandlers(journey: journey, session: ssoToken)
             XCTFail("Expected driveSuccessHandlers to throw on network failure")
         } catch {
-            XCTAssertTrue(error is URLError, "Expected a URLError, got \(error)")
+            // The httpClient maps URLError to NetworkError; either is acceptable evidence the failure propagated.
+            let propagated = (error is URLError) || (error is NetworkError)
+            XCTAssertTrue(propagated, "Expected URLError or NetworkError, got \(error)")
         }
     }
 

--- a/Journey/JourneyTests/OidcDeviceApprovalTests.swift
+++ b/Journey/JourneyTests/OidcDeviceApprovalTests.swift
@@ -1,0 +1,262 @@
+//
+//  OidcDeviceApprovalTests.swift
+//  JourneyTests
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+import PingOrchestrate
+import PingJourneyPlugin
+@testable import PingJourney
+@testable import PingOidc
+@testable import PingNetwork
+@testable import PingLogger
+
+final class OidcDeviceApprovalTests: XCTestCase, @unchecked Sendable {
+
+    override func setUp() {
+        super.setUp()
+        MockURLProtocol.startInterceptingRequests()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        MockURLProtocol.stopInterceptingRequests()
+    }
+
+    // Builds a Journey with MockURLProtocol wired in. Device approval is built into OidcModule.
+    private func makeJourney() -> Journey {
+        Journey.createJourney { journeyConfig in
+            journeyConfig.serverUrl = "https://openam.example.com/am"
+            journeyConfig.realm = "alpha"
+            journeyConfig.cookie = "iPlanetDirectoryPro"
+            journeyConfig.httpClient = MockURLProtocol.makeClient()
+            journeyConfig.module(PingJourney.OidcModule.config) { oidcValue in
+                oidcValue.clientId = "testClient"
+                oidcValue.scopes = ["openid"]
+                oidcValue.redirectUri = "myapp://callback"
+                oidcValue.discoveryEndpoint = "https://openam.example.com/am/oauth2/alpha/.well-known/openid-configuration"
+            }
+        }
+    }
+
+    private func makeSSOToken(value: String = "test-sso-token") -> SSOTokenImpl {
+        SSOTokenImpl(value: value, successUrl: "https://openam.example.com/console", realm: "alpha")
+    }
+
+    // Runs all successHandlers on the journey and returns the last SuccessNode emitted.
+    private func driveSuccessHandlers(journey: Journey, session: Session) async throws -> SuccessNode {
+        let context = FlowContext(flowContext: journey.sharedContext)
+        var node = SuccessNode(session: session)
+        for handler in journey.successHandlers {
+            node = try await handler(context, node)
+        }
+        return node
+    }
+
+    // MARK: - No-op when verificationUriComplete is absent
+
+    func testNoOpWhenVerificationUriCompleteKeyAbsent() async throws {
+        let journey = makeJourney()
+        // verificationUriCompleteKey is NOT set in sharedContext
+
+        var deviceUserRequestMade = false
+        MockURLProtocol.requestHandler = { request in
+            if request.url?.path.contains("device/user") == true {
+                deviceUserRequestMade = true
+            }
+            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data())
+        }
+
+        let result = try await driveSuccessHandlers(journey: journey, session: makeSSOToken())
+
+        XCTAssertFalse(deviceUserRequestMade, "No device/user POST should be made when verificationUriComplete is absent")
+        XCTAssertEqual(result.session.value, makeSSOToken().value)
+    }
+
+    // MARK: - No-op when session is not SSOToken
+
+    func testNoOpWhenSessionIsNotSSOToken() async throws {
+        let journey = makeJourney()
+        journey.sharedContext.set(
+            key: SharedContext.Keys.journeyVerificationUriCompleteKey,
+            value: "https://openam.example.com/activate?user_code=ABCD-1234"
+        )
+
+        var deviceUserRequestMade = false
+        MockURLProtocol.requestHandler = { request in
+            if request.url?.path.contains("device/user") == true {
+                deviceUserRequestMade = true
+            }
+            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data())
+        }
+
+        // MockSession is not an SSOToken — the module's guard should short-circuit
+        let nonSsoSession = MockSession(value: "non-sso")
+        _ = try await driveSuccessHandlers(journey: journey, session: nonSsoSession)
+
+        XCTAssertFalse(deviceUserRequestMade, "No device/user POST should be made when session is not SSOToken")
+    }
+
+    // MARK: - AM POST with correct parameters
+
+    func testDeviceApprovalPostWithCorrectParameters() async throws {
+        let journey = makeJourney()
+        let ssoToken = makeSSOToken(value: "my-sso-session-token")
+        let verificationUri = "https://openam.example.com/activate?user_code=ABCD-1234"
+        journey.sharedContext.set(
+            key: SharedContext.Keys.journeyVerificationUriCompleteKey,
+            value: verificationUri
+        )
+
+        var capturedRequest: URLRequest?
+        var capturedBodyParams = [String: String]()
+
+        MockURLProtocol.requestHandler = { request in
+            // The module POSTs to the verificationUriComplete URL itself (/activate), not a /device/user path.
+            if request.url?.absoluteString == verificationUri {
+                capturedRequest = request
+                // URLSession may move httpBody to httpBodyStream before giving the request to URLProtocol.
+                let bodyData: Data?
+                if let data = request.httpBody {
+                    bodyData = data
+                } else if let stream = request.httpBodyStream {
+                    stream.open()
+                    var data = Data()
+                    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 4096)
+                    while stream.hasBytesAvailable {
+                        let count = stream.read(buffer, maxLength: 4096)
+                        if count > 0 { data.append(buffer, count: count) }
+                    }
+                    buffer.deallocate()
+                    stream.close()
+                    bodyData = data
+                } else {
+                    bodyData = nil
+                }
+                if let data = bodyData, let bodyString = String(data: data, encoding: .utf8) {
+                    for pair in bodyString.components(separatedBy: "&") {
+                        let kv = pair.components(separatedBy: "=")
+                        if kv.count == 2 {
+                            capturedBodyParams[kv[0]] = kv[1].removingPercentEncoding ?? kv[1]
+                        }
+                    }
+                }
+                return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data())
+            }
+            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data())
+        }
+
+        let result = try await driveSuccessHandlers(journey: journey, session: ssoToken)
+
+        // The SuccessNode should be returned unchanged.
+        XCTAssertEqual(result.session.value, ssoToken.value)
+
+        // A POST should have been made to the verificationUriComplete URL.
+        XCTAssertNotNil(capturedRequest, "Expected a POST to the verificationUriComplete URL")
+        XCTAssertEqual(capturedRequest?.url?.absoluteString, verificationUri)
+
+        // Form parameters must match RFC 8628 expectations.
+        XCTAssertEqual(capturedBodyParams["user_code"], "ABCD-1234")
+        XCTAssertEqual(capturedBodyParams["decision"], "allow")
+        XCTAssertEqual(capturedBodyParams["csrf"], ssoToken.value)
+
+        // SSO token should appear in the custom cookie header (name taken from JourneyConfig.cookie).
+        // makeJourney() sets journeyConfig.cookie = "iPlanetDirectoryPro".
+        let cookieHeaderValue = capturedRequest?.value(forHTTPHeaderField: "iPlanetDirectoryPro") ?? ""
+        XCTAssertEqual(cookieHeaderValue, ssoToken.value,
+                       "iPlanetDirectoryPro header should carry the SSO token value")
+    }
+
+    // MARK: - No-op when verificationUriComplete URI is malformed
+
+    func testNoOpWhenVerificationUriCompleteIsMalformed() async throws {
+        let journey = makeJourney()
+        journey.sharedContext.set(
+            key: SharedContext.Keys.journeyVerificationUriCompleteKey,
+            value: "not a valid url %%%"
+        )
+
+        var deviceUserRequestMade = false
+        MockURLProtocol.requestHandler = { request in
+            if request.url?.path.contains("device/user") == true {
+                deviceUserRequestMade = true
+            }
+            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data())
+        }
+
+        _ = try await driveSuccessHandlers(journey: journey, session: makeSSOToken())
+
+        XCTAssertFalse(deviceUserRequestMade, "No POST should be made when verificationUriComplete is a malformed URL")
+    }
+
+    // MARK: - No-op when user_code is missing from URI
+
+    func testNoOpWhenUserCodeIsMissingFromUri() async throws {
+        let journey = makeJourney()
+        // Valid URL but no user_code query parameter
+        journey.sharedContext.set(
+            key: SharedContext.Keys.journeyVerificationUriCompleteKey,
+            value: "https://openam.example.com/activate"
+        )
+
+        var deviceUserRequestMade = false
+        MockURLProtocol.requestHandler = { request in
+            if request.url?.path.contains("device/user") == true {
+                deviceUserRequestMade = true
+            }
+            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data())
+        }
+
+        _ = try await driveSuccessHandlers(journey: journey, session: makeSSOToken())
+
+        XCTAssertFalse(deviceUserRequestMade, "No POST should be made when user_code is absent from verificationUriComplete")
+    }
+
+    // MARK: - No-op when user_code is empty
+
+    func testNoOpWhenUserCodeIsEmpty() async throws {
+        let journey = makeJourney()
+        journey.sharedContext.set(
+            key: SharedContext.Keys.journeyVerificationUriCompleteKey,
+            value: "https://openam.example.com/activate?user_code="
+        )
+
+        var deviceUserRequestMade = false
+        MockURLProtocol.requestHandler = { request in
+            if request.url?.path.contains("device/user") == true {
+                deviceUserRequestMade = true
+            }
+            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data())
+        }
+
+        _ = try await driveSuccessHandlers(journey: journey, session: makeSSOToken())
+
+        XCTAssertFalse(deviceUserRequestMade, "No POST should be made when user_code value is empty")
+    }
+
+    // MARK: - Network failure does not convert SuccessNode to FailureNode
+
+    func testNetworkFailureDoesNotFailSuccessNode() async throws {
+        let journey = makeJourney()
+        journey.sharedContext.set(
+            key: SharedContext.Keys.journeyVerificationUriCompleteKey,
+            value: "https://openam.example.com/activate?user_code=EFGH-5678"
+        )
+
+        MockURLProtocol.requestHandler = { request in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let ssoToken = makeSSOToken()
+        let result = try await driveSuccessHandlers(journey: journey, session: ssoToken)
+
+        // Even when the network call throws, the module must absorb the error and return SuccessNode.
+        XCTAssertEqual(result.session.value, ssoToken.value,
+                       "SuccessNode session should be unchanged after a network failure in device approval")
+    }
+}

--- a/Journey/JourneyTests/OidcDeviceApprovalTests.swift
+++ b/Journey/JourneyTests/OidcDeviceApprovalTests.swift
@@ -239,9 +239,9 @@ final class OidcDeviceApprovalTests: XCTestCase, @unchecked Sendable {
         XCTAssertFalse(deviceUserRequestMade, "No POST should be made when user_code value is empty")
     }
 
-    // MARK: - Network failure does not convert SuccessNode to FailureNode
+    // MARK: - Network failure propagates as a throw (caller sees FailureNode)
 
-    func testNetworkFailureDoesNotFailSuccessNode() async throws {
+    func testNetworkFailurePropagates() async throws {
         let journey = makeJourney()
         journey.sharedContext.set(
             key: SharedContext.Keys.journeyVerificationUriCompleteKey,
@@ -253,10 +253,39 @@ final class OidcDeviceApprovalTests: XCTestCase, @unchecked Sendable {
         }
 
         let ssoToken = makeSSOToken()
-        let result = try await driveSuccessHandlers(journey: journey, session: ssoToken)
+        do {
+            _ = try await driveSuccessHandlers(journey: journey, session: ssoToken)
+            XCTFail("Expected driveSuccessHandlers to throw on network failure")
+        } catch {
+            XCTAssertTrue(error is URLError, "Expected a URLError, got \(error)")
+        }
+    }
 
-        // Even when the network call throws, the module must absorb the error and return SuccessNode.
-        XCTAssertEqual(result.session.value, ssoToken.value,
-                       "SuccessNode session should be unchanged after a network failure in device approval")
+    // MARK: - Non-2xx approval response propagates as a throw (caller sees FailureNode)
+
+    func testNon2xxApprovalResponsePropagates() async throws {
+        let journey = makeJourney()
+        journey.sharedContext.set(
+            key: SharedContext.Keys.journeyVerificationUriCompleteKey,
+            value: "https://openam.example.com/activate?user_code=EFGH-5678"
+        )
+
+        MockURLProtocol.requestHandler = { request in
+            return (HTTPURLResponse(url: request.url!, statusCode: 403, httpVersion: nil, headerFields: nil)!, Data())
+        }
+
+        let ssoToken = makeSSOToken()
+        do {
+            _ = try await driveSuccessHandlers(journey: journey, session: ssoToken)
+            XCTFail("Expected driveSuccessHandlers to throw on non-2xx approval response")
+        } catch let error as OidcError {
+            if case .apiError(let code, _) = error {
+                XCTAssertEqual(code, 403)
+            } else {
+                XCTFail("Expected OidcError.apiError, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected OidcError, got \(error)")
+        }
     }
 }

--- a/Journey/README.md
+++ b/Journey/README.md
@@ -158,6 +158,20 @@ let journey = Journey.createJourney { config in
 
 The PAR endpoint is discovered automatically from the OpenID configuration. If the server does not advertise a `pushed_authorization_request_endpoint`, the SDK falls back to the standard authorization flow.
 
+### Device Authorization Grant — approving device (RFC 8628)
+
+When this device is acting as the *approving* device for an [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628) device-flow request initiated elsewhere (e.g., a smart TV), pass the `verificationUriComplete` URL into `start(_:configure:)`. After the user authenticates through the Journey flow, the `OidcModule` extracts the `user_code` from the URL and POSTs it (with `decision=allow` and the SSO token as cookie) to that URL, approving the requesting device.
+
+```swift
+let node = await journey.start("Login") { options in
+    options.verificationUriComplete = URL(string: verificationUriCompleteString)
+}
+```
+
+`verificationUriComplete` is the URL returned in the `verification_uri_complete` field of the requesting device's `DeviceAuthorizationResponse` — typically scanned from a QR code or pasted by the user. Approval happens transparently in `OidcModule.success` after Journey authentication completes; the requesting device then receives its access token via its own polling loop.
+
+When `verificationUriComplete` is not set, the `OidcModule` proceeds with normal user-delegate setup and no approval POST is made. The cookie name used for the approval POST is taken from `JourneyConfig.cookie`.
+
 ### Navigating the Authentication Flow
 
 The `start()` method initiates the authentication journey and returns a `Node` instance,

--- a/JourneyPlugin/JourneyPlugin/Constants.swift
+++ b/JourneyPlugin/JourneyPlugin/Constants.swift
@@ -144,4 +144,10 @@ public enum JourneyConstants {
     public static let description = "description"
     public static let submitButtonText = "submitButtonText"
     public static let pageFooter = "pageFooter"
+
+    /// RFC 8628 Device Authorization Grant approval constants
+    public static let userCode = "user_code"
+    public static let decision = "decision"
+    public static let decisionAllow = "allow"
+    public static let csrf = "csrf"
 }

--- a/Oidc/Oidc.xcodeproj/project.pbxproj
+++ b/Oidc/Oidc.xcodeproj/project.pbxproj
@@ -11,6 +11,11 @@
 		3AB1CA162BD6F99C003FCE3C /* Oidc.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB1CA0A2BD6F99C003FCE3C /* Oidc.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3AB1CA2D2BD7727B003FCE3C /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB1CA2A2BD7727B003FCE3C /* Token.swift */; };
 		3AB1CA2E2BD7727B003FCE3C /* Pkce.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB1CA2B2BD7727B003FCE3C /* Pkce.swift */; };
+		SDKS4785A001 /* DeviceAuthorizationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS4785F001 /* DeviceAuthorizationResponse.swift */; };
+		SDKS4785A002 /* DeviceFlowStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS4785F002 /* DeviceFlowStatus.swift */; };
+		SDKS4785A003 /* OidcDeviceClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS4785F003 /* OidcDeviceClientTests.swift */; };
+		SDKS4785A005 /* OidcDeviceClientAdditionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS4785F005 /* OidcDeviceClientAdditionalTests.swift */; };
+		SDKS4785A004 /* OidcDeviceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS4785F004 /* OidcDeviceClient.swift */; };
 		3AB1CA312BD859BC003FCE3C /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB1CA302BD859BC003FCE3C /* User.swift */; };
 		3AB1CA332BD8823C003FCE3C /* Agent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB1CA322BD8823C003FCE3C /* Agent.swift */; };
 		3AB1CA352BD884E4003FCE3C /* OidcClientConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB1CA342BD884E4003FCE3C /* OidcClientConfig.swift */; };
@@ -101,6 +106,11 @@
 		EC0CB5942E266F3400A82D6C /* Oidc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Oidc.swift; sourceTree = "<group>"; };
 		EC23D5122E295AAB00C43D42 /* Web.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Web.swift; sourceTree = "<group>"; };
 		EC23D5142E2E7A1100C43D42 /* OidcWebClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcWebClientTests.swift; sourceTree = "<group>"; };
+		SDKS4785F001 /* DeviceAuthorizationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceAuthorizationResponse.swift; sourceTree = "<group>"; };
+		SDKS4785F002 /* DeviceFlowStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceFlowStatus.swift; sourceTree = "<group>"; };
+		SDKS4785F003 /* OidcDeviceClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcDeviceClientTests.swift; sourceTree = "<group>"; };
+		SDKS4785F005 /* OidcDeviceClientAdditionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcDeviceClientAdditionalTests.swift; sourceTree = "<group>"; };
+		SDKS4785F004 /* OidcDeviceClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcDeviceClient.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -163,6 +173,9 @@
 				EC0CB5932E266F2D00A82D6C /* Module */,
 				3AB1CA322BD8823C003FCE3C /* Agent.swift */,
 				A50966B72C4C34CB00A4E5B5 /* AuthCode.swift */,
+				SDKS4785F001 /* DeviceAuthorizationResponse.swift */,
+				SDKS4785F002 /* DeviceFlowStatus.swift */,
+				SDKS4785F004 /* OidcDeviceClient.swift */,
 				3AB1CA3C2BD961A2003FCE3C /* OidcClient.swift */,
 				3AB1CA342BD884E4003FCE3C /* OidcClientConfig.swift */,
 				A50966B52C4C342800A4E5B5 /* OidcError.swift */,
@@ -184,6 +197,8 @@
 				A50966E22C4F2F4300A4E5B5 /* OidcClientTests.swift */,
 						7101980CC54DBB835D4F7DB3 /* OidcClientPARTests.swift */,
 						77E2E5250895DD43A8388F8A /* OidcAdditionalTests.swift */,
+				SDKS4785F003 /* OidcDeviceClientTests.swift */,
+				SDKS4785F005 /* OidcDeviceClientAdditionalTests.swift */,
 				EC23D5142E2E7A1100C43D42 /* OidcWebClientTests.swift */,
 				A50966DA2C4DDFAE00A4E5B5 /* PkceTests.swift */,
 				A50966D42C4DD79000A4E5B5 /* TokenTests.swift */,
@@ -326,6 +341,9 @@
 			files = (
 				3AB1CA312BD859BC003FCE3C /* User.swift in Sources */,
 				EC0CB5952E266F3900A82D6C /* Oidc.swift in Sources */,
+				SDKS4785A001 /* DeviceAuthorizationResponse.swift in Sources */,
+				SDKS4785A002 /* DeviceFlowStatus.swift in Sources */,
+				SDKS4785A004 /* OidcDeviceClient.swift in Sources */,
 				3AB1CA3D2BD961A2003FCE3C /* OidcClient.swift in Sources */,
 				3AB1CA332BD8823C003FCE3C /* Agent.swift in Sources */,
 				A50966B82C4C34CB00A4E5B5 /* AuthCode.swift in Sources */,
@@ -355,6 +373,8 @@
 				A50966E32C4F2F4300A4E5B5 /* OidcClientTests.swift in Sources */,
 						700AADB6B22EDCF175F25320 /* OidcClientPARTests.swift in Sources */,
 						CE68EBE71BABE65295E0CFCA /* OidcAdditionalTests.swift in Sources */,
+				SDKS4785A003 /* OidcDeviceClientTests.swift in Sources */,
+				SDKS4785A005 /* OidcDeviceClientAdditionalTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Oidc/Oidc/DeviceAuthorizationResponse.swift
+++ b/Oidc/Oidc/DeviceAuthorizationResponse.swift
@@ -1,0 +1,48 @@
+//
+//  DeviceAuthorizationResponse.swift
+//  PingOidc
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+/// Represents the server response to a device authorization request (RFC 8628).
+public struct DeviceAuthorizationResponse: Decodable, Sendable {
+    /// The device verification code.
+    public let deviceCode: String
+    /// The end-user verification code.
+    public let userCode: String
+    /// The end-user verification URI on the authorization server.
+    public let verificationUri: String
+    /// An optional verification URI that includes the `user_code` for non-textual transmission.
+    public let verificationUriComplete: String?
+    /// The lifetime in seconds of the `deviceCode` and `userCode`.
+    public let expiresIn: Int
+    /// The minimum amount of time in seconds the client should wait between polling requests.
+    /// Defaults to `5` if absent from the server response.
+    public let interval: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case deviceCode = "device_code"
+        case userCode = "user_code"
+        case verificationUri = "verification_uri"
+        case verificationUriComplete = "verification_uri_complete"
+        case expiresIn = "expires_in"
+        case interval
+    }
+
+    /// Decodes a `DeviceAuthorizationResponse` from the standard RFC 8628 JSON
+    /// representation, mapping snake-case JSON keys to camelCase properties.
+    /// `interval` defaults to `5` seconds when omitted by the server.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        deviceCode = try container.decode(String.self, forKey: .deviceCode)
+        userCode = try container.decode(String.self, forKey: .userCode)
+        verificationUri = try container.decode(String.self, forKey: .verificationUri)
+        verificationUriComplete = try container.decodeIfPresent(String.self, forKey: .verificationUriComplete)
+        expiresIn = try container.decode(Int.self, forKey: .expiresIn)
+        interval = try container.decodeIfPresent(Int.self, forKey: .interval) ?? 5
+    }
+}

--- a/Oidc/Oidc/DeviceFlowStatus.swift
+++ b/Oidc/Oidc/DeviceFlowStatus.swift
@@ -1,0 +1,29 @@
+//
+//  DeviceFlowStatus.swift
+//  PingOidc
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import Foundation
+
+/// Represents the status of an RFC 8628 device authorization flow.
+public enum DeviceFlowStatus: Sendable {
+    /// The device authorization request succeeded. The associated value carries the server response
+    /// including the `userCode` and `verificationUri` to display to the end user.
+    case started(DeviceAuthorizationResponse)
+    /// The polling loop is active. Carries the current poll count, current interval (seconds),
+    /// and the `Date` at which the next poll will be attempted.
+    case polling(pollCount: Int, pollInterval: Int, nextPollAt: Date)
+    /// Authorization succeeded. The associated value is the authenticated `User`.
+    case success(any User)
+    /// The device code has expired before the user authorized the request.
+    case expired
+    /// The user denied the authorization request.
+    case accessDenied
+    /// A terminal error occurred that does not map to a specific RFC 8628 error code.
+    case failure(any Error)
+}

--- a/Oidc/Oidc/OidcClient.swift
+++ b/Oidc/Oidc/OidcClient.swift
@@ -498,4 +498,7 @@ public extension OidcClient.Constants {
     static let state = "state"
     static let piflow = "pi.flow"
     static let query = "query"
+    static let userCodeSnake = "user_code"
+    static let userCodeCamel = "userCode"
+    static let asDeviceAuthorizationPath = "/as/device_authorization"
 }

--- a/Oidc/Oidc/OidcClientConfig.swift
+++ b/Oidc/Oidc/OidcClientConfig.swift
@@ -55,6 +55,10 @@ public class OidcClientConfig: @unchecked Sendable {
     public var par: Bool = false
     /// HTTP client for making network requests.
     public var httpClient: (any HttpClientProtocol)?
+    /// Called once after OpenID discovery completes, allowing callers to patch any field
+    /// on the discovered `OpenIdConfiguration` before it is used (e.g. override
+    /// `deviceAuthorizationEndpoint` for a non-standard server).
+    public var openIdOverride: ((inout OpenIdConfiguration) -> Void)?
     
     /// Initializes a new `OidcClientConfig` instance.
     public init() {
@@ -84,8 +88,12 @@ public class OidcClientConfig: @unchecked Sendable {
         if openId != nil {
             return
         }
-        
+
         openId = try await discover()
+        if var discovered = openId {
+            openIdOverride?(&discovered)
+            openId = discovered
+        }
     }
     
     /// Discovers the OpenID configuration from the discovery endpoint.
@@ -141,5 +149,6 @@ public class OidcClientConfig: @unchecked Sendable {
         self.additionalParameters = other.additionalParameters
         self.par = other.par
         self.httpClient = other.httpClient
+        self.openIdOverride = other.openIdOverride
     }
 }

--- a/Oidc/Oidc/OidcClientConfig.swift
+++ b/Oidc/Oidc/OidcClientConfig.swift
@@ -15,6 +15,10 @@ import PingLogger
 import PingStorage
 
 /// Configuration class for OIDC client.
+///
+/// - Important: This class is `@unchecked Sendable` and contains mutable `var` fields.
+///   Configure all properties before passing the instance to any client or workflow — do
+///   not mutate it afterwards, as it may be read concurrently from background threads.
 public class OidcClientConfig: @unchecked Sendable {
     /// OpenID configuration.
     public var openId: OpenIdConfiguration?

--- a/Oidc/Oidc/OidcDeviceClient.swift
+++ b/Oidc/Oidc/OidcDeviceClient.swift
@@ -1,0 +1,295 @@
+//
+//  OidcDeviceClient.swift
+//  PingOidc
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import Foundation
+import PingBrowser
+import PingLogger
+
+/// A client that implements the RFC 8628 Device Authorization Grant (requesting-device side).
+///
+/// Use `OidcDeviceClient` when the device cannot open a browser directly
+/// (e.g., a smart TV or CLI tool). Call `deviceAuthorization()` to start the
+/// flow and receive a stream of `DeviceFlowStatus` updates. The stream yields
+/// `.started` with the `userCode` and `verificationUri` to display, then
+/// `.polling` on each poll, and finally `.success`, `.accessDenied`, or
+/// `.expired` when the flow resolves.
+public class OidcDeviceClient: @unchecked Sendable {
+
+    enum Constants {
+        static let deviceCode = "device_code"
+        static let deviceCodeGrantType = "urn:ietf:params:oauth:grant-type:device_code"
+        static let error = "error"
+        static let authorizationPending = "authorization_pending"
+        static let slowDown = "slow_down"
+        static let accessDenied = "access_denied"
+        static let expiredToken = "expired_token"
+    }
+
+    private let config: OidcClientConfig
+    private let logger: Logger
+
+    /// Initializes a new `OidcDeviceClient`.
+    /// - Parameter config: The OIDC client configuration to use.
+    public init(config: OidcClientConfig) {
+        self.config = config
+        self.logger = config.logger
+    }
+
+    /// Creates an `OidcDeviceClient` using the provided configuration block.
+    /// - Parameter block: A closure to configure the `OidcClientConfig`.
+    /// - Returns: A fully configured `OidcDeviceClient`.
+    public static func createOidcDeviceClient(block: (OidcClientConfig) -> Void) -> OidcDeviceClient {
+        let config = OidcClientConfig()
+        block(config)
+        return OidcDeviceClient(config: config)
+    }
+
+    // MARK: - Device Authorization
+
+    /// Starts the RFC 8628 device authorization flow.
+    ///
+    /// 1. Calls `config.oidcInitialize()` to set up the HTTP client and discover endpoints.
+    /// 2. POSTs to the `device_authorization_endpoint` to obtain a `DeviceAuthorizationResponse`.
+    /// 3. Returns an `AsyncThrowingStream` that yields `.started`, then polls the token
+    ///    endpoint and yields `.polling` / `.success` / `.accessDenied` / `.expired`.
+    ///
+    /// - Returns: An `AsyncThrowingStream<DeviceFlowStatus, Error>`.
+    /// - Throws: `OidcError.unknown` if the discovered configuration does not include a
+    ///   device authorization endpoint; `OidcError.apiError` if the initial POST fails.
+    public func deviceAuthorization() async throws -> AsyncThrowingStream<DeviceFlowStatus, Error> {
+        try await config.oidcInitialize()
+
+        guard let deviceAuthorizationEndpoint = config.openId?.deviceAuthorizationEndpoint else {
+            throw OidcError.unknown(message: "Device authorization endpoint not found in OpenID configuration")
+        }
+
+        guard let httpClient = config.httpClient else {
+            throw OidcError.networkError(message: "HTTP client not found")
+        }
+
+        guard let openId = config.openId else {
+            throw OidcError.unknown(message: "OpenID configuration not found")
+        }
+
+        let scopeString = config.scopes.joined(separator: " ")
+        let clientId = config.clientId
+
+        let response = try await httpClient.request { request in
+            request.url = deviceAuthorizationEndpoint
+            request.form(parameters: [
+                OidcClient.Constants.client_id: clientId,
+                OidcClient.Constants.scope: scopeString
+            ])
+        }
+
+        guard response.status.isSuccess() else {
+            throw OidcError.apiError(code: response.status, message: response.bodyAsString())
+        }
+
+        let deviceAuthResponse = try JSONDecoder().decode(
+            DeviceAuthorizationResponse.self,
+            from: response.body ?? Data()
+        )
+
+        // Capture everything needed inside the stream closure — device_code never touches logger
+        let deviceCode = deviceAuthResponse.deviceCode
+        let tokenEndpoint = openId.tokenEndpoint
+        let storage = config.storage
+        let capturedConfig = config
+        let capturedLogger = logger
+
+        return AsyncThrowingStream { continuation in
+            let task = Task.detached {
+                continuation.yield(.started(deviceAuthResponse))
+
+                var interval = deviceAuthResponse.interval
+                var pollCount = 0
+                var consecutiveTimeouts = 0
+
+                while true {
+                    do {
+                        try await Task.sleep(for: .seconds(interval))
+                    } catch {
+                        continuation.finish(throwing: error)
+                        return
+                    }
+
+                    do {
+                        let tokenResponse = try await httpClient.request { request in
+                            request.url = tokenEndpoint
+                            request.form(parameters: [
+                                OidcClient.Constants.grant_type: Constants.deviceCodeGrantType,
+                                Constants.deviceCode: deviceCode,
+                                OidcClient.Constants.client_id: clientId
+                            ])
+                        }
+
+                        if tokenResponse.status.isSuccess() {
+                            // Attempt to decode as a Token
+                            if let token = try? JSONDecoder().decode(Token.self, from: tokenResponse.body ?? Data()) {
+                                try? await storage.save(item: token)
+                                continuation.yield(.success(OidcUser(config: capturedConfig)))
+                                continuation.finish()
+                                return
+                            }
+                        }
+
+                        // Parse error response
+                        if let body = tokenResponse.body,
+                           let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+                           let errorCode = json[Constants.error] as? String {
+
+                            switch errorCode {
+                            case Constants.authorizationPending:
+                                consecutiveTimeouts = 0
+                                pollCount += 1
+                                continuation.yield(.polling(
+                                    pollCount: pollCount,
+                                    pollInterval: interval,
+                                    nextPollAt: Date().addingTimeInterval(Double(interval))
+                                ))
+
+                            case Constants.slowDown:
+                                consecutiveTimeouts = 0
+                                interval += 5
+                                pollCount += 1
+                                continuation.yield(.polling(
+                                    pollCount: pollCount,
+                                    pollInterval: interval,
+                                    nextPollAt: Date().addingTimeInterval(Double(interval))
+                                ))
+
+                            case Constants.accessDenied:
+                                continuation.yield(.accessDenied)
+                                continuation.finish()
+                                return
+
+                            case Constants.expiredToken:
+                                continuation.yield(.expired)
+                                continuation.finish()
+                                return
+
+                            default:
+                                continuation.finish(
+                                    throwing: OidcError.apiError(
+                                        code: tokenResponse.status,
+                                        message: tokenResponse.bodyAsString()
+                                    )
+                                )
+                                return
+                            }
+                        } else {
+                            // Non-success, non-parseable error response
+                            continuation.finish(
+                                throwing: OidcError.apiError(
+                                    code: tokenResponse.status,
+                                    message: tokenResponse.bodyAsString()
+                                )
+                            )
+                            return
+                        }
+
+                    } catch let urlError as URLError {
+                        // Network/timeout error — apply exponential backoff and continue
+                        consecutiveTimeouts += 1
+                        let backoffMultiplier = 1 << min(consecutiveTimeouts, 3)
+                        interval = min(max(interval * backoffMultiplier, 5), 60)
+                        pollCount += 1
+                        capturedLogger.w("Device flow poll encountered a network error. Backing off to \(interval)s.", error: urlError)
+                        continuation.yield(.polling(
+                            pollCount: pollCount,
+                            pollInterval: interval,
+                            nextPollAt: Date().addingTimeInterval(Double(interval))
+                        ))
+                    } catch {
+                        // Non-OidcError generic error — apply backoff and continue
+                        if error is OidcError {
+                            continuation.finish(throwing: error)
+                            return
+                        }
+                        consecutiveTimeouts += 1
+                        let backoffMultiplier = 1 << min(consecutiveTimeouts, 3)
+                        interval = min(max(interval * backoffMultiplier, 5), 60)
+                        pollCount += 1
+                        capturedLogger.w("Device flow poll encountered an error. Backing off to \(interval)s.", error: error)
+                        continuation.yield(.polling(
+                            pollCount: pollCount,
+                            pollInterval: interval,
+                            nextPollAt: Date().addingTimeInterval(Double(interval))
+                        ))
+                    }
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    // MARK: - Browser Authorization
+
+    /// Opens the `verificationUriComplete` URL in an `SFSafariViewController` so the user
+    /// can approve the device flow on this device. Suspends until the browser is dismissed
+    /// (either via the redirect callback or because the user closed it); the polling loop
+    /// in `deviceAuthorization()` continues independently while this method is awaiting.
+    ///
+    /// - Parameter verificationUriComplete: The verification URI (including `user_code`)
+    ///   returned in the `DeviceAuthorizationResponse`.
+    /// - Throws: `BrowserError.externalUserAgentCancelled` if the user closed the browser
+    ///   before completing the flow, or any other error surfaced by `BrowserLauncher`.
+    ///   No-ops (returns without throwing) if `verificationUriComplete` is not a valid URL
+    ///   or `config.redirectUri` has no scheme.
+    public func authorize(verificationUriComplete: String) async throws {
+        guard let url = URL(string: verificationUriComplete) else {
+            logger.w("authorize: invalid verificationUriComplete URL", error: nil)
+            return
+        }
+
+        guard let callbackURLScheme = redirectURIScheme() else {
+            logger.w("authorize: no redirectUri scheme configured", error: nil)
+            return
+        }
+
+        _ = try await BrowserLauncher.currentBrowser.launch(
+            url: url,
+            customParams: nil,
+            browserType: .sfViewController,
+            browserMode: .login,
+            callbackURLScheme: callbackURLScheme,
+            logger: logger
+        )
+    }
+
+    // MARK: - Revoke
+
+    /// Revokes the stored token by delegating to `OidcClient`.
+    public func revoke() async {
+        await OidcClient(config: config).revoke()
+    }
+
+    // MARK: - User
+
+    /// Returns an `OidcUser` if a token exists in storage; otherwise returns `nil`.
+    public func user() async -> (any User)? {
+        if (try? await config.storage.get()) != nil {
+            return OidcUser(config: config)
+        }
+        return nil
+    }
+
+    // MARK: - Private Helpers
+
+    /// Extracts the URL scheme from `config.redirectUri`, matching the approach used
+    /// by `OidcClient.redirectURIScheme()`.
+    private func redirectURIScheme() -> String? {
+        if let redirectURI = URL(string: config.redirectUri), let scheme = redirectURI.scheme {
+            return scheme
+        }
+        return nil
+    }
+}

--- a/Oidc/Oidc/OidcDeviceClient.swift
+++ b/Oidc/Oidc/OidcDeviceClient.swift
@@ -20,6 +20,10 @@ import PingLogger
 /// `.started` with the `userCode` and `verificationUri` to display, then
 /// `.polling` on each poll, and finally `.success`, `.accessDenied`, or
 /// `.expired` when the flow resolves.
+///
+/// - Important: `OidcClientConfig` is marked `@unchecked Sendable` and contains mutable
+///   `var` fields. Do not mutate the config after passing it to this initializer — the
+///   polling loop captures the config and reads it from a background thread.
 public class OidcDeviceClient: @unchecked Sendable {
 
     enum Constants {
@@ -106,10 +110,12 @@ public class OidcDeviceClient: @unchecked Sendable {
         let capturedLogger = logger
 
         return AsyncThrowingStream { continuation in
-            let task = Task.detached {
+            // Cancellation is handled below via continuation.onTermination.
+            let task = Task {
                 continuation.yield(.started(deviceAuthResponse))
 
-                var interval = deviceAuthResponse.interval
+                let baseInterval = deviceAuthResponse.interval
+                var interval = baseInterval
                 var pollCount = 0
                 var consecutiveTimeouts = 0
 
@@ -148,7 +154,9 @@ public class OidcDeviceClient: @unchecked Sendable {
 
                             switch errorCode {
                             case Constants.authorizationPending:
+                                // Network recovered — restore interval to the server-provided base (RFC 8628 §3.5).
                                 consecutiveTimeouts = 0
+                                interval = baseInterval
                                 pollCount += 1
                                 continuation.yield(.polling(
                                     pollCount: pollCount,
@@ -200,7 +208,7 @@ public class OidcDeviceClient: @unchecked Sendable {
                         // Network/timeout error — apply exponential backoff and continue
                         consecutiveTimeouts += 1
                         let backoffMultiplier = 1 << min(consecutiveTimeouts, 3)
-                        interval = min(max(interval * backoffMultiplier, 5), 60)
+                        interval = min(max(baseInterval * backoffMultiplier, 5), 60)
                         pollCount += 1
                         capturedLogger.w("Device flow poll encountered a network error. Backing off to \(interval)s.", error: urlError)
                         continuation.yield(.polling(
@@ -216,7 +224,7 @@ public class OidcDeviceClient: @unchecked Sendable {
                         }
                         consecutiveTimeouts += 1
                         let backoffMultiplier = 1 << min(consecutiveTimeouts, 3)
-                        interval = min(max(interval * backoffMultiplier, 5), 60)
+                        interval = min(max(baseInterval * backoffMultiplier, 5), 60)
                         pollCount += 1
                         capturedLogger.w("Device flow poll encountered an error. Backing off to \(interval)s.", error: error)
                         continuation.yield(.polling(
@@ -240,19 +248,17 @@ public class OidcDeviceClient: @unchecked Sendable {
     ///
     /// - Parameter verificationUriComplete: The verification URI (including `user_code`)
     ///   returned in the `DeviceAuthorizationResponse`.
-    /// - Throws: `BrowserError.externalUserAgentCancelled` if the user closed the browser
-    ///   before completing the flow, or any other error surfaced by `BrowserLauncher`.
-    ///   No-ops (returns without throwing) if `verificationUriComplete` is not a valid URL
-    ///   or `config.redirectUri` has no scheme.
+    /// - Throws: `OidcError.unknown` if `verificationUriComplete` is not a valid URL or
+    ///   `config.redirectUri` has no scheme; `BrowserError.externalUserAgentCancelled` if
+    ///   the user closed the browser before completing the flow, or any other error surfaced
+    ///   by `BrowserLauncher`.
     public func authorize(verificationUriComplete: String) async throws {
         guard let url = URL(string: verificationUriComplete) else {
-            logger.w("authorize: invalid verificationUriComplete URL", error: nil)
-            return
+            throw OidcError.unknown(message: "authorize: invalid verificationUriComplete URL: \(verificationUriComplete)")
         }
 
         guard let callbackURLScheme = redirectURIScheme() else {
-            logger.w("authorize: no redirectUri scheme configured", error: nil)
-            return
+            throw OidcError.unknown(message: "authorize: no redirectUri scheme configured")
         }
 
         _ = try await BrowserLauncher.currentBrowser.launch(

--- a/Oidc/Oidc/OpenIdConfiguration.swift
+++ b/Oidc/Oidc/OpenIdConfiguration.swift
@@ -27,7 +27,9 @@ public struct OpenIdConfiguration: Codable, Sendable {
     public let pingEndsessionEndpoint: String?
     /// The URL of the pushed authorization request endpoint (PAR, RFC 9126).
     public let pushedAuthorizationRequestEndpoint: String?
-    
+    /// The URL of the device authorization endpoint (RFC 8628).
+    public var deviceAuthorizationEndpoint: String?
+
     /// Initializes a new `OpenIdConfiguration` instance.
     /// - Parameters:
     ///   - authorizationEndpoint: The URL of the authorization endpoint.
@@ -37,6 +39,7 @@ public struct OpenIdConfiguration: Codable, Sendable {
     ///   - revocationEndpoint: The URL of the revocation endpoint.
     ///   - pingEndsessionEndpoint: The URL of the Ping end IDP session endpoint.
     ///   - pushedAuthorizationRequestEndpoint: The URL of the PAR endpoint.
+    ///   - deviceAuthorizationEndpoint: The URL of the device authorization endpoint (RFC 8628).
     public init(
         authorizationEndpoint: String,
         tokenEndpoint: String,
@@ -44,7 +47,8 @@ public struct OpenIdConfiguration: Codable, Sendable {
         endSessionEndpoint: String,
         revocationEndpoint: String,
         pingEndsessionEndpoint: String? = nil,
-        pushedAuthorizationRequestEndpoint: String? = nil
+        pushedAuthorizationRequestEndpoint: String? = nil,
+        deviceAuthorizationEndpoint: String? = nil
     ) {
         self.authorizationEndpoint = authorizationEndpoint
         self.tokenEndpoint = tokenEndpoint
@@ -53,8 +57,9 @@ public struct OpenIdConfiguration: Codable, Sendable {
         self.revocationEndpoint = revocationEndpoint
         self.pingEndsessionEndpoint = pingEndsessionEndpoint
         self.pushedAuthorizationRequestEndpoint = pushedAuthorizationRequestEndpoint
+        self.deviceAuthorizationEndpoint = deviceAuthorizationEndpoint
     }
-    
+
     // Define CodingKeys enum to map serialized names to property names
     private enum CodingKeys: String, CodingKey {
         case authorizationEndpoint = "authorization_endpoint"
@@ -64,5 +69,6 @@ public struct OpenIdConfiguration: Codable, Sendable {
         case revocationEndpoint = "revocation_endpoint"
         case pingEndsessionEndpoint = "ping_end_idp_session_endpoint"
         case pushedAuthorizationRequestEndpoint = "pushed_authorization_request_endpoint"
+        case deviceAuthorizationEndpoint = "device_authorization_endpoint"
     }
 }

--- a/Oidc/OidcTests/OidcDeviceClientAdditionalTests.swift
+++ b/Oidc/OidcTests/OidcDeviceClientAdditionalTests.swift
@@ -1,0 +1,357 @@
+//
+//  OidcDeviceClientAdditionalTests.swift
+//  OidcTests
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+//  QA-authored tests for SDKS-4785 covering edge cases not addressed by existing suite.
+
+import XCTest
+@testable import PingOidc
+@testable import PingNetwork
+
+class OidcDeviceClientAdditionalTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeOpenIdConfig(includeDeviceEndpoint: Bool = true) -> OpenIdConfiguration {
+        OpenIdConfiguration(
+            authorizationEndpoint: MockAPIEndpoint.authorization.url.absoluteString,
+            tokenEndpoint: MockAPIEndpoint.token.url.absoluteString,
+            userinfoEndpoint: MockAPIEndpoint.userinfo.url.absoluteString,
+            endSessionEndpoint: MockAPIEndpoint.endSession.url.absoluteString,
+            revocationEndpoint: MockAPIEndpoint.revocation.url.absoluteString,
+            deviceAuthorizationEndpoint: includeDeviceEndpoint
+                ? MockAPIEndpoint.deviceAuthorization.url.absoluteString
+                : nil
+        )
+    }
+
+    private func makeConfig(includeDeviceEndpoint: Bool = true) -> OidcClientConfig {
+        let config = OidcClientConfig()
+        config.clientId = "qa-client-id"
+        config.scopes = Set(["openid", "profile"])
+        config.redirectUri = "org.forgerock.demo://oauth2redirect"
+        config.storage = MockStorage<Token>()
+        config.httpClient = MockURLProtocol.makeClient()
+        config.openId = makeOpenIdConfig(includeDeviceEndpoint: includeDeviceEndpoint)
+        return config
+    }
+
+    private func mockHTTPResponse(url: URL, statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: MockResponse.headers
+        )!
+    }
+
+    // MARK: - Edge Case 1: user() returns nil when no token is stored
+
+    /// Verify `user()` returns nil when storage is empty.
+    func testUserReturnsNilWhenStorageEmpty() async {
+        let config = makeConfig()
+        let client = OidcDeviceClient(config: config)
+        let user = await client.user()
+        XCTAssertNil(user, "user() must return nil when no token has been stored")
+    }
+
+    // MARK: - Edge Case 2: user() returns OidcUser after successful flow
+
+    /// Verify `user()` returns a non-nil User after a token has been saved to storage.
+    func testUserReturnsOidcUserAfterTokenStored() async throws {
+        MockURLProtocol.startInterceptingRequests()
+        defer { MockURLProtocol.stopInterceptingRequests() }
+
+        nonisolated(unsafe) var tokenCallCount = 0
+
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
+            case MockAPIEndpoint.deviceAuthorization.url.path:
+                return (mockHTTPResponse(url: MockAPIEndpoint.deviceAuthorization.url, statusCode: 200),
+                        MockResponse.deviceAuthorizationResponseFastInterval)
+            case MockAPIEndpoint.token.url.path:
+                tokenCallCount += 1
+                return (mockHTTPResponse(url: MockAPIEndpoint.token.url, statusCode: 200),
+                        MockResponse.token)
+            default:
+                XCTFail("Unexpected request: \(request.url?.absoluteString ?? "<nil>")")
+                return (mockHTTPResponse(url: MockAPIEndpoint.discovery.url, statusCode: 500), Data())
+            }
+        }
+
+        let config = makeConfig()
+        let client = OidcDeviceClient(config: config)
+        let stream = try await client.deviceAuthorization()
+
+        for try await status in stream {
+            if case .success = status { break }
+        }
+
+        let user = await client.user()
+        XCTAssertNotNil(user, "user() must return a non-nil OidcUser after the device flow succeeds and saves a token")
+    }
+
+    // MARK: - Edge Case 3: deviceAuthorization() includes client_id and scope in POST body
+
+    /// Verify the device authorization POST body contains client_id and scope parameters.
+    func testDeviceAuthorizationPostBodyContainsClientIdAndScope() async throws {
+        MockURLProtocol.startInterceptingRequests()
+        defer { MockURLProtocol.stopInterceptingRequests() }
+
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
+            case MockAPIEndpoint.deviceAuthorization.url.path:
+                return (mockHTTPResponse(url: MockAPIEndpoint.deviceAuthorization.url, statusCode: 200),
+                        MockResponse.deviceAuthorizationResponseFastInterval)
+            case MockAPIEndpoint.token.url.path:
+                return (mockHTTPResponse(url: MockAPIEndpoint.token.url, statusCode: 400),
+                        MockResponse.accessDenied)
+            default:
+                return (mockHTTPResponse(url: request.url ?? MockAPIEndpoint.discovery.url, statusCode: 500), Data())
+            }
+        }
+
+        let config = makeConfig()
+        let client = OidcDeviceClient(config: config)
+        _ = try await client.deviceAuthorization()
+
+        let deviceAuthRequest = MockURLProtocol.requestHistory.first {
+            $0.url?.path == MockAPIEndpoint.deviceAuthorization.url.path
+        }
+        XCTAssertNotNil(deviceAuthRequest, "Expected a device authorization POST request")
+
+        // Read POST body
+        var bodyData = Data()
+        if let data = deviceAuthRequest?.httpBody {
+            bodyData = data
+        } else if let stream = deviceAuthRequest?.httpBodyStream {
+            stream.open()
+            defer { stream.close() }
+            let bufferSize = 4096
+            let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+            defer { buffer.deallocate() }
+            while stream.hasBytesAvailable {
+                let n = stream.read(buffer, maxLength: bufferSize)
+                if n > 0 { bodyData.append(buffer, count: n) }
+            }
+        }
+
+        let bodyString = String(data: bodyData, encoding: .utf8) ?? ""
+        XCTAssertTrue(bodyString.contains("client_id=qa-client-id"),
+                      "Device auth POST body should contain client_id=qa-client-id, got: \(bodyString)")
+        // scope contains openid and profile (order may vary)
+        XCTAssertTrue(bodyString.contains("scope="),
+                      "Device auth POST body should contain scope parameter, got: \(bodyString)")
+    }
+
+    // MARK: - Edge Case 4: interval=0 applies 5-second floor after URLError
+
+    /// Verify that when the initial interval is 0 and a URLError occurs, the backoff
+    /// floors at 5 seconds — i.e. min(max(0 * 2, 5), 60) = 5.
+    func testBackoffIntervalIsNonNegativeWhenInitialIntervalIsZero() async throws {
+        MockURLProtocol.startInterceptingRequests()
+        defer { MockURLProtocol.stopInterceptingRequests() }
+
+        nonisolated(unsafe) var tokenCallCount = 0
+
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
+            case MockAPIEndpoint.deviceAuthorization.url.path:
+                return (mockHTTPResponse(url: MockAPIEndpoint.deviceAuthorization.url, statusCode: 200),
+                        MockResponse.deviceAuthorizationResponseFastInterval) // interval = 0
+            case MockAPIEndpoint.token.url.path:
+                tokenCallCount += 1
+                throw URLError(.timedOut)
+            default:
+                return (mockHTTPResponse(url: request.url ?? MockAPIEndpoint.discovery.url, statusCode: 500), Data())
+            }
+        }
+
+        let config = makeConfig()
+        let client = OidcDeviceClient(config: config)
+        let stream = try await client.deviceAuthorization()
+
+        var capturedInterval: Int? = nil
+        outerLoop: for try await status in stream {
+            switch status {
+            case .polling(let count, let interval, _):
+                capturedInterval = interval
+                if count >= 1 { break outerLoop }
+            case .started:
+                break
+            default:
+                break outerLoop
+            }
+        }
+
+        // min(max(0 * 2, 5), 60) = 5; the floor must be respected even when initial interval is 0
+        if let interval = capturedInterval {
+            XCTAssertGreaterThanOrEqual(interval, 5,
+                "Backoff interval must be at least 5s even when initial interval is 0, got: \(interval)")
+        }
+    }
+
+    // MARK: - Edge Case 5: unknown error code from token endpoint throws
+
+    /// Verify that an unrecognized error code from the token endpoint causes the stream to throw.
+    func testUnknownErrorCodeCausesStreamToThrow() async throws {
+        MockURLProtocol.startInterceptingRequests()
+        defer { MockURLProtocol.stopInterceptingRequests() }
+
+        let unknownErrorBody = """
+        {"error": "some_unknown_error_code"}
+        """.data(using: .utf8)!
+
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
+            case MockAPIEndpoint.deviceAuthorization.url.path:
+                return (mockHTTPResponse(url: MockAPIEndpoint.deviceAuthorization.url, statusCode: 200),
+                        MockResponse.deviceAuthorizationResponseFastInterval)
+            case MockAPIEndpoint.token.url.path:
+                return (mockHTTPResponse(url: MockAPIEndpoint.token.url, statusCode: 400),
+                        unknownErrorBody)
+            default:
+                return (mockHTTPResponse(url: request.url ?? MockAPIEndpoint.discovery.url, statusCode: 500), Data())
+            }
+        }
+
+        let config = makeConfig()
+        let client = OidcDeviceClient(config: config)
+        let stream = try await client.deviceAuthorization()
+
+        var didThrow = false
+        do {
+            for try await _ in stream {}
+        } catch {
+            didThrow = true
+        }
+
+        XCTAssertTrue(didThrow,
+            "An unknown error code from the token endpoint should cause the stream to throw")
+    }
+
+    // MARK: - Edge Case 6: DeviceAuthorizationResponse decodes interval=0
+
+    /// Verify that interval=0 in the server response is preserved (not clamped to 5).
+    func testIntervalZeroIsPreservedFromJSON() throws {
+        let response = try JSONDecoder().decode(
+            DeviceAuthorizationResponse.self,
+            from: MockResponse.deviceAuthorizationResponseFastInterval
+        )
+        XCTAssertEqual(response.interval, 0,
+            "interval=0 in server response should be decoded as 0, not defaulted to 5")
+    }
+
+    // MARK: - Edge Case 7: openIdConfiguration decodes device_authorization_endpoint
+
+    /// Verify that `OpenIdConfiguration.deviceAuthorizationEndpoint` is decoded when present.
+    func testOpenIdConfigurationDecodesDeviceAuthorizationEndpoint() throws {
+        let json = """
+        {
+          "authorization_endpoint": "https://auth.example.com/authorize",
+          "token_endpoint": "https://auth.example.com/token",
+          "userinfo_endpoint": "https://auth.example.com/userinfo",
+          "end_session_endpoint": "https://auth.example.com/signoff",
+          "revocation_endpoint": "https://auth.example.com/revoke",
+          "device_authorization_endpoint": "https://auth.example.com/device_authorization"
+        }
+        """.data(using: .utf8)!
+
+        let config = try JSONDecoder().decode(OpenIdConfiguration.self, from: json)
+        XCTAssertEqual(
+            config.deviceAuthorizationEndpoint,
+            "https://auth.example.com/device_authorization",
+            "OpenIdConfiguration should decode device_authorization_endpoint field"
+        )
+    }
+
+    /// Verify that `OpenIdConfiguration.deviceAuthorizationEndpoint` is nil when absent.
+    func testOpenIdConfigurationDeviceEndpointIsNilWhenAbsent() throws {
+        let json = """
+        {
+          "authorization_endpoint": "https://auth.example.com/authorize",
+          "token_endpoint": "https://auth.example.com/token",
+          "userinfo_endpoint": "https://auth.example.com/userinfo",
+          "end_session_endpoint": "https://auth.example.com/signoff",
+          "revocation_endpoint": "https://auth.example.com/revoke"
+        }
+        """.data(using: .utf8)!
+
+        let config = try JSONDecoder().decode(OpenIdConfiguration.self, from: json)
+        XCTAssertNil(
+            config.deviceAuthorizationEndpoint,
+            "OpenIdConfiguration.deviceAuthorizationEndpoint must be nil when absent from discovery response"
+        )
+    }
+
+    // MARK: - Edge Case 7b: revoke() delegates to OidcClient
+
+    /// Verify `revoke()` completes without error when no token is stored (nothing to revoke).
+    func testRevokeWithNoStoredTokenCompletesWithoutError() async {
+        let config = makeConfig()
+        let client = OidcDeviceClient(config: config)
+        // Should complete without throwing or crashing
+        await client.revoke()
+    }
+
+    // MARK: - Edge Case 8: slow_down accumulates across multiple rounds
+
+    /// Verify that two consecutive slow_down responses increase interval by 5 each time.
+    func testSlowDownAccumulatesIntervalAcrossMultipleRounds() async throws {
+        MockURLProtocol.startInterceptingRequests()
+        defer { MockURLProtocol.stopInterceptingRequests() }
+
+        nonisolated(unsafe) var tokenCallCount = 0
+
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
+            case MockAPIEndpoint.deviceAuthorization.url.path:
+                // interval=0 so we start from 0 and accumulate
+                return (mockHTTPResponse(url: MockAPIEndpoint.deviceAuthorization.url, statusCode: 200),
+                        MockResponse.deviceAuthorizationResponseFastInterval)
+            case MockAPIEndpoint.token.url.path:
+                tokenCallCount += 1
+                if tokenCallCount <= 2 {
+                    return (mockHTTPResponse(url: MockAPIEndpoint.token.url, statusCode: 400),
+                            MockResponse.slowDown)
+                } else {
+                    // Terminate with access_denied so the stream ends
+                    return (mockHTTPResponse(url: MockAPIEndpoint.token.url, statusCode: 400),
+                            MockResponse.accessDenied)
+                }
+            default:
+                return (mockHTTPResponse(url: request.url ?? MockAPIEndpoint.discovery.url, statusCode: 500), Data())
+            }
+        }
+
+        let config = makeConfig()
+        let client = OidcDeviceClient(config: config)
+        let stream = try await client.deviceAuthorization()
+
+        var pollingIntervals: [Int] = []
+        for try await status in stream {
+            switch status {
+            case .polling(_, let interval, _):
+                pollingIntervals.append(interval)
+            case .started, .accessDenied, .expired, .success, .failure:
+                break
+            }
+        }
+
+        // First slow_down: 0 + 5 = 5
+        // Second slow_down: 5 + 5 = 10
+        XCTAssertEqual(pollingIntervals.count, 2,
+            "Expected 2 polling statuses from 2 slow_down responses, got \(pollingIntervals)")
+        if pollingIntervals.count >= 2 {
+            XCTAssertEqual(pollingIntervals[0], 5,
+                "First slow_down should increase interval from 0 to 5")
+            XCTAssertEqual(pollingIntervals[1], 10,
+                "Second slow_down should increase interval from 5 to 10")
+        }
+    }
+}

--- a/Oidc/OidcTests/OidcDeviceClientTests.swift
+++ b/Oidc/OidcTests/OidcDeviceClientTests.swift
@@ -315,6 +315,63 @@ class OidcDeviceClientTests: XCTestCase {
         XCTAssertTrue(statuses.contains("polling"), "Stream should have yielded .polling after slow_down")
     }
 
+    // MARK: - Test 2b: slow_down compounds, authorization_pending resets to baseInterval
+
+    /// Test: consecutive `slow_down` responses compound `interval` per RFC 8628 §3.5
+    /// (+5 each), and a subsequent `authorization_pending` resets `interval` back to
+    /// the server-provided `baseInterval`.
+    /// Uses interval=0 fixture so the test can drive multiple polls without long sleeps.
+    func testSlowDownCompoundsAndAuthorizationPendingResets() async throws {
+        MockURLProtocol.startInterceptingRequests()
+        defer { MockURLProtocol.stopInterceptingRequests() }
+
+        nonisolated(unsafe) var tokenCallCount = 0
+
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
+            case MockAPIEndpoint.deviceAuthorization.url.path:
+                return (mockHTTPResponse(url: MockAPIEndpoint.deviceAuthorization.url, statusCode: 200),
+                        MockResponse.deviceAuthorizationResponseFastInterval)
+            case MockAPIEndpoint.token.url.path:
+                tokenCallCount += 1
+                switch tokenCallCount {
+                case 1, 2:
+                    return (mockHTTPResponse(url: MockAPIEndpoint.token.url, statusCode: 400),
+                            MockResponse.slowDown)
+                default:
+                    return (mockHTTPResponse(url: MockAPIEndpoint.token.url, statusCode: 400),
+                            MockResponse.authorizationPending)
+                }
+            default:
+                return (mockHTTPResponse(url: MockAPIEndpoint.discovery.url, statusCode: 500), Data())
+            }
+        }
+
+        let config = makeConfig()
+        let client = OidcDeviceClient(config: config)
+        let stream = try await client.deviceAuthorization()
+
+        var pollIntervals: [Int] = []
+
+        outerLoop: for try await status in stream {
+            switch status {
+            case .polling(_, let interval, _):
+                pollIntervals.append(interval)
+                // After we observe the post-reset polling, exit before sleeping for it.
+                if pollIntervals.count >= 3 { break outerLoop }
+            case .started: continue
+            case .success, .expired, .accessDenied, .failure:
+                XCTFail("Unexpected terminal status: \(status)")
+                break outerLoop
+            }
+        }
+
+        XCTAssertEqual(pollIntervals.count, 3, "Expected three .polling yields (two slow_down + one authorization_pending)")
+        XCTAssertEqual(pollIntervals[0], 5, "First slow_down: 0 + 5 = 5")
+        XCTAssertEqual(pollIntervals[1], 10, "Second slow_down compounds: 5 + 5 = 10")
+        XCTAssertEqual(pollIntervals[2], 0, "authorization_pending resets to baseInterval (0 in this fixture)")
+    }
+
     // MARK: - Test 3: access_denied finishes stream
 
     /// Test: access_denied response yields .accessDenied and stream finishes without throwing.

--- a/Oidc/OidcTests/OidcDeviceClientTests.swift
+++ b/Oidc/OidcTests/OidcDeviceClientTests.swift
@@ -591,10 +591,8 @@ class OidcDeviceClientTests: XCTestCase {
 
         XCTAssertTrue(statuses.contains("started"), "Stream should have yielded .started")
         XCTAssertTrue(statuses.contains("polling"), "Stream should have yielded .polling after URLError backoff")
-        // After first URLError, consecutiveTimeouts=1, backoffMultiplier=2, interval=min(0*2,60)=0; but interval
-        // cannot go below the original value — verify it is at least 0 (not negative) and the stream continued
-        XCTAssertNotNil(pollingIntervalAfterError, "Should have captured the backoff polling interval")
-        XCTAssertGreaterThanOrEqual(pollingIntervalAfterError ?? -1, 0, "Backoff interval should be non-negative")
+        // baseInterval=0, consecutiveTimeouts=1, backoffMultiplier=2: min(max(0*2,5),60) = 5
+        XCTAssertEqual(pollingIntervalAfterError, 5, "Backoff interval after first URLError should be 5s (min floor)")
     }
 }
 

--- a/Oidc/OidcTests/OidcDeviceClientTests.swift
+++ b/Oidc/OidcTests/OidcDeviceClientTests.swift
@@ -1,0 +1,609 @@
+//
+//  OidcDeviceClientTests.swift
+//  OidcTests
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+@testable import PingOidc
+@testable import PingNetwork
+
+class OidcDeviceClientTests: XCTestCase {
+
+    // MARK: - DeviceAuthorizationResponse decoding
+
+    /// Test: DeviceAuthorizationResponse decodes correctly from valid RFC 8628 JSON.
+    func testDeviceAuthorizationResponseDecodesFromValidJSON() throws {
+        let response = try JSONDecoder().decode(
+            DeviceAuthorizationResponse.self,
+            from: MockResponse.deviceAuthorizationResponse
+        )
+
+        XCTAssertEqual(response.deviceCode, "GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNhszIySk9eS")
+        XCTAssertEqual(response.userCode, "WDJB-MJHT")
+        XCTAssertEqual(response.verificationUri, "https://auth.test-one-pingone.com/activate")
+        XCTAssertEqual(response.verificationUriComplete, "https://auth.test-one-pingone.com/activate?user_code=WDJB-MJHT")
+        XCTAssertEqual(response.expiresIn, 1800)
+        XCTAssertEqual(response.interval, 5)
+    }
+
+    /// Test: interval defaults to 5 when absent from JSON.
+    func testIntervalDefaultsToFiveWhenAbsent() throws {
+        let response = try JSONDecoder().decode(
+            DeviceAuthorizationResponse.self,
+            from: MockResponse.deviceAuthorizationResponseNoInterval
+        )
+
+        XCTAssertEqual(response.interval, 5)
+    }
+
+    /// Test: verificationUriComplete is nil when absent from JSON.
+    func testVerificationUriCompleteIsNilWhenAbsent() throws {
+        let json = """
+        {
+          "device_code" : "test-device-code",
+          "user_code" : "ABCD-1234",
+          "verification_uri" : "https://auth.test-one-pingone.com/activate",
+          "expires_in" : 600
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(DeviceAuthorizationResponse.self, from: json)
+
+        XCTAssertNil(response.verificationUriComplete)
+        XCTAssertEqual(response.userCode, "ABCD-1234")
+        XCTAssertEqual(response.verificationUri, "https://auth.test-one-pingone.com/activate")
+    }
+
+    /// Test: DeviceFlowStatus cases can be constructed (compile check).
+    func testDeviceFlowStatusCasesCanBeConstructed() throws {
+        let deviceAuthResponse = try JSONDecoder().decode(
+            DeviceAuthorizationResponse.self,
+            from: MockResponse.deviceAuthorizationResponse
+        )
+
+        let started = DeviceFlowStatus.started(deviceAuthResponse)
+        let polling = DeviceFlowStatus.polling(pollCount: 1, pollInterval: 5, nextPollAt: Date())
+        let expired = DeviceFlowStatus.expired
+        let accessDenied = DeviceFlowStatus.accessDenied
+        let failure = DeviceFlowStatus.failure(NSError(domain: "test", code: -1))
+
+        // Verify the started case holds the correct response
+        if case .started(let r) = started {
+            XCTAssertEqual(r.userCode, "WDJB-MJHT")
+        } else {
+            XCTFail("Expected .started case")
+        }
+
+        // Verify polling case holds associated values
+        if case .polling(let count, let interval, _) = polling {
+            XCTAssertEqual(count, 1)
+            XCTAssertEqual(interval, 5)
+        } else {
+            XCTFail("Expected .polling case")
+        }
+
+        // Verify terminal cases exist (compile-time check via exhaustive switch)
+        switch expired {
+        case .expired: break
+        default: XCTFail("Expected .expired")
+        }
+
+        switch accessDenied {
+        case .accessDenied: break
+        default: XCTFail("Expected .accessDenied")
+        }
+
+        if case .failure(let err) = failure {
+            XCTAssertEqual((err as NSError).code, -1)
+        } else {
+            XCTFail("Expected .failure case")
+        }
+    }
+
+    /// Test: DeviceFlowStatus.success carries the provided User value.
+    func testDeviceFlowStatusSuccessCarriesUser() {
+        let mockUser = MockUser()
+        let status = DeviceFlowStatus.success(mockUser)
+
+        if case .success(let user) = status {
+            XCTAssertTrue(user is MockUser)
+        } else {
+            XCTFail("Expected .success case")
+        }
+    }
+
+    // MARK: - Polling tests
+
+    /// Shared OpenIdConfiguration pre-built with deviceAuthorizationEndpoint to skip real discovery.
+    private func makeOpenIdConfig(includeDeviceEndpoint: Bool = true) -> OpenIdConfiguration {
+        OpenIdConfiguration(
+            authorizationEndpoint: MockAPIEndpoint.authorization.url.absoluteString,
+            tokenEndpoint: MockAPIEndpoint.token.url.absoluteString,
+            userinfoEndpoint: MockAPIEndpoint.userinfo.url.absoluteString,
+            endSessionEndpoint: MockAPIEndpoint.endSession.url.absoluteString,
+            revocationEndpoint: MockAPIEndpoint.revocation.url.absoluteString,
+            deviceAuthorizationEndpoint: includeDeviceEndpoint ? MockAPIEndpoint.deviceAuthorization.url.absoluteString : nil
+        )
+    }
+
+    /// Shared helper that builds an OidcClientConfig wired to MockURLProtocol.
+    private func makeConfig(includeDeviceEndpoint: Bool = true) -> OidcClientConfig {
+        let config = OidcClientConfig()
+        config.clientId = "test-client-id"
+        config.scopes = Set(["openid"])
+        config.redirectUri = "org.forgerock.demo://oauth2redirect"
+        config.storage = MockStorage<Token>()
+        config.httpClient = MockURLProtocol.makeClient()
+        // Set openId directly so oidcInitialize() skips real discovery
+        config.openId = makeOpenIdConfig(includeDeviceEndpoint: includeDeviceEndpoint)
+        return config
+    }
+
+    /// Returns a mock HTTPURLResponse for a given URL and status code.
+    private func mockHTTPResponse(url: URL, statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: MockResponse.headers)!
+    }
+
+    /// Helper to read httpBodyStream data from URLRequest (httpBody is nil when using URLSession with URLProtocol).
+    private func bodyData(from request: URLRequest) -> Data {
+        if let body = request.httpBody {
+            return body
+        }
+        guard let stream = request.httpBodyStream else {
+            return Data()
+        }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 4096
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let bytesRead = stream.read(buffer, maxLength: bufferSize)
+            if bytesRead > 0 {
+                data.append(buffer, count: bytesRead)
+            } else {
+                break
+            }
+        }
+        return data
+    }
+
+    // MARK: - Test 1: Happy path
+
+    /// Test: happy path — device auth OK, one authorization_pending, then token success.
+    /// Expected stream: .started, .polling, .success
+    func testDeviceAuthorizationHappyPath() async throws {
+        MockURLProtocol.startInterceptingRequests()
+        defer { MockURLProtocol.stopInterceptingRequests() }
+
+        // Use a counter to serve different responses to the token endpoint
+        nonisolated(unsafe) var tokenCallCount = 0
+
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
+            case MockAPIEndpoint.deviceAuthorization.url.path:
+                return (mockHTTPResponse(url: MockAPIEndpoint.deviceAuthorization.url, statusCode: 200),
+                        MockResponse.deviceAuthorizationResponseFastInterval)
+            case MockAPIEndpoint.token.url.path:
+                tokenCallCount += 1
+                if tokenCallCount == 1 {
+                    return (mockHTTPResponse(url: MockAPIEndpoint.token.url, statusCode: 400),
+                            MockResponse.authorizationPending)
+                } else {
+                    return (mockHTTPResponse(url: MockAPIEndpoint.token.url, statusCode: 200),
+                            MockResponse.token)
+                }
+            default:
+                XCTFail("Unexpected request: \(request.url?.absoluteString ?? "<nil>")")
+                return (mockHTTPResponse(url: MockAPIEndpoint.discovery.url, statusCode: 500), Data())
+            }
+        }
+
+        let config = makeConfig()
+        let client = OidcDeviceClient(config: config)
+
+        let stream = try await client.deviceAuthorization()
+
+        var statuses: [String] = []
+        for try await status in stream {
+            switch status {
+            case .started(let response):
+                statuses.append("started")
+                XCTAssertEqual(response.userCode, "WDJB-MJHT")
+            case .polling:
+                statuses.append("polling")
+            case .success:
+                statuses.append("success")
+            case .expired:
+                statuses.append("expired")
+                XCTFail("Unexpected .expired status")
+            case .accessDenied:
+                statuses.append("accessDenied")
+                XCTFail("Unexpected .accessDenied status")
+            case .failure(let error):
+                statuses.append("failure")
+                XCTFail("Unexpected .failure status: \(error)")
+            }
+        }
+
+        XCTAssertEqual(statuses, ["started", "polling", "success"])
+
+        // Verify device_code appears in the token POST body but not in logged strings
+        let tokenRequests = MockURLProtocol.requestHistory.filter {
+            $0.url?.path == MockAPIEndpoint.token.url.path
+        }
+        XCTAssertGreaterThan(tokenRequests.count, 0, "Token endpoint should have been polled")
+        let tokenBody = String(data: bodyData(from: tokenRequests[0]), encoding: .utf8) ?? ""
+        XCTAssertTrue(tokenBody.contains("device_code="), "Token POST body should contain device_code parameter")
+    }
+
+    // MARK: - Test 2: slow_down increases interval
+
+    /// Test: slow_down response increases interval by 5.
+    /// Uses interval=0 fixture so slow_down bumps to 5 and the test finishes immediately.
+    /// Expected stream: .started, .polling(pollCount:1, pollInterval:5, ...), .success
+    func testSlowDownIncreasesInterval() async throws {
+        MockURLProtocol.startInterceptingRequests()
+        defer { MockURLProtocol.stopInterceptingRequests() }
+
+        nonisolated(unsafe) var tokenCallCount = 0
+
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
+            case MockAPIEndpoint.deviceAuthorization.url.path:
+                // interval=0 so slow_down bumps to 0+5=5 and no real sleep occurs
+                return (mockHTTPResponse(url: MockAPIEndpoint.deviceAuthorization.url, statusCode: 200),
+                        MockResponse.deviceAuthorizationResponseFastInterval)
+            case MockAPIEndpoint.token.url.path:
+                tokenCallCount += 1
+                if tokenCallCount == 1 {
+                    return (mockHTTPResponse(url: MockAPIEndpoint.token.url, statusCode: 400),
+                            MockResponse.slowDown)
+                } else {
+                    return (mockHTTPResponse(url: MockAPIEndpoint.token.url, statusCode: 200),
+                            MockResponse.token)
+                }
+            default:
+                XCTFail("Unexpected request: \(request.url?.absoluteString ?? "<nil>")")
+                return (mockHTTPResponse(url: MockAPIEndpoint.discovery.url, statusCode: 500), Data())
+            }
+        }
+
+        let config = makeConfig()
+        let client = OidcDeviceClient(config: config)
+
+        let stream = try await client.deviceAuthorization()
+
+        var statuses: [String] = []
+        var pollingInterval: Int?
+        var pollingCount: Int?
+
+        outerLoop: for try await status in stream {
+            switch status {
+            case .started:
+                statuses.append("started")
+            case .polling(let count, let interval, _):
+                statuses.append("polling")
+                pollingInterval = interval
+                pollingCount = count
+                // Exit the loop after the first .polling to avoid sleeping for the bumped interval.
+                break outerLoop
+            case .success:
+                statuses.append("success")
+            case .expired:
+                statuses.append("expired")
+                XCTFail("Unexpected .expired status")
+            case .accessDenied:
+                statuses.append("accessDenied")
+                XCTFail("Unexpected .accessDenied status")
+            case .failure(let error):
+                statuses.append("failure")
+                XCTFail("Unexpected .failure status: \(error)")
+            }
+        }
+
+        // Verify the slow_down case increments interval from 0 to 5
+        XCTAssertEqual(pollingInterval, 5, "slow_down should have increased interval from 0 to 5")
+        XCTAssertEqual(pollingCount, 1, "Poll count should be 1 after first slow_down")
+        XCTAssertTrue(statuses.contains("started"), "Stream should have yielded .started")
+        XCTAssertTrue(statuses.contains("polling"), "Stream should have yielded .polling after slow_down")
+    }
+
+    // MARK: - Test 3: access_denied finishes stream
+
+    /// Test: access_denied response yields .accessDenied and stream finishes without throwing.
+    func testAccessDeniedFinishesStream() async throws {
+        MockURLProtocol.startInterceptingRequests()
+        defer { MockURLProtocol.stopInterceptingRequests() }
+
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
+            case MockAPIEndpoint.deviceAuthorization.url.path:
+                return (mockHTTPResponse(url: MockAPIEndpoint.deviceAuthorization.url, statusCode: 200),
+                        MockResponse.deviceAuthorizationResponseFastInterval)
+            case MockAPIEndpoint.token.url.path:
+                return (mockHTTPResponse(url: MockAPIEndpoint.token.url, statusCode: 400),
+                        MockResponse.accessDenied)
+            default:
+                XCTFail("Unexpected request: \(request.url?.absoluteString ?? "<nil>")")
+                return (mockHTTPResponse(url: MockAPIEndpoint.discovery.url, statusCode: 500), Data())
+            }
+        }
+
+        let config = makeConfig()
+        let client = OidcDeviceClient(config: config)
+
+        let stream = try await client.deviceAuthorization()
+
+        var statuses: [String] = []
+        // Iterating with for try await — stream should finish (not throw) on access_denied
+        for try await status in stream {
+            switch status {
+            case .started:
+                statuses.append("started")
+            case .polling:
+                statuses.append("polling")
+            case .success:
+                statuses.append("success")
+                XCTFail("Unexpected .success — stream should have ended with .accessDenied")
+            case .expired:
+                statuses.append("expired")
+                XCTFail("Unexpected .expired")
+            case .accessDenied:
+                statuses.append("accessDenied")
+            case .failure(let error):
+                statuses.append("failure")
+                XCTFail("Unexpected .failure: \(error)")
+            }
+        }
+
+        XCTAssertEqual(statuses, ["started", "accessDenied"], "Stream should yield .started then .accessDenied")
+    }
+
+    // MARK: - Test 4: expired_token finishes stream
+
+    /// Test: expired_token response yields .expired and stream finishes without throwing.
+    func testExpiredTokenFinishesStream() async throws {
+        MockURLProtocol.startInterceptingRequests()
+        defer { MockURLProtocol.stopInterceptingRequests() }
+
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
+            case MockAPIEndpoint.deviceAuthorization.url.path:
+                return (mockHTTPResponse(url: MockAPIEndpoint.deviceAuthorization.url, statusCode: 200),
+                        MockResponse.deviceAuthorizationResponseFastInterval)
+            case MockAPIEndpoint.token.url.path:
+                return (mockHTTPResponse(url: MockAPIEndpoint.token.url, statusCode: 400),
+                        MockResponse.expiredToken)
+            default:
+                XCTFail("Unexpected request: \(request.url?.absoluteString ?? "<nil>")")
+                return (mockHTTPResponse(url: MockAPIEndpoint.discovery.url, statusCode: 500), Data())
+            }
+        }
+
+        let config = makeConfig()
+        let client = OidcDeviceClient(config: config)
+
+        let stream = try await client.deviceAuthorization()
+
+        var statuses: [String] = []
+        for try await status in stream {
+            switch status {
+            case .started:
+                statuses.append("started")
+            case .polling:
+                statuses.append("polling")
+            case .success:
+                statuses.append("success")
+                XCTFail("Unexpected .success — stream should have ended with .expired")
+            case .expired:
+                statuses.append("expired")
+            case .accessDenied:
+                statuses.append("accessDenied")
+                XCTFail("Unexpected .accessDenied")
+            case .failure(let error):
+                statuses.append("failure")
+                XCTFail("Unexpected .failure: \(error)")
+            }
+        }
+
+        XCTAssertEqual(statuses, ["started", "expired"], "Stream should yield .started then .expired")
+    }
+
+    // MARK: - Test 5: missing device authorization endpoint throws
+
+    /// Test: deviceAuthorizationEndpoint absent in config causes deviceAuthorization() to throw.
+    func testMissingDeviceAuthorizationEndpointThrows() async throws {
+        MockURLProtocol.startInterceptingRequests()
+        defer { MockURLProtocol.stopInterceptingRequests() }
+
+        MockURLProtocol.requestHandler = { [self] request in
+            // Only discovery calls would come through; no device auth endpoint
+            return (mockHTTPResponse(url: request.url ?? MockAPIEndpoint.discovery.url, statusCode: 500), Data())
+        }
+
+        // Config without deviceAuthorizationEndpoint
+        let config = makeConfig(includeDeviceEndpoint: false)
+        let client = OidcDeviceClient(config: config)
+
+        do {
+            _ = try await client.deviceAuthorization()
+            XCTFail("Expected deviceAuthorization() to throw when endpoint is absent")
+        } catch {
+            // Any thrown error is acceptable — the important thing is it does throw
+            XCTAssertNotNil(error)
+        }
+    }
+
+    // MARK: - Test 6: device authorization POST failure throws
+
+    /// Test: non-200 response to the device authorization POST causes deviceAuthorization() to throw.
+    func testDeviceAuthorizationPostFailureThrows() async throws {
+        MockURLProtocol.startInterceptingRequests()
+        defer { MockURLProtocol.stopInterceptingRequests() }
+
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
+            case MockAPIEndpoint.deviceAuthorization.url.path:
+                return (mockHTTPResponse(url: MockAPIEndpoint.deviceAuthorization.url, statusCode: 500),
+                        MockResponse.error)
+            default:
+                XCTFail("Unexpected request: \(request.url?.absoluteString ?? "<nil>")")
+                return (mockHTTPResponse(url: MockAPIEndpoint.discovery.url, statusCode: 500), Data())
+            }
+        }
+
+        let config = makeConfig()
+        let client = OidcDeviceClient(config: config)
+
+        do {
+            _ = try await client.deviceAuthorization()
+            XCTFail("Expected deviceAuthorization() to throw on 500 device auth response")
+        } catch {
+            // Verify the error is an OidcError.apiError with 500
+            if let oidcError = error as? OidcError {
+                switch oidcError {
+                case .apiError(let code, _):
+                    XCTAssertEqual(code, 500)
+                default:
+                    XCTFail("Expected .apiError(500) but got \(oidcError)")
+                }
+            } else {
+                XCTFail("Expected OidcError but got \(type(of: error)): \(error)")
+            }
+        }
+    }
+
+    // MARK: - Test 6b: 200 response with malformed token body throws
+
+    /// Test: a 200 from the token endpoint that cannot be decoded as Token, and whose body has
+    /// no `"error"` key, causes the stream to finish throwing OidcError.apiError.
+    /// (The non-success, non-parseable branch in the polling loop terminates the stream.)
+    func testMalformedTokenResponseThrows() async throws {
+        MockURLProtocol.startInterceptingRequests()
+        defer { MockURLProtocol.stopInterceptingRequests() }
+
+        let malformedBody = """
+        { "not_a_token": true }
+        """.data(using: .utf8)!
+
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
+            case MockAPIEndpoint.deviceAuthorization.url.path:
+                return (mockHTTPResponse(url: MockAPIEndpoint.deviceAuthorization.url, statusCode: 200),
+                        MockResponse.deviceAuthorizationResponseFastInterval)
+            case MockAPIEndpoint.token.url.path:
+                return (mockHTTPResponse(url: MockAPIEndpoint.token.url, statusCode: 200),
+                        malformedBody)
+            default:
+                return (mockHTTPResponse(url: MockAPIEndpoint.discovery.url, statusCode: 500), Data())
+            }
+        }
+
+        let config = makeConfig()
+        let client = OidcDeviceClient(config: config)
+        let stream = try await client.deviceAuthorization()
+
+        var didThrow = false
+        var receivedSuccess = false
+        do {
+            for try await status in stream {
+                if case .success = status { receivedSuccess = true }
+            }
+        } catch {
+            didThrow = true
+        }
+
+        XCTAssertFalse(receivedSuccess, "A 200 with undecodable body should not yield .success")
+        XCTAssertTrue(didThrow, "A 200 with no 'error' key and undecodable body should cause the stream to throw")
+    }
+
+    // MARK: - Test 7: URLError triggers backoff and stream continues
+
+    /// Test: a URLError on the token endpoint causes the stream to back off and continue polling.
+    /// Verifies Amendment 4: network errors do not terminate the stream.
+    /// Expected stream: .started, .polling (with increased interval), .success
+    func testURLErrorCausesBackoffAndContinues() async throws {
+        MockURLProtocol.startInterceptingRequests()
+        defer { MockURLProtocol.stopInterceptingRequests() }
+
+        nonisolated(unsafe) var tokenCallCount = 0
+
+        MockURLProtocol.requestHandler = { [self] request in
+            switch request.url?.path ?? "" {
+            case MockAPIEndpoint.deviceAuthorization.url.path:
+                return (mockHTTPResponse(url: MockAPIEndpoint.deviceAuthorization.url, statusCode: 200),
+                        MockResponse.deviceAuthorizationResponseFastInterval)
+            case MockAPIEndpoint.token.url.path:
+                tokenCallCount += 1
+                if tokenCallCount == 1 {
+                    // Simulate a URLError by throwing from the handler
+                    throw URLError(.timedOut)
+                } else {
+                    return (mockHTTPResponse(url: MockAPIEndpoint.token.url, statusCode: 200),
+                            MockResponse.token)
+                }
+            default:
+                XCTFail("Unexpected request: \(request.url?.absoluteString ?? "<nil>")")
+                return (mockHTTPResponse(url: MockAPIEndpoint.discovery.url, statusCode: 500), Data())
+            }
+        }
+
+        let config = makeConfig()
+        let client = OidcDeviceClient(config: config)
+
+        let stream = try await client.deviceAuthorization()
+
+        var statuses: [String] = []
+        var pollingIntervalAfterError: Int?
+
+        outerLoop: for try await status in stream {
+            switch status {
+            case .started:
+                statuses.append("started")
+            case .polling(let count, let interval, _):
+                statuses.append("polling")
+                if count == 1 {
+                    // Capture the interval after the first URLError-triggered backoff
+                    pollingIntervalAfterError = interval
+                    // Exit after capturing backoff — avoids sleeping for the backed-off interval
+                    break outerLoop
+                }
+            case .success:
+                statuses.append("success")
+            case .expired:
+                statuses.append("expired")
+                XCTFail("Unexpected .expired — stream should have continued after URLError")
+            case .accessDenied:
+                statuses.append("accessDenied")
+                XCTFail("Unexpected .accessDenied — stream should have continued after URLError")
+            case .failure(let error):
+                statuses.append("failure")
+                XCTFail("Unexpected .failure — stream should have continued after URLError: \(error)")
+            }
+        }
+
+        XCTAssertTrue(statuses.contains("started"), "Stream should have yielded .started")
+        XCTAssertTrue(statuses.contains("polling"), "Stream should have yielded .polling after URLError backoff")
+        // After first URLError, consecutiveTimeouts=1, backoffMultiplier=2, interval=min(0*2,60)=0; but interval
+        // cannot go below the original value — verify it is at least 0 (not negative) and the stream continued
+        XCTAssertNotNil(pollingIntervalAfterError, "Should have captured the backoff polling interval")
+        XCTAssertGreaterThanOrEqual(pollingIntervalAfterError ?? -1, 0, "Backoff interval should be non-negative")
+    }
+}
+
+// MARK: - Test Helpers
+
+private struct MockUser: User {
+    func token() async -> Result<Token, OidcError> { .failure(.unknown()) }
+    func refresh() async -> Result<Token, OidcError> { .failure(.unknown()) }
+    func revoke() async {}
+    func userinfo(cache: Bool) async -> Result<UserInfo, OidcError> { .failure(.unknown()) }
+    func logout() async {}
+}

--- a/Oidc/OidcTests/mock/MockAPIEndpoint.swift
+++ b/Oidc/OidcTests/mock/MockAPIEndpoint.swift
@@ -2,7 +2,7 @@
 //  MockAPIEndpoint.swift
 //  OidcTests
 //
-//  Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -20,7 +20,8 @@ enum MockAPIEndpoint {
     case endSession
     case revocation
     case discovery
-    
+    case deviceAuthorization
+
     var url: URL {
         switch self {
         case .authorization:
@@ -35,6 +36,8 @@ enum MockAPIEndpoint {
             return URL(string: "\(MockAPIEndpoint.baseURL)/revoke")!
         case .discovery:
             return URL(string: "\(MockAPIEndpoint.baseURL)/.well-known/openid-configuration")!
+        case .deviceAuthorization:
+            return URL(string: "\(MockAPIEndpoint.baseURL)/device_authorization")!
         }
     }
 }

--- a/Oidc/OidcTests/mock/MockResponse.swift
+++ b/Oidc/OidcTests/mock/MockResponse.swift
@@ -66,4 +66,74 @@ struct MockResponse {
     }
     """.data(using: .utf8)!
     }
+
+    static var deviceAuthorizationResponse: Data {
+        """
+    {
+      "device_code" : "GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNhszIySk9eS",
+      "user_code" : "WDJB-MJHT",
+      "verification_uri" : "https://auth.test-one-pingone.com/activate",
+      "verification_uri_complete" : "https://auth.test-one-pingone.com/activate?user_code=WDJB-MJHT",
+      "expires_in" : 1800,
+      "interval" : 5
+    }
+    """.data(using: .utf8)!
+    }
+
+    static var deviceAuthorizationResponseNoInterval: Data {
+        """
+    {
+      "device_code" : "GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNhszIySk9eS",
+      "user_code" : "WDJB-MJHT",
+      "verification_uri" : "https://auth.test-one-pingone.com/activate",
+      "verification_uri_complete" : "https://auth.test-one-pingone.com/activate?user_code=WDJB-MJHT",
+      "expires_in" : 1800
+    }
+    """.data(using: .utf8)!
+    }
+
+    static var authorizationPending: Data {
+        """
+    {
+      "error" : "authorization_pending"
+    }
+    """.data(using: .utf8)!
+    }
+
+    static var slowDown: Data {
+        """
+    {
+      "error" : "slow_down"
+    }
+    """.data(using: .utf8)!
+    }
+
+    static var accessDenied: Data {
+        """
+    {
+      "error" : "access_denied"
+    }
+    """.data(using: .utf8)!
+    }
+
+    static var expiredToken: Data {
+        """
+    {
+      "error" : "expired_token"
+    }
+    """.data(using: .utf8)!
+    }
+
+    static var deviceAuthorizationResponseFastInterval: Data {
+        """
+    {
+      "device_code" : "GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNhszIySk9eS",
+      "user_code" : "WDJB-MJHT",
+      "verification_uri" : "https://auth.test-one-pingone.com/activate",
+      "verification_uri_complete" : "https://auth.test-one-pingone.com/activate?user_code=WDJB-MJHT",
+      "expires_in" : 1800,
+      "interval" : 0
+    }
+    """.data(using: .utf8)!
+    }
 }

--- a/Oidc/README.md
+++ b/Oidc/README.md
@@ -151,6 +151,61 @@ let oidcLogin = OidcWebClient.createOidcWebClient { config in
 - The server's OpenID configuration (discovery document) must include a `pushed_authorization_request_endpoint`.
 - If `par` is enabled but the discovery document does not include the PAR endpoint, the SDK falls back to the standard authorization flow automatically.
 
+## Device Authorization Grant (RFC 8628)
+
+`PingOidc` supports the [OAuth 2.0 Device Authorization Grant (RFC 8628)](https://datatracker.ietf.org/doc/html/rfc8628) for input-constrained devices (smart TVs, CLI tools) that can't directly open a browser. Use `OidcDeviceClient` to start a device flow, display the user code and verification URL, and poll for the access token.
+
+```swift
+let deviceClient = OidcDeviceClient.createOidcDeviceClient { config in
+    config.clientId = "ClientID"
+    config.scopes = ["openid", "profile", "email"]
+    config.redirectUri = "org.forgerock.demo://oauth2redirect"
+    config.discoveryEndpoint = "https://auth.example.com/.well-known/openid-configuration"
+}
+
+// Start the flow — returns an AsyncThrowingStream<DeviceFlowStatus, Error>
+let stream = try await deviceClient.deviceAuthorization()
+
+for try await status in stream {
+    switch status {
+    case .started(let response):
+        // Display response.userCode and response.verificationUri (or response.verificationUriComplete)
+        // to the user — for example as a QR code linking to verificationUriComplete.
+        print("Visit \(response.verificationUri) and enter \(response.userCode)")
+    case .polling(let pollCount, let pollInterval, let nextPollAt):
+        // Optional: update UI with polling progress
+        break
+    case .success(let user):
+        // Token has been saved to storage. `user` is an OidcUser ready to call .token() on.
+        let token = await user.token()
+    case .accessDenied:
+        // The user denied the request.
+        break
+    case .expired:
+        // The user code expired before the user authorized.
+        break
+    case .failure(let error):
+        // Terminal error not covered by the RFC 8628 error codes.
+        break
+    }
+}
+
+// Optionally open the verification URL in SFSafariViewController on this device:
+try await deviceClient.authorize(verificationUriComplete: response.verificationUriComplete ?? response.verificationUri)
+
+// Retrieve the existing user (returns nil if no token has been saved):
+let user = await deviceClient.user()
+
+// Revoke the stored token:
+await deviceClient.revoke()
+```
+
+**Requirements:**
+- The server's OpenID configuration (discovery document) must include a `device_authorization_endpoint`.
+- If the endpoint is missing, `deviceAuthorization()` throws `OidcError.unknown`.
+
+The polling loop honors the server-supplied `interval` and increases it by 5 seconds on every `slow_down` response per RFC 8628. Network errors (`URLError`) trigger an exponential backoff (capped at 60 seconds) and the stream continues; the stream only finishes on `.success`, `.accessDenied`, `.expired`, or a non-recoverable error.
+
 ## Custom Agent
 
 You can also provide a custom agent to launch the authorization request.

--- a/SampleApps/PingExample/PingExample.xcodeproj/project.pbxproj
+++ b/SampleApps/PingExample/PingExample.xcodeproj/project.pbxproj
@@ -60,8 +60,11 @@
 		A525E7B82DD7647200B02C17 /* PingExternalIdPFacebook.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A525E7B12DD7647200B02C17 /* PingExternalIdPFacebook.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A525E7B92DD7647200B02C17 /* PingExternalIdPGoogle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A525E7B22DD7647200B02C17 /* PingExternalIdPGoogle.framework */; };
 		A525E7BA2DD7647200B02C17 /* PingExternalIdPGoogle.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A525E7B22DD7647200B02C17 /* PingExternalIdPGoogle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		A55177322FA502D100E575CF /* BooleanCollectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55177312FA502D100E575CF /* BooleanCollectorView.swift */; };
 		A53B6E5B2F9A659B00B279CE /* ReadOnlyTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53B6E5A2F9A659B00B279CE /* ReadOnlyTextView.swift */; };
+		A55177322FA502D100E575CF /* BooleanCollectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55177312FA502D100E575CF /* BooleanCollectorView.swift */; };
+		A5517AB42FB5007B00E575CF /* DeviceFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5517AB32FB5007B00E575CF /* DeviceFlowView.swift */; };
+		A5517AC12FB5007B00E575CF /* ApproveDeviceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5517AC02FB5007B00E575CF /* ApproveDeviceView.swift */; };
+		A5517AC32FB5007B00E575CF /* DeviceQRScannerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5517AC22FB5007B00E575CF /* DeviceQRScannerSheet.swift */; };
 		A5560CA22CFE4EDA0076CA8D /* PingLogger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A57A08FA2CE50D51006F0CBB /* PingLogger.framework */; };
 		A5560CA32CFE4EDA0076CA8D /* PingLogger.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A57A08FA2CE50D51006F0CBB /* PingLogger.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A5560CA42CFE4EDA0076CA8D /* PingOidc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A57A09122CE51162006F0CBB /* PingOidc.framework */; };
@@ -681,8 +684,11 @@
 		A525E7BB2DD7680900B02C17 /* ExternalIdP.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ExternalIdP.xcodeproj; path = ../../ExternalIdP/ExternalIdP.xcodeproj; sourceTree = SOURCE_ROOT; };
 		A525E7C62DD7683500B02C17 /* ExternalIdPGoogle.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ExternalIdPGoogle.xcodeproj; path = ../../ExternalIdPGoogle/ExternalIdPGoogle.xcodeproj; sourceTree = SOURCE_ROOT; };
 		A525E7DC2DD7687800B02C17 /* ExternalIdPApple.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ExternalIdPApple.xcodeproj; path = ../../ExternalIdPApple/ExternalIdPApple.xcodeproj; sourceTree = SOURCE_ROOT; };
-		A55177312FA502D100E575CF /* BooleanCollectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooleanCollectorView.swift; sourceTree = "<group>"; };
 		A53B6E5A2F9A659B00B279CE /* ReadOnlyTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadOnlyTextView.swift; sourceTree = "<group>"; };
+		A55177312FA502D100E575CF /* BooleanCollectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooleanCollectorView.swift; sourceTree = "<group>"; };
+		A5517AB32FB5007B00E575CF /* DeviceFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceFlowView.swift; sourceTree = "<group>"; };
+		A5517AC02FB5007B00E575CF /* ApproveDeviceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApproveDeviceView.swift; sourceTree = "<group>"; };
+		A5517AC22FB5007B00E575CF /* DeviceQRScannerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceQRScannerSheet.swift; sourceTree = "<group>"; };
 		A55A25022ED4A49100D8820C /* DeviceClient.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DeviceClient.xcodeproj; path = ../../DeviceClient/DeviceClient.xcodeproj; sourceTree = SOURCE_ROOT; };
 		A56741BC2EE1EBFD009D29B9 /* Commons.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Commons.xcodeproj; path = ../../Commons/Commons.xcodeproj; sourceTree = SOURCE_ROOT; };
 		A569DBB82E789BD200F4D7A8 /* DeviceProfile.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DeviceProfile.xcodeproj; path = ../../DeviceProfile/DeviceProfile.xcodeproj; sourceTree = SOURCE_ROOT; };
@@ -991,6 +997,9 @@
 				1B7A9C7D2EE7BD2A00989A55 /* PushAccountsView.swift */,
 				1B7A9C7E2EE7BD2A00989A55 /* PushAccountsViewModel.swift */,
 				1B7A9C7F2EE7BD2A00989A55 /* PushNotificationCardView.swift */,
+				A5517AB32FB5007B00E575CF /* DeviceFlowView.swift */,
+				A5517AC02FB5007B00E575CF /* ApproveDeviceView.swift */,
+				A5517AC22FB5007B00E575CF /* DeviceQRScannerSheet.swift */,
 				1B18D6422EECC33C0004F205 /* PushNotificationDetailView.swift */,
 				1B7A9C802EE7BD2A00989A55 /* PushNotificationsView.swift */,
 				1B7A9C812EE7BD2A00989A55 /* PushNotificationsViewModel.swift */,
@@ -2041,6 +2050,9 @@
 				A5E9AEE12D30D304000533ED /* SubmitButtonView.swift in Sources */,
 				3A8092F42BE99F0F00AD667F /* CustomViews.swift in Sources */,
 				EC23D5712E2E8ECF00C43D42 /* OidcLoginView.swift in Sources */,
+				A5517AB42FB5007B00E575CF /* DeviceFlowView.swift in Sources */,
+				A5517AC12FB5007B00E575CF /* ApproveDeviceView.swift in Sources */,
+				A5517AC32FB5007B00E575CF /* DeviceQRScannerSheet.swift in Sources */,
 				A570D52E2ECCE47500CBBCCF /* DeviceManagementViewModel.swift in Sources */,
 				EC23D5722E2E8ECF00C43D42 /* OidcLoginViewModel.swift in Sources */,
 				A5EFA97F2D35F88D00F771FE /* PasswordView.swift in Sources */,

--- a/SampleApps/PingExample/PingExample/AccessTokenViewModel.swift
+++ b/SampleApps/PingExample/PingExample/AccessTokenViewModel.swift
@@ -29,7 +29,8 @@ class AccessTokenViewModel: ObservableObject {
     @Published var results: [AuthTab: AccessTokenResult] = [
         .journey: AccessTokenResult(),
         .davinci: AccessTokenResult(),
-        .oidc: AccessTokenResult()
+        .oidc: AccessTokenResult(),
+        .device: AccessTokenResult()
     ]
     
     init() {
@@ -44,7 +45,8 @@ class AccessTokenViewModel: ObservableObject {
             group.addTask { await (.journey, self.fetchToken(for: .journey)) }
             group.addTask { await (.davinci, self.fetchToken(for: .davinci)) }
             group.addTask { await (.oidc, self.fetchToken(for: .oidc)) }
-            
+            group.addTask { await (.device, self.fetchToken(for: .device)) }
+
             for await (tab, result) in group {
                 results[tab] = result
             }
@@ -60,6 +62,8 @@ class AccessTokenViewModel: ObservableObject {
             user = await ConfigurationManager.shared.davinciUser
         case .oidc:
             user = await ConfigurationManager.shared.oidcUser
+        case .device:
+            user = await ConfigurationManager.shared.deviceUser
         }
         
         guard let user = user else {
@@ -120,6 +124,8 @@ class AccessTokenViewModel: ObservableObject {
             return await ConfigurationManager.shared.davinciUser
         case .oidc:
             return await ConfigurationManager.shared.oidcUser
+        case .device:
+            return await ConfigurationManager.shared.deviceUser
         }
     }
 }

--- a/SampleApps/PingExample/PingExample/ApproveDeviceView.swift
+++ b/SampleApps/PingExample/PingExample/ApproveDeviceView.swift
@@ -1,0 +1,249 @@
+//
+//  ApproveDeviceView.swift
+//  PingExample
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import SwiftUI
+import UIKit
+import PingOidc
+import PingBrowser
+
+// UITextView wrapper that sets inputAccessoryView to an empty zero-frame view,
+// silencing the UIKit internal accessoryView/inputView constraint conflict in sheets.
+private struct NoAccessoryTextView: UIViewRepresentable {
+    @Binding var text: String
+
+    func makeUIView(context: Context) -> UITextView {
+        let tv = UITextView()
+        tv.delegate = context.coordinator
+        tv.inputAccessoryView = UIView(frame: .zero)
+        tv.backgroundColor = .clear
+        tv.font = UIFont.monospacedSystemFont(ofSize: 14, weight: .regular)
+        tv.autocorrectionType = .no
+        tv.autocapitalizationType = .none
+        tv.keyboardType = .URL
+        tv.textContainerInset = .zero
+        tv.textContainer.lineFragmentPadding = 0
+        tv.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        return tv
+    }
+
+    func updateUIView(_ uiView: UITextView, context: Context) {
+        if uiView.text != text { uiView.text = text }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    final class Coordinator: NSObject, UITextViewDelegate {
+        var parent: NoAccessoryTextView
+        init(_ parent: NoAccessoryTextView) { self.parent = parent }
+        func textViewDidChange(_ textView: UITextView) { parent.text = textView.text }
+    }
+}
+
+/// Side-channel for handing a verification URL to a navigation destination
+/// without going through `@State`/`@Binding` propagation. SwiftUI does not
+/// guarantee that two sibling `@State` writes (`pendingVerificationUri` and
+/// `path.append`) are coalesced into the same render pass, so the destination
+/// view can be constructed before the URL binding is observed by the parent.
+@MainActor
+enum DeviceApproval {
+    static var pendingVerificationUri: URL?
+}
+
+struct ApproveDeviceView: View {
+    @Binding var path: [MenuItem]
+
+    @State private var verificationUri = ""
+    @State private var isAuthorizing = false
+    @State private var errorMessage: String? = nil
+    @State private var showScanner = false
+
+    private var hasDavinci: Bool { ConfigurationManager.shared.davinci != nil }
+    private var hasJourney: Bool { ConfigurationManager.shared.journey != nil }
+    private var hasDevice: Bool { ConfigurationManager.shared.deviceClient != nil }
+    private var trimmedUri: String { verificationUri.trimmingCharacters(in: .whitespaces) }
+    private var isUriEmpty: Bool { trimmedUri.isEmpty }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(spacing: 24) {
+                    VStack(spacing: 8) {
+                        Image(systemName: "checkmark.shield.fill")
+                            .font(.system(size: 56))
+                            .foregroundColor(.themeButtonBackground)
+
+                        Text("Approve on This Device")
+                            .font(.system(size: 20, weight: .semibold))
+
+                        Text("Paste the verification URL from another device (including the user_code) and tap Approve to authorize it here.")
+                            .font(.system(size: 14))
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("Verification URL")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundColor(.secondary)
+                                .textCase(.uppercase)
+
+                            Spacer()
+
+                            Button {
+                                showScanner = true
+                            } label: {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "qrcode.viewfinder")
+                                        .font(.system(size: 14))
+                                    Text("Scan")
+                                        .font(.system(size: 12, weight: .medium))
+                                }
+                                .foregroundColor(.themeButtonBackground)
+                            }
+                            .buttonStyle(PlainButtonStyle())
+                        }
+
+                        ZStack(alignment: .topLeading) {
+                            if verificationUri.isEmpty {
+                                Text("https://…?user_code=XXXX-XXXX")
+                                    .font(.system(size: 14, design: .monospaced))
+                                    .foregroundColor(Color(.placeholderText))
+                                    .allowsHitTesting(false)
+                            }
+                            NoAccessoryTextView(text: $verificationUri)
+                                .frame(minHeight: 72)
+                        }
+                        .padding(8)
+                        .background(Color(.systemGray6))
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                    }
+
+                    if let error = errorMessage {
+                        HStack(spacing: 8) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundColor(.orange)
+                            Text(error)
+                                .font(.system(size: 13))
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(12)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color(.systemGray6))
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                    }
+                }
+                .padding(20)
+            }
+
+            // Buttons pinned to the bottom
+            VStack(spacing: 10) {
+                if isAuthorizing {
+                    ProgressView("Opening browser…")
+                        .padding(.vertical, 8)
+                } else {
+                    if hasDavinci {
+                        approveButton(
+                            title: "Approve with DaVinci",
+                            icon: "key.fill",
+                            style: .primary,
+                            action: { approveNative(.davinciDeviceApprove) }
+                        )
+                    }
+                    if hasJourney {
+                        approveButton(
+                            title: "Approve with Journey",
+                            icon: "map.fill",
+                            style: .primary,
+                            action: { approveNative(.journeyDeviceApprove) }
+                        )
+                    }
+                    if hasDevice {
+                        approveButton(
+                            title: "Approve in Browser",
+                            icon: "safari.fill",
+                            style: .secondary,
+                            action: authorizeBrowser
+                        )
+                    }
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 12)
+            .padding(.bottom, 24)
+            .background(Color(.systemGroupedBackground))
+        }
+        .background(Color(.systemGroupedBackground))
+        .ignoresSafeArea(.keyboard)
+        .navigationTitle("Approve Device")
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $showScanner) {
+            DeviceQRScannerSheet(verificationUri: $verificationUri)
+        }
+    }
+
+    private enum ButtonStyleVariant { case primary, secondary }
+
+    @ViewBuilder
+    private func approveButton(title: String, icon: String, style: ButtonStyleVariant, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Image(systemName: icon)
+                    .font(.system(size: 14))
+                Text(title)
+                    .font(.system(size: 14, weight: .semibold))
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .foregroundColor(style == .primary
+                ? .white
+                : (isUriEmpty ? Color.gray : Color.themeButtonBackground))
+            .background(style == .primary
+                ? (isUriEmpty ? Color.gray.opacity(0.4) : Color.themeButtonBackground)
+                : Color.themeButtonBackground.opacity(0.12))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+        }
+        .buttonStyle(PlainButtonStyle())
+        .disabled(isUriEmpty)
+    }
+
+    private func approveNative(_ menuItem: MenuItem) {
+        errorMessage = nil
+        guard let url = URL(string: trimmedUri) else {
+            errorMessage = "Invalid verification URL."
+            return
+        }
+        DeviceApproval.pendingVerificationUri = url
+        path.append(menuItem)
+    }
+
+    private func authorizeBrowser() {
+        errorMessage = nil
+        guard let client = ConfigurationManager.shared.deviceClient else {
+            errorMessage = "No Device Flow configuration found. Add one in Configurations."
+            return
+        }
+        isAuthorizing = true
+        let uri = trimmedUri
+        Task {
+            do {
+                try await client.authorize(verificationUriComplete: uri)
+            } catch BrowserError.externalUserAgentCancelled {
+                // user closed the browser — fall through to pop
+            } catch {
+                errorMessage = error.localizedDescription
+                isAuthorizing = false
+                return
+            }
+            isAuthorizing = false
+            path.removeLast()
+        }
+    }
+}

--- a/SampleApps/PingExample/PingExample/ConfigurationListView.swift
+++ b/SampleApps/PingExample/PingExample/ConfigurationListView.swift
@@ -219,6 +219,7 @@ private extension ConfigType {
         case .journey: return "map.fill"
         case .davinci: return "key.fill"
         case .oidcWeb: return "lock.shield.fill"
+        case .device: return "tv"
         }
     }
 }

--- a/SampleApps/PingExample/PingExample/ConfigurationManager.swift
+++ b/SampleApps/PingExample/PingExample/ConfigurationManager.swift
@@ -37,7 +37,8 @@ class ConfigurationManager: ObservableObject {
     private static let selectionKeys: [ConfigType: String] = [
         .journey: "SelectedJourneyConfigName",
         .davinci: "SelectedDaVinciConfigName",
-        .oidcWeb: "SelectedOidcWebConfigName"
+        .oidcWeb: "SelectedOidcWebConfigName",
+        .device: "SelectedDeviceConfigName"
     ]
     
     private static let userConfigsKey = "UserConfigurations"
@@ -57,6 +58,7 @@ class ConfigurationManager: ObservableObject {
     public var journey: Journey?
     public var davinci: DaVinci?
     public var oidcLogin: OidcWebClient?
+    public var deviceClient: OidcDeviceClient?
 
     // MFA Clients
     public var oathClient: OathClient?
@@ -77,16 +79,19 @@ class ConfigurationManager: ObservableObject {
         let journeyConfig = ConfigurationManager.loadSelection(for: .journey, from: allConfigs)
         let davinciConfig = ConfigurationManager.loadSelection(for: .davinci, from: allConfigs)
         let oidcWebConfig = ConfigurationManager.loadSelection(for: .oidcWeb, from: allConfigs)
-        
+        let deviceConfig = ConfigurationManager.loadSelection(for: .device, from: allConfigs)
+
         var sels = [ConfigType: Configuration]()
         if let c = journeyConfig { sels[.journey] = c }
         if let c = davinciConfig { sels[.davinci] = c }
         if let c = oidcWebConfig { sels[.oidcWeb] = c }
+        if let c = deviceConfig { sels[.device] = c }
         self.selections = sels
-        
+
         self.journey = journeyConfig.map { ConfigurationManager.buildJourney($0) }
         self.davinci = davinciConfig.map { ConfigurationManager.buildDaVinci($0) }
         self.oidcLogin = oidcWebConfig.map { ConfigurationManager.buildOidcWebClient($0) }
+        self.deviceClient = deviceConfig.map { ConfigurationManager.buildDeviceClient($0) }
     }
     
     // MARK: - Configuration Selection
@@ -120,6 +125,8 @@ class ConfigurationManager: ObservableObject {
             davinci = ConfigurationManager.buildDaVinci(config)
         case .oidcWeb:
             oidcLogin = ConfigurationManager.buildOidcWebClient(config)
+        case .device:
+            deviceClient = ConfigurationManager.buildDeviceClient(config)
         }
     }
     
@@ -164,6 +171,7 @@ class ConfigurationManager: ObservableObject {
                 case .journey: journey = nil
                 case .davinci: davinci = nil
                 case .oidcWeb: oidcLogin = nil
+                case .device: deviceClient = nil
                 }
             }
         }
@@ -174,6 +182,12 @@ class ConfigurationManager: ObservableObject {
     public var journeyUser: User? {
         get async {
             return await journey?.journeyUser()
+        }
+    }
+
+    public var deviceUser: User? {
+        get async {
+            return await deviceClient?.user()
         }
     }
     
@@ -247,6 +261,22 @@ class ConfigurationManager: ObservableObject {
         }
     }
     
+    private static func buildDeviceClient(_ config: Configuration) -> OidcDeviceClient {
+        OidcDeviceClient.createOidcDeviceClient { oidcConfig in
+            oidcConfig.clientId = config.clientId
+            oidcConfig.scopes = Set<String>(config.scopes)
+            oidcConfig.redirectUri = config.redirectUri
+            oidcConfig.discoveryEndpoint = config.discoveryEndpoint
+            oidcConfig.storage = KeychainStorage<Token>(account: "ACCESS_TOKEN_STORAGE_DEVICE")
+            oidcConfig.logger = LogManager.standard
+            oidcConfig.openIdOverride = { openId in
+                if config.deviceAuthorizationEndpoint != nil {
+                    openId.deviceAuthorizationEndpoint = config.deviceAuthorizationEndpoint
+                }
+            }
+        }
+    }
+
     // MARK: - Persistence Helpers
     
     /// Loads all configurations: defaults plus user-added configs from UserDefaults.

--- a/SampleApps/PingExample/PingExample/ConfigurationViewModel.swift
+++ b/SampleApps/PingExample/PingExample/ConfigurationViewModel.swift
@@ -27,6 +27,7 @@ struct Configuration: Codable, Sendable {
     var redirectUri: String
     var signOutUri: String?
     var discoveryEndpoint: String
+    var deviceAuthorizationEndpoint: String?
     var environment: String
     var cookieName: String?
     var serverUrl: String?
@@ -45,12 +46,14 @@ enum ConfigType: String, Codable, CaseIterable, Sendable {
     case journey = "Journey"
     case davinci = "DaVinci"
     case oidcWeb = "OIDC (Web)"
-    
+    case device = "Device Flow"
+
     var iconName: String {
         switch self {
         case .journey: return "map.fill"
         case .davinci: return "key.fill"
         case .oidcWeb: return "lock.shield.fill"
+        case .device: return "tv"
         }
     }
 }

--- a/SampleApps/PingExample/PingExample/ContentView.swift
+++ b/SampleApps/PingExample/PingExample/ContentView.swift
@@ -68,7 +68,7 @@ enum MenuSection: CaseIterable, Identifiable {
     var items: [MenuItem] {
         switch self {
         case .authentication:
-            return [.davinci, .journey, .oidc]
+            return [.davinci, .journey, .oidc, .device]
         case .userManagement:
             return [.token, .user, .deviceManagement, .logout]
         case .mfa:
@@ -84,6 +84,7 @@ enum MenuItem: String, CaseIterable, Identifiable {
     case davinci = "DaVinci"
     case journey = "Journey"
     case oidc = "OIDC (Web)"
+    case device = "Device Flow"
     case oathAccounts = "OATH"
     case pushAccounts = "Push"
     case qrScanner = "QR Scanner"
@@ -101,6 +102,10 @@ enum MenuItem: String, CaseIterable, Identifiable {
     case journeyToken = "Journey Token"
     case davinciToken = "DaVinci Token"
     case oidcToken = "OIDC Token"
+    case deviceToken = "Device Token"
+    case davinciDeviceApprove = "Approve with DaVinci"
+    case journeyDeviceApprove = "Approve with Journey"
+    case approveDevice = "Approve Device"
 
     var id: String { rawValue }
     
@@ -109,6 +114,7 @@ enum MenuItem: String, CaseIterable, Identifiable {
         case .davinci: return "key.fill"
         case .journey: return "map.fill"
         case .oidc: return "lock.shield.fill"
+        case .device: return "tv"
         case .oathAccounts: return "key.viewfinder"
         case .pushAccounts: return "bell.badge.fill"
         case .qrScanner: return "qrcode.viewfinder"
@@ -126,6 +132,10 @@ enum MenuItem: String, CaseIterable, Identifiable {
         case .journeyToken: return "map.fill"
         case .davinciToken: return "key.fill"
         case .oidcToken: return "lock.shield.fill"
+        case .deviceToken: return "tv"
+        case .davinciDeviceApprove: return "key.fill"
+        case .journeyDeviceApprove: return "map.fill"
+        case .approveDevice: return "checkmark.shield.fill"
         }
     }
     
@@ -134,6 +144,7 @@ enum MenuItem: String, CaseIterable, Identifiable {
         case .davinci: return "DaVinci Flow"
         case .journey: return "Journey Flow"
         case .oidc: return "OIDC (Web) Login"
+        case .device: return "Device Flow"
         case .oathAccounts: return "OATH"
         case .pushAccounts: return "Push"
         case .qrScanner: return "QR Scanner"
@@ -147,10 +158,14 @@ enum MenuItem: String, CaseIterable, Identifiable {
         case .storage: return "Storage"
         case .bindingKeys: return "Binding Keys"
         case .migration: return "Migration"
-        case .configuration: return "Configurationss"
+        case .configuration: return "Configurations"
         case .journeyToken: return "Journey Access Token"
         case .davinciToken: return "DaVinci Access Token"
         case .oidcToken: return "OIDC (Web) Access Token"
+        case .deviceToken: return "Device Flow Access Token"
+        case .davinciDeviceApprove: return "Approve with DaVinci"
+        case .journeyDeviceApprove: return "Approve with Journey"
+        case .approveDevice: return "Approve Device"
         }
     }
     
@@ -159,6 +174,7 @@ enum MenuItem: String, CaseIterable, Identifiable {
         case .davinci: return "Test DaVinci authentication"
         case .journey: return "Test Journey authentication"
         case .oidc: return "OpenID Connect flow"
+        case .device: return "RFC 8628 device authorization"
         case .oathAccounts: return "Manage TOTP and HOTP accounts"
         case .pushAccounts: return "Manage push authentication accounts"
         case .qrScanner: return "Scan QR codes for registration"
@@ -176,6 +192,10 @@ enum MenuItem: String, CaseIterable, Identifiable {
         case .journeyToken: return "View Journey token"
         case .davinciToken: return "View DaVinci token"
         case .oidcToken: return "View OIDC token"
+        case .deviceToken: return "View Device Flow token"
+        case .davinciDeviceApprove: return "Approve device flow via DaVinci"
+        case .journeyDeviceApprove: return "Approve device flow via Journey"
+        case .approveDevice: return "Approve a device's verification URL"
         }
     }
     
@@ -185,6 +205,7 @@ enum MenuItem: String, CaseIterable, Identifiable {
         case .journey, .journeyToken: return .journey
         case .davinci, .davinciToken: return .davinci
         case .oidc, .oidcToken: return .oidcWeb
+        case .device, .deviceToken: return .device
         default: return nil
         }
     }
@@ -241,6 +262,8 @@ struct ContentView: View {
                     JourneyView(path: $path)
                 case .oidc:
                     OidcLoginView(path: $path)
+                case .device:
+                    DeviceFlowView(path: $path)
                 case .oathAccounts:
                     OathAccountsView(path: $path)
                 case .pushAccounts:
@@ -257,6 +280,8 @@ struct ContentView: View {
                     AccessTokenView(menuItem: item, fixedTab: .davinci)
                 case .oidcToken:
                     AccessTokenView(menuItem: item, fixedTab: .oidc)
+                case .deviceToken:
+                    AccessTokenView(menuItem: item, fixedTab: .device)
                 case .user:
                     UserInfoView(menuItem: item)
                 case .deviceManagement:
@@ -273,6 +298,12 @@ struct ContentView: View {
                     AuthMigrationView()
                 case .deviceInfo:
                     DeviceInfoView(menuItem: item)
+                case .davinciDeviceApprove:
+                    DavinciView(path: $path, verificationUriComplete: DeviceApproval.pendingVerificationUri)
+                case .journeyDeviceApprove:
+                    JourneyView(path: $path, verificationUriComplete: DeviceApproval.pendingVerificationUri)
+                case .approveDevice:
+                    ApproveDeviceView(path: $path)
                 }
             }
             .task {
@@ -307,28 +338,28 @@ struct ContentView: View {
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing
             )
-            
+
             VStack(spacing: 12) {
                 Image("Logo")
                     .resizable()
                     .scaledToFit()
                     .frame(width: 80, height: 80)
-                
+
                 Text("Ping SDK")
                     .font(.system(size: 28, weight: .bold))
                     .foregroundColor(.white)
-                
+
                 Text("Development Testing Suite")
                     .font(.system(size: 14, weight: .medium))
                     .foregroundColor(.white.opacity(0.9))
-                
+
                 Text(sdkVersion)
                     .font(.system(size: 13, design: .monospaced))
                     .foregroundColor(.white.opacity(0.7))
             }
             .padding(.vertical, 10)
             .frame(maxWidth: .infinity)
-            
+
             Button {
                 path.append(.configuration)
             } label: {

--- a/SampleApps/PingExample/PingExample/DavinciView.swift
+++ b/SampleApps/PingExample/PingExample/DavinciView.swift
@@ -17,9 +17,16 @@ import PingDavinci
 /// The main view for orchestrating the Davinci flow.
 struct DavinciView: View {
     /// The view model that manages the Davinci flow logic.
-    @StateObject private var davinciViewModel = DavinciViewModel()
+    @StateObject private var davinciViewModel: DavinciViewModel
     /// A binding to the navigation stack path.
     @Binding var path: [MenuItem]
+
+    init(path: Binding<[MenuItem]>, verificationUriComplete: URL? = nil) {
+        self._path = path
+        self._davinciViewModel = StateObject(
+            wrappedValue: DavinciViewModel(verificationUriComplete: verificationUriComplete)
+        )
+    }
     
     var body: some View {
         ZStack {

--- a/SampleApps/PingExample/PingExample/DavinciViewModel.swift
+++ b/SampleApps/PingExample/PingExample/DavinciViewModel.swift
@@ -90,25 +90,40 @@ class DavinciViewModel: ObservableObject {
     @Published public var state: DavinciState = DavinciState()
     /// Published property to track whether the view is currently loading.
     @Published public var isLoading: Bool = false
-    
+
+    /// Optional verification URI for the RFC 8628 device authorization grant.
+    /// When set, DaVinci.start extracts the user_code from the URL.
+    public var verificationUriComplete: URL?
+
     /// Initializes the view model and starts the DaVinci orchestration process.
-    init() {
+    /// - Parameter verificationUriComplete: Optional verification URI for the RFC 8628
+    ///   device authorization grant. When provided, the user_code is extracted and
+    ///   forwarded to DaVinci so the requesting device is approved on success.
+    init(verificationUriComplete: URL? = nil) {
+        self.verificationUriComplete = verificationUriComplete
         Task {
             await startDavinci()
         }
     }
-    
+
     /// Starts the DaVinci orchestration process.
     /// - Sets the initial node and updates the `data` property with the starting node.
     public func startDavinci() async {
-        
+
         await MainActor.run {
             isLoading = true
         }
-        
+
         // Starts the DaVinci orchestration process and retrieves the first node.
         guard let davinci = davinci else { return }
-        let next = await davinci.start()
+        let next: Node
+        if let uri = verificationUriComplete {
+            next = await davinci.start { options in
+                options.verificationUriComplete = uri
+            }
+        } else {
+            next = await davinci.start()
+        }
         await MainActor.run {
             self.state = DavinciState(node: next)
             isLoading = false

--- a/SampleApps/PingExample/PingExample/DeviceFlowView.swift
+++ b/SampleApps/PingExample/PingExample/DeviceFlowView.swift
@@ -91,6 +91,8 @@ final class DeviceFlowViewModel: ObservableObject {
     }
 
     func reset() {
+        // cancel() signals cancellation; production code should await the task value before
+        // treating the flow as fully stopped to avoid two flows running concurrently.
         streamTask?.cancel()
         streamTask = nil
         isLoading = false

--- a/SampleApps/PingExample/PingExample/DeviceFlowView.swift
+++ b/SampleApps/PingExample/PingExample/DeviceFlowView.swift
@@ -1,0 +1,437 @@
+//
+//  DeviceFlowView.swift
+//  PingExample
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import SwiftUI
+import CoreImage.CIFilterBuiltins
+import PingOidc
+
+// MARK: - ViewModel
+
+@MainActor
+final class DeviceFlowViewModel: ObservableObject {
+
+    enum State {
+        case idle
+        case active(pollCount: Int?, nextPollAt: Date?)   // started + polling share one state
+        case accessDenied
+        case expired
+        case failure(String)
+    }
+
+    @Published var state: State = .idle
+    @Published var isLoading = false
+    @Published var isSuccess = false
+
+    // Retained once received; never cleared while flow is active.
+    @Published var userCode: String = ""
+    @Published var verificationUri: String = ""
+    @Published var verificationUriComplete: String? = nil
+
+    private var streamTask: Task<Void, Never>?
+
+    func start() {
+        guard let client = ConfigurationManager.shared.deviceClient else { return }
+        isLoading = true
+        streamTask?.cancel()
+
+        streamTask = Task {
+            do {
+                let stream = try await client.deviceAuthorization()
+                for try await status in stream {
+                    switch status {
+                    case .started(let response):
+                        userCode = response.userCode
+                        verificationUri = response.verificationUri
+                        verificationUriComplete = response.verificationUriComplete
+                        isLoading = false
+                        state = .active(pollCount: nil, nextPollAt: nil)
+                    case .polling(let count, _, let nextPollAt):
+                        isLoading = false
+                        state = .active(pollCount: count, nextPollAt: nextPollAt)
+                    case .success:
+                        isLoading = false
+                        isSuccess = true
+                    case .accessDenied:
+                        isLoading = false
+                        state = .accessDenied
+                    case .expired:
+                        isLoading = false
+                        state = .expired
+                    case .failure(let error):
+                        isLoading = false
+                        state = .failure(error.localizedDescription)
+                    }
+                }
+            } catch {
+                if error is CancellationError { return }
+                isLoading = false
+                state = .failure(error.localizedDescription)
+            }
+        }
+    }
+
+    func authorize() {
+        guard let client = ConfigurationManager.shared.deviceClient,
+              let uriComplete = verificationUriComplete else { return }
+        Task { try? await client.authorize(verificationUriComplete: uriComplete) }
+    }
+
+    func hasExistingUser() async -> Bool {
+        guard let client = ConfigurationManager.shared.deviceClient else { return false }
+        return await client.user() != nil
+    }
+
+    func reset() {
+        streamTask?.cancel()
+        streamTask = nil
+        isLoading = false
+        isSuccess = false
+        userCode = ""
+        verificationUri = ""
+        verificationUriComplete = nil
+        state = .idle
+    }
+}
+
+// MARK: - View
+
+struct DeviceFlowView: View {
+    @Binding var path: [MenuItem]
+    @StateObject private var viewModel = DeviceFlowViewModel()
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                content
+            }
+            .padding(20)
+        }
+        .navigationTitle("Device Flow")
+        .navigationBarTitleDisplayMode(.inline)
+        .onDisappear { viewModel.reset() }
+        .onChange(of: viewModel.isSuccess) { success in
+            if success {
+                path.removeLast()
+                path.append(.deviceToken)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch viewModel.state {
+        case .idle:
+            idleCard
+            orDivider
+            approveCard
+
+        case .active(let pollCount, let nextPollAt):
+            activationCard
+            pollingStatusCard(pollCount: pollCount, nextPollAt: nextPollAt)
+
+        case .accessDenied:
+            resultCard(
+                icon: "xmark.circle.fill",
+                iconColor: .red,
+                title: "Access Denied",
+                message: "The authorization request was denied."
+            )
+
+        case .expired:
+            resultCard(
+                icon: "clock.badge.xmark",
+                iconColor: .orange,
+                title: "Expired",
+                message: "The device code has expired. Please start a new flow."
+            )
+
+        case .failure(let message):
+            resultCard(
+                icon: "exclamationmark.triangle.fill",
+                iconColor: .orange,
+                title: "Error",
+                message: message
+            )
+        }
+    }
+
+    // MARK: - Idle
+
+    private var idleCard: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "tv")
+                .font(.system(size: 64))
+                .foregroundColor(.themeButtonBackground)
+
+            Text("Device Authorization Flow")
+                .font(.system(size: 20, weight: .semibold))
+
+            Text("Start the RFC 8628 device authorization grant. The server returns a user code and verification URL — enter them on another device (phone, laptop) to complete sign-in here.")
+                .font(.system(size: 14))
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+
+            if viewModel.isLoading {
+                ProgressView("Starting flow…")
+            } else {
+                Button {
+                    Task {
+                        if await viewModel.hasExistingUser() {
+                            path.removeLast()
+                            path.append(.deviceToken)
+                        } else {
+                            viewModel.start()
+                        }
+                    }
+                } label: {
+                    Text("Start Device Flow")
+                        .font(.system(size: 14, weight: .semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .foregroundColor(.white)
+                        .background(Color.themeButtonBackground)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+        }
+        .padding(24)
+        .background(Color(.secondarySystemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .shadow(color: .black.opacity(0.05), radius: 4, x: 0, y: 2)
+    }
+
+    // MARK: - Divider
+
+    private var orDivider: some View {
+        HStack(spacing: 12) {
+            Rectangle()
+                .fill(Color.secondary.opacity(0.3))
+                .frame(height: 1)
+            Text("OR")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(.secondary)
+            Rectangle()
+                .fill(Color.secondary.opacity(0.3))
+                .frame(height: 1)
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Approve
+
+    private var approveCard: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "checkmark.shield.fill")
+                .font(.system(size: 64))
+                .foregroundColor(.themeButtonBackground)
+
+            Text("Approve a Device")
+                .font(.system(size: 20, weight: .semibold))
+
+            Text("This device is approving another device's request. Paste or scan the verification URL from the requesting device to complete sign-in there.")
+                .font(.system(size: 14))
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+
+            Button {
+                path.append(.approveDevice)
+            } label: {
+                Text("Approve a Device")
+                    .font(.system(size: 14, weight: .semibold))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .foregroundColor(.white)
+                    .background(Color.themeButtonBackground)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+            }
+            .buttonStyle(PlainButtonStyle())
+        }
+        .padding(24)
+        .background(Color(.secondarySystemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .shadow(color: .black.opacity(0.05), radius: 4, x: 0, y: 2)
+    }
+
+    // MARK: - Activation (persists through polling)
+
+    private var activationCard: some View {
+        VStack(spacing: 20) {
+            VStack(spacing: 8) {
+                Text("Activate Your Device")
+                    .font(.system(size: 18, weight: .semibold))
+
+                Text("Scan the QR code or visit the URL below and enter the code.")
+                    .font(.system(size: 13))
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            // QR code — prefer verificationUriComplete so the code is pre-filled on scan
+            let qrContent = viewModel.verificationUriComplete ?? viewModel.verificationUri
+            if !qrContent.isEmpty {
+                QRCodeDisplayView(content: qrContent)
+                    .frame(width: 180, height: 180)
+                    .padding(8)
+                    .background(Color.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+
+            VStack(spacing: 4) {
+                Text("User Code")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(.secondary)
+                    .textCase(.uppercase)
+
+                CopyableRow {
+                    Text(viewModel.userCode)
+                        .font(.system(size: 36, weight: .bold, design: .monospaced))
+                        .foregroundColor(.themeButtonBackground)
+                } value: { viewModel.userCode }
+            }
+
+            VStack(spacing: 4) {
+                Text("Verification URL")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(.secondary)
+                    .textCase(.uppercase)
+
+                CopyableRow {
+                    Text(viewModel.verificationUriComplete ?? viewModel.verificationUri)
+                        .font(.system(size: 13, design: .monospaced))
+                        .foregroundColor(.primary)
+                        .multilineTextAlignment(.center)
+                } value: { viewModel.verificationUriComplete ?? viewModel.verificationUri }
+            }
+        }
+        .padding(24)
+        .background(Color(.secondarySystemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .shadow(color: .black.opacity(0.05), radius: 4, x: 0, y: 2)
+    }
+
+    // MARK: - Polling Status
+
+    private func pollingStatusCard(pollCount: Int?, nextPollAt: Date?) -> some View {
+        HStack(spacing: 12) {
+            ProgressView()
+
+            if let count = pollCount, let next = nextPollAt {
+                TimelineView(.periodic(from: .now, by: 1)) { context in
+                    let remaining = max(0, Int(next.timeIntervalSince(context.date).rounded()))
+                    let timeStr = next.formatted(.dateTime.hour().minute().second())
+                    Text("Poll #\(count) — next in \(remaining)s (at \(timeStr))")
+                        .font(.system(size: 13))
+                        .foregroundColor(.secondary)
+                }
+            } else {
+                Text("Waiting for authorization…")
+                    .font(.system(size: 13))
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.secondarySystemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.05), radius: 4, x: 0, y: 2)
+    }
+
+    // MARK: - Result
+
+    private func resultCard(icon: String, iconColor: Color, title: String, message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: icon)
+                .font(.system(size: 56))
+                .foregroundColor(iconColor)
+
+            Text(title)
+                .font(.system(size: 20, weight: .semibold))
+
+            Text(message)
+                .font(.system(size: 14))
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+
+            Button {
+                viewModel.reset()
+            } label: {
+                Text("Start New Flow")
+                    .font(.system(size: 14, weight: .semibold))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .foregroundColor(.white)
+                    .background(Color.themeButtonBackground)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+            }
+            .buttonStyle(PlainButtonStyle())
+        }
+        .padding(24)
+        .background(Color(.secondarySystemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .shadow(color: .black.opacity(0.05), radius: 4, x: 0, y: 2)
+    }
+}
+
+// MARK: - Copyable Row
+
+private struct CopyableRow<Label: View>: View {
+    @ViewBuilder let label: () -> Label
+    let value: () -> String
+    @State private var copied = false
+
+    var body: some View {
+        Button {
+            UIPasteboard.general.string = value()
+            copied = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { copied = false }
+        } label: {
+            HStack(spacing: 10) {
+                label()
+                    .frame(maxWidth: .infinity)
+                Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                    .font(.system(size: 15))
+                    .foregroundColor(copied ? .green : .secondary)
+                    .animation(.easeInOut(duration: 0.2), value: copied)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(Color(.systemGray6))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - QR Code
+
+private struct QRCodeDisplayView: View {
+    let content: String
+
+    var body: some View {
+        if let image = makeQRCode(from: content) {
+            Image(uiImage: image)
+                .interpolation(.none)
+                .resizable()
+                .scaledToFit()
+        }
+    }
+
+    private func makeQRCode(from string: String) -> UIImage? {
+        let filter = CIFilter.qrCodeGenerator()
+        filter.message = Data(string.utf8)
+        filter.correctionLevel = "M"
+        guard let ciImage = filter.outputImage else { return nil }
+        let scaled = ciImage.transformed(by: CGAffineTransform(scaleX: 10, y: 10))
+        guard let cgImage = CIContext().createCGImage(scaled, from: scaled.extent) else { return nil }
+        return UIImage(cgImage: cgImage)
+    }
+}

--- a/SampleApps/PingExample/PingExample/DeviceFlowView.swift
+++ b/SampleApps/PingExample/PingExample/DeviceFlowView.swift
@@ -39,6 +39,8 @@ final class DeviceFlowViewModel: ObservableObject {
     func start() {
         guard let client = ConfigurationManager.shared.deviceClient else { return }
         isLoading = true
+        // cancel() signals cancellation; the in-flight poll exits on the next Task.sleep check.
+        // Production code should await the task before starting a new one to prevent two flows running concurrently.
         streamTask?.cancel()
 
         streamTask = Task {

--- a/SampleApps/PingExample/PingExample/DeviceQRScannerSheet.swift
+++ b/SampleApps/PingExample/PingExample/DeviceQRScannerSheet.swift
@@ -1,0 +1,49 @@
+//
+//  DeviceQRScannerSheet.swift
+//  PingExample
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import SwiftUI
+
+struct DeviceQRScannerSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Binding var verificationUri: String
+    @State private var scannerDelegate: ScannerDelegate?
+
+    @MainActor
+    final class ScannerDelegate: NSObject, QRScannerDelegate {
+        let onScan: @MainActor (String) -> Void
+        init(onScan: @escaping @MainActor (String) -> Void) { self.onScan = onScan }
+        nonisolated func didScan(code: String) {
+            Task { @MainActor [weak self] in self?.onScan(code) }
+        }
+        nonisolated func didFailWithError(error: Error) {}
+    }
+
+    var body: some View {
+        NavigationStack {
+            QRScannerView(delegate: scannerDelegate)
+                .ignoresSafeArea()
+                .navigationTitle("Scan Verification QR")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { dismiss() }
+                    }
+                }
+                .onAppear {
+                    if scannerDelegate == nil {
+                        scannerDelegate = ScannerDelegate { code in
+                            verificationUri = code
+                            dismiss()
+                        }
+                    }
+                }
+        }
+    }
+}

--- a/SampleApps/PingExample/PingExample/JourneyView.swift
+++ b/SampleApps/PingExample/PingExample/JourneyView.swift
@@ -22,9 +22,16 @@ import PingCommons
 
 struct JourneyView: View {
     /// The view model that manages the Journey flow logic.
-    @StateObject private var journeyViewModel = JourneyViewModel()
+    @StateObject private var journeyViewModel: JourneyViewModel
     /// A binding to the navigation stack path.
     @Binding var path: [MenuItem]
+
+    init(path: Binding<[MenuItem]>, verificationUriComplete: URL? = nil) {
+        self._path = path
+        self._journeyViewModel = StateObject(
+            wrappedValue: JourneyViewModel(verificationUriComplete: verificationUriComplete)
+        )
+    }
     
     var body: some View {
         ZStack {

--- a/SampleApps/PingExample/PingExample/JourneyViewModel.swift
+++ b/SampleApps/PingExample/PingExample/JourneyViewModel.swift
@@ -134,10 +134,14 @@ class JourneyViewModel: ObservableObject {
     /// Published property to control whether to show the journey name input screen
     @Published public var showJourneyNameInput: Bool = true
 
+    /// Optional verification URI for the RFC 8628 device authorization grant.
+    /// When set, the user_code is extracted and the requesting device is approved on success.
+    public var verificationUriComplete: URL?
+
     /// Initializes the view model but does NOT automatically start the journey.
     /// The journey will start when the user enters a journey name.
-    init() {
-        // Remove auto-start - let user enter journey name first
+    init(verificationUriComplete: URL? = nil) {
+        self.verificationUriComplete = verificationUriComplete
     }
 
     /// Starts the Journey orchestration process with a specific journey name.
@@ -148,11 +152,13 @@ class JourneyViewModel: ObservableObject {
         await MainActor.run {
             isLoading = true
         }
-        
+
         guard let journey = journey else { return }
+        let uri = verificationUriComplete
         let next = await journey.start(journeyName) { options in
             options.forceAuth = false
             options.noSession = false
+            options.verificationUriComplete = uri
         }
 
         await MainActor.run {

--- a/SampleApps/PingExample/PingExample/LogOutViewModel.swift
+++ b/SampleApps/PingExample/PingExample/LogOutViewModel.swift
@@ -49,6 +49,9 @@ class LogOutViewModel: ObservableObject {
            case .success = await ConfigurationManager.shared.oidcUser?.token() {
             sessions.append(SessionInfo(tab: .oidc, title: "OIDC (Web)", description: "Authenticated via OpenID Connect"))
         }
+        if await ConfigurationManager.shared.deviceUser != nil {
+            sessions.append(SessionInfo(tab: .device, title: "Device Flow", description: "Authenticated via RFC 8628 Device Flow"))
+        }
         
         activeSessions = sessions
         isLoading = false
@@ -63,15 +66,18 @@ class LogOutViewModel: ObservableObject {
             await ConfigurationManager.shared.davinciUser?.logout()
         case .oidc:
             await ConfigurationManager.shared.oidcUser?.logout()
+        case .device:
+            await ConfigurationManager.shared.deviceClient?.revoke()
         }
         activeSessions.removeAll { $0.tab == session.tab }
     }
-    
-    /// Logs out all active sessions across Journey, DaVinci, and OIDC.
+
+    /// Logs out all active sessions across Journey, DaVinci, OIDC, and Device Flow.
     func logoutAll() async {
         await ConfigurationManager.shared.journeyUser?.logout()
         await ConfigurationManager.shared.davinciUser?.logout()
         await ConfigurationManager.shared.oidcUser?.logout()
+        await ConfigurationManager.shared.deviceClient?.revoke()
         activeSessions.removeAll()
     }
 }

--- a/SampleApps/PingExample/PingExample/UserInfoViewModel.swift
+++ b/SampleApps/PingExample/PingExample/UserInfoViewModel.swift
@@ -19,14 +19,16 @@ enum AuthTab: String, CaseIterable, Identifiable {
     case journey = "Journey"
     case davinci = "DaVinci"
     case oidc = "OIDC (Web)"
-    
+    case device = "Device Flow"
+
     var id: String { rawValue }
-    
+
     var icon: String {
         switch self {
         case .journey: return "map.fill"
         case .davinci: return "key.fill"
         case .oidc: return "lock.shield.fill"
+        case .device: return "tv"
         }
     }
 }
@@ -46,7 +48,8 @@ class UserInfoViewModel: ObservableObject {
     @Published var results: [AuthTab: UserInfoResult] = [
         .journey: UserInfoResult(),
         .davinci: UserInfoResult(),
-        .oidc: UserInfoResult()
+        .oidc: UserInfoResult(),
+        .device: UserInfoResult()
     ]
     
     init() {
@@ -61,7 +64,8 @@ class UserInfoViewModel: ObservableObject {
             group.addTask { await (.journey, self.fetchUserInfo(for: .journey)) }
             group.addTask { await (.davinci, self.fetchUserInfo(for: .davinci)) }
             group.addTask { await (.oidc, self.fetchUserInfo(for: .oidc)) }
-            
+            group.addTask { await (.device, self.fetchUserInfo(for: .device)) }
+
             for await (tab, result) in group {
                 results[tab] = result
             }
@@ -77,8 +81,10 @@ class UserInfoViewModel: ObservableObject {
             user = await ConfigurationManager.shared.davinciUser
         case .oidc:
             user = await ConfigurationManager.shared.oidcUser
+        case .device:
+            user = await ConfigurationManager.shared.deviceUser
         }
-        
+
         guard let user = user else {
             return UserInfoResult(info: "", error: "No session, please start \(tab.rawValue) flow to authenticate.", isLoading: false)
         }


### PR DESCRIPTION
[SDKS-4785](https://pingidentity.atlassian.net/browse/SDKS-4785) [Ping SDKs] [iOS]: Update OIDC Module to Support Device Authorization Grant (RFC 8628)
[SDKS-5027](https://pingidentity.atlassian.net/browse/SDKS-5027) [iOS] Update Development Sample App to support Device Authorization Grant.


  - Add OidcDeviceClient with polling loop and DeviceAuthorizationResponse/DeviceFlowStatus models
  - Add OidcClientConfig and OpenIdConfiguration fields for device authorization endpoint
  - Add DaVinci+Device.swift entry point and update Davinci Oidc/Request modules
  - Update Journey Oidc module with device approval flow support
  - Add JourneyPlugin constants for device authorization
  - Add BrowserLauncher changes for device flow
  - Add DeviceFlowView and ApproveDeviceView UI with QR scanner to sample app
  - Update ConfigurationManager, ViewModels, and ContentView for device flow configuration
  - Add unit tests for OidcDeviceClient (core + additional) and DaVinci/Journey device flows
  - Update Oidc, Davinci, and Journey READMEs with device grant usage