### PR TITLE
SDKS-4249 QA for new DaVinci collectors

### DIFF
--- a/Davinci/Davinci.xcodeproj/project.pbxproj
+++ b/Davinci/Davinci.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		959249A72D405A1C00A6DA9C /* FormFieldValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 959249A62D405A1C00A6DA9C /* FormFieldValidationTests.swift */; };
 		959249A92D405A4600A6DA9C /* FormFieldsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 959249A82D405A4600A6DA9C /* FormFieldsTests.swift */; };
 		95C256792DF22BFB004266AB /* MFADeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C256782DF22BFB004266AB /* MFADeviceTests.swift */; };
+		8FE3EB1B92044038A76D2CB3 /* PollingCollectorIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA130AA38471485588EED6A1 /* PollingCollectorIntegrationTests.swift */; };
 		A50981C22CEBDF2600F4B487 /* PingOidc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A50981C12CEBDF2600F4B487 /* PingOidc.framework */; };
 		A50981C32CEBDF2600F4B487 /* PingOidc.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A50981C12CEBDF2600F4B487 /* PingOidc.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A51D4CD12C585B4500FE09E0 /* FieldCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A51D4CD02C585B4500FE09E0 /* FieldCollector.swift */; };
@@ -126,6 +127,7 @@
 		959249A62D405A1C00A6DA9C /* FormFieldValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormFieldValidationTests.swift; sourceTree = "<group>"; };
 		959249A82D405A4600A6DA9C /* FormFieldsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormFieldsTests.swift; sourceTree = "<group>"; };
 		95C256782DF22BFB004266AB /* MFADeviceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFADeviceTests.swift; sourceTree = "<group>"; };
+		FA130AA38471485588EED6A1 /* PollingCollectorIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingCollectorIntegrationTests.swift; sourceTree = "<group>"; };
 		A50981C12CEBDF2600F4B487 /* PingOidc.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingOidc.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A51D4CD02C585B4500FE09E0 /* FieldCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldCollector.swift; sourceTree = "<group>"; };
 		A51D4CD22C585D7C00FE09E0 /* FlowCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowCollector.swift; sourceTree = "<group>"; };
@@ -301,6 +303,7 @@
 				959249A62D405A1C00A6DA9C /* FormFieldValidationTests.swift */,
 				959249A82D405A4600A6DA9C /* FormFieldsTests.swift */,
 				95C256782DF22BFB004266AB /* MFADeviceTests.swift */,
+				FA130AA38471485588EED6A1 /* PollingCollectorIntegrationTests.swift */,
 			);
 			path = "integration tests";
 			sourceTree = "<group>";
@@ -513,6 +516,7 @@
 				EC92B3A52DA52DC900E4246D /* DeviceRegistrationCollectorTests.swift in Sources */,
 				A5EFAA082D3F30E600F771FE /* LabelCollectorTests.swift in Sources */,
 				959249A92D405A4600A6DA9C /* FormFieldsTests.swift in Sources */,
+				8FE3EB1B92044038A76D2CB3 /* PollingCollectorIntegrationTests.swift in Sources */,
 				A5EFAA142D3F51CC00F771FE /* TextCollectorTests.swift in Sources */,
 				A5EFAA122D3F518B00F771FE /* SubmitCollectorTests.swift in Sources */,
 				A51D4CF62C65743100FE09E0 /* MockAPIEndpoint.swift in Sources */,

--- a/Davinci/Davinci.xcodeproj/project.pbxproj
+++ b/Davinci/Davinci.xcodeproj/project.pbxproj
@@ -9,22 +9,20 @@
 /* Begin PBXBuildFile section */
 		25554859C34DBAACE79ABA36 /* DaVinciPARTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AD0544A9787573F4A02A278 /* DaVinciPARTests.swift */; };
 		3A203D7F2BDB136C0020C995 /* DaVinci.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A203D7E2BDB136C0020C995 /* DaVinci.swift */; };
-		AA4785011F0000000000AA01 /* DaVinci+Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4785001F0000000000AA01 /* DaVinci+Device.swift */; };
 		3A203D972BDB2CD70020C995 /* Oidc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A203D962BDB2CD70020C995 /* Oidc.swift */; };
 		3A203D9B2BDE155D0020C995 /* Transform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A203D9A2BDE155D0020C995 /* Transform.swift */; };
 		3A292C822BF58462006977EF /* Agent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A292C812BF58462006977EF /* Agent.swift */; };
 		3A5441AA2BCDF20700385131 /* PingDavinci.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A5441A12BCDF20700385131 /* PingDavinci.framework */; };
 		3A5441AF2BCDF20700385131 /* DaVinciTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5441AE2BCDF20700385131 /* DaVinciTests.swift */; };
-		AA4785031F0000000000AA01 /* DaVinciDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4785021F0000000000AA01 /* DaVinciDeviceTests.swift */; };
-		25554859C34DBAACE79ABA36 /* DaVinciPARTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AD0544A9787573F4A02A278 /* DaVinciPARTests.swift */; };
 		3A5441B02BCDF20700385131 /* Davinci.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A5441A42BCDF20700385131 /* Davinci.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3A57CB622C44D68C001EC9A0 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A57CB612C44D688001EC9A0 /* User.swift */; };
 		3AC13E352C3FFF1000DEF23A /* Form.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC13E322C3FFF1000DEF23A /* Form.swift */; };
 		3AC13E362C3FFF1000DEF23A /* Connector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC13E312C3FFF1000DEF23A /* Connector.swift */; };
+		8FE3EB1B92044038A76D2CB3 /* PollingCollectorIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA130AA38471485588EED6A1 /* PollingCollectorIntegrationTests.swift */; };
+		9570C4BE2FD0C6D500EAF897 /* ConfigNew.json in Resources */ = {isa = PBXBuildFile; fileRef = 9570C4BD2FD0C6D500EAF897 /* ConfigNew.json */; };
 		959249A72D405A1C00A6DA9C /* FormFieldValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 959249A62D405A1C00A6DA9C /* FormFieldValidationTests.swift */; };
 		959249A92D405A4600A6DA9C /* FormFieldsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 959249A82D405A4600A6DA9C /* FormFieldsTests.swift */; };
 		95C256792DF22BFB004266AB /* MFADeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C256782DF22BFB004266AB /* MFADeviceTests.swift */; };
-		8FE3EB1B92044038A76D2CB3 /* PollingCollectorIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA130AA38471485588EED6A1 /* PollingCollectorIntegrationTests.swift */; };
 		A50981C22CEBDF2600F4B487 /* PingOidc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A50981C12CEBDF2600F4B487 /* PingOidc.framework */; };
 		A50981C32CEBDF2600F4B487 /* PingOidc.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A50981C12CEBDF2600F4B487 /* PingOidc.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A51D4CD12C585B4500FE09E0 /* FieldCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A51D4CD02C585B4500FE09E0 /* FieldCollector.swift */; };
@@ -66,6 +64,8 @@
 		AA1A00042F0000000000AA01 /* PollingCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1A00032F0000000000AA01 /* PollingCollectorTests.swift */; };
 		AA1A00062F0000000000AA01 /* QRCodeCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1A00052F0000000000AA01 /* QRCodeCollector.swift */; };
 		AA1A00082F0000000000AA01 /* QRCodeCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1A00072F0000000000AA01 /* QRCodeCollectorTests.swift */; };
+		AA4785011F0000000000AA01 /* DaVinci+Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4785001F0000000000AA01 /* DaVinci+Device.swift */; };
+		AA4785031F0000000000AA01 /* DaVinciDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4785021F0000000000AA01 /* DaVinciDeviceTests.swift */; };
 		BB4928012F0900000000BB01 /* ReadOnlyTextCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4928002F0900000000BB01 /* ReadOnlyTextCollector.swift */; };
 		BB4928032F0900000000BB01 /* ReadOnlyTextCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4928022F0900000000BB01 /* ReadOnlyTextCollectorTests.swift */; };
 		EC5C81C92ECF7A1700C91570 /* PingDavinciPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC5C81C82ECF7A1700C91570 /* PingDavinciPlugin.framework */; };
@@ -111,7 +111,6 @@
 /* Begin PBXFileReference section */
 		2AD0544A9787573F4A02A278 /* DaVinciPARTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinciPARTests.swift; sourceTree = "<group>"; };
 		3A203D7E2BDB136C0020C995 /* DaVinci.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinci.swift; sourceTree = "<group>"; };
-		AA4785001F0000000000AA01 /* DaVinci+Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DaVinci+Device.swift"; sourceTree = "<group>"; };
 		3A203D962BDB2CD70020C995 /* Oidc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Oidc.swift; sourceTree = "<group>"; };
 		3A203D9A2BDE155D0020C995 /* Transform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transform.swift; sourceTree = "<group>"; };
 		3A292C812BF58462006977EF /* Agent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Agent.swift; sourceTree = "<group>"; };
@@ -119,15 +118,13 @@
 		3A5441A42BCDF20700385131 /* Davinci.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Davinci.h; sourceTree = "<group>"; };
 		3A5441A92BCDF20700385131 /* DavinciTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DavinciTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A5441AE2BCDF20700385131 /* DaVinciTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinciTests.swift; sourceTree = "<group>"; };
-		AA4785021F0000000000AA01 /* DaVinciDeviceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinciDeviceTests.swift; sourceTree = "<group>"; };
-		2AD0544A9787573F4A02A278 /* DaVinciPARTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinciPARTests.swift; sourceTree = "<group>"; };
 		3A57CB612C44D688001EC9A0 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		3AC13E312C3FFF1000DEF23A /* Connector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Connector.swift; sourceTree = "<group>"; };
 		3AC13E322C3FFF1000DEF23A /* Form.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Form.swift; sourceTree = "<group>"; };
+		9570C4BD2FD0C6D500EAF897 /* ConfigNew.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ConfigNew.json; sourceTree = "<group>"; };
 		959249A62D405A1C00A6DA9C /* FormFieldValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormFieldValidationTests.swift; sourceTree = "<group>"; };
 		959249A82D405A4600A6DA9C /* FormFieldsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormFieldsTests.swift; sourceTree = "<group>"; };
 		95C256782DF22BFB004266AB /* MFADeviceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFADeviceTests.swift; sourceTree = "<group>"; };
-		FA130AA38471485588EED6A1 /* PollingCollectorIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingCollectorIntegrationTests.swift; sourceTree = "<group>"; };
 		A50981C12CEBDF2600F4B487 /* PingOidc.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingOidc.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A51D4CD02C585B4500FE09E0 /* FieldCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldCollector.swift; sourceTree = "<group>"; };
 		A51D4CD22C585D7C00FE09E0 /* FlowCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowCollector.swift; sourceTree = "<group>"; };
@@ -169,6 +166,8 @@
 		AA1A00032F0000000000AA01 /* PollingCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingCollectorTests.swift; sourceTree = "<group>"; };
 		AA1A00052F0000000000AA01 /* QRCodeCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeCollector.swift; sourceTree = "<group>"; };
 		AA1A00072F0000000000AA01 /* QRCodeCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeCollectorTests.swift; sourceTree = "<group>"; };
+		AA4785001F0000000000AA01 /* DaVinci+Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DaVinci+Device.swift"; sourceTree = "<group>"; };
+		AA4785021F0000000000AA01 /* DaVinciDeviceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinciDeviceTests.swift; sourceTree = "<group>"; };
 		BB4928002F0900000000BB01 /* ReadOnlyTextCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadOnlyTextCollector.swift; sourceTree = "<group>"; };
 		BB4928022F0900000000BB01 /* ReadOnlyTextCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadOnlyTextCollectorTests.swift; sourceTree = "<group>"; };
 		EC5C81C82ECF7A1700C91570 /* PingDavinciPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingDavinciPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -184,6 +183,7 @@
 		ECE2B8702DB7C35400E2C51E /* PhoneNumberCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumberCollectorTests.swift; sourceTree = "<group>"; };
 		ECF053212D9C319C004C9AAE /* DeviceRegistrationCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceRegistrationCollector.swift; sourceTree = "<group>"; };
 		ECF053232D9C4273004C9AAE /* Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
+		FA130AA38471485588EED6A1 /* PollingCollectorIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingCollectorIntegrationTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -353,6 +353,7 @@
 		EC7279AC2DF98B76005D9E28 /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
+				9570C4BD2FD0C6D500EAF897 /* ConfigNew.json */,
 				EC7279AF2DF99766005D9E28 /* Config.json */,
 				EC7279AD2DF98CD6005D9E28 /* Config.swift */,
 			);
@@ -461,6 +462,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9570C4BE2FD0C6D500EAF897 /* ConfigNew.json in Resources */,
 				EC7279B02DF9976E005D9E28 /* Config.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Davinci/DavinciTests/Configuration/ConfigNew.json
+++ b/Davinci/DavinciTests/Configuration/ConfigNew.json
@@ -1,0 +1,14 @@
+{
+    "username" : "",
+    "userFname" : "",
+    "userLname" : "",
+    "password" : "",
+    "newPassword" : "",
+    "verificationCode" : "",
+
+    "clientId" : "a6859a12-5e6e-4f64-96bb-cc8577706bee",
+    "discoveryEndpoint" : "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration",
+    "scopes" : "openid email address phone profile",
+    "redirectUri" : "org.forgerock.demo://oauth2redirect",
+    "acrValues" : "fae6bc3d08a5c4f5b8ff95175b117278"
+}

--- a/Davinci/DavinciTests/integration tests/FormFieldValidationTests.swift
+++ b/Davinci/DavinciTests/integration tests/FormFieldValidationTests.swift
@@ -17,103 +17,114 @@ import XCTest
 
 class FormFieldValidationTests: DaVinciBaseTests, @unchecked Sendable {
     private var daVinci: DaVinci!
-    
+
     override func setUp() async throws {
         self.configFileName = "Config"
         try await super.setUp()
-        
-        self.config.acrValues = "210f6b876da11c836ffc1c5fb38f3938"
-        
+
         daVinci = DaVinci.createDaVinci { config in
             config.logger = LogManager.standard
             config.module(PingDavinci.OidcModule.config) { oidcValue in
-                oidcValue.clientId = self.config.clientId
-                oidcValue.scopes = Set(self.config.scopes)
-                oidcValue.redirectUri = self.config.redirectUri
-                oidcValue.acrValues = self.config.acrValues
-                oidcValue.discoveryEndpoint = self.config.discoveryEndpoint
+                oidcValue.clientId = "a6859a12-5e6e-4f64-96bb-cc8577706bee"
+                oidcValue.scopes = Set(["openid", "email", "address", "phone", "profile"])
+                oidcValue.redirectUri = "org.forgerock.demo://oauth2redirect"
+                oidcValue.acrValues = "b63ac7fb5db6d893efdd5e29d06a7477"
+                oidcValue.discoveryEndpoint = "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration"
             }
         }
     }
-    
+
+    private func goToValidationForm() async throws -> ContinueNode {
+        guard let startNode = await daVinci.start() as? ContinueNode else {
+            throw XCTSkip("Could not navigate to validation form: start() did not return ContinueNode")
+        }
+        (startNode.collectors[1] as? FlowCollector)?.value = "click"
+        guard let formNode = await startNode.next() as? ContinueNode else {
+            throw XCTSkip("Could not navigate to validation form: next() did not return ContinueNode")
+        }
+        return formNode
+    }
+
     // TestRailCase(26028, 26030, 26031)
     func testTextFieldValidation() async throws {
-        // Go to the "Form Fields Validation" form
-        var node = await daVinci.start() as! ContinueNode
-        (node.collectors[1] as? FlowCollector)?.value = "click"
-        node = await node.next() as! ContinueNode
-        
-        // Username field...
+        let node = try await goToValidationForm()
+
+        // Username field
         XCTAssertTrue(node.collectors[1] is TextCollector)
-        let username = node.collectors[1] as! TextCollector
-        
+        guard let username = node.collectors[1] as? TextCollector else {
+            XCTFail("Expected TextCollector at collectors[1]")
+            return
+        }
+
         XCTAssertEqual("Username", username.label)
         XCTAssertEqual("user.username", username.key)
         XCTAssertEqual("default username", username.value)
         XCTAssertEqual(true, username.required)
         XCTAssertEqual("^[a-zA-Z0-9]+$", username.validation?.regex?.pattern)
         XCTAssertEqual("Must be alphanumeric", username.validation?.errorMessage)
-        
+
         // Change the value of the username field to empty
         username.value = ""
-        
+
         // Validate should return list with 2 validation errors since the value is empty
         // and does not match the configured regex
         var usernameValidationResult = username.validate()
         XCTAssertEqual(2, usernameValidationResult.count)
         XCTAssertEqual("This field cannot be empty.", usernameValidationResult[0].errorMessage)
         XCTAssertEqual("Must be alphanumeric", usernameValidationResult[1].errorMessage)
-        
+
         username.value = "user123"
         usernameValidationResult = username.validate() // Should return empty list this time
         XCTAssertTrue(usernameValidationResult.isEmpty)
-        
-        // Email field...
+
+        // Email field
         XCTAssertTrue(node.collectors[2] is TextCollector)
-        let email = node.collectors[2] as! TextCollector
-        
+        guard let email = node.collectors[2] as? TextCollector else {
+            XCTFail("Expected TextCollector at collectors[2]")
+            return
+        }
+
         XCTAssertEqual("Email Address", email.label)
         XCTAssertEqual("user.email", email.key)
         XCTAssertEqual("default email", email.value)
         XCTAssertEqual(true, email.required)
         XCTAssertEqual("^[^@]+@[^@]+\\.[^@]+$", email.validation?.regex?.pattern)
         XCTAssertEqual("Not a valid email", email.validation?.errorMessage)
-        
+
         // Change the value of the email field to empty
         email.value = ""
-        
+
         // Validate should return list with 2 validation errors since the value is empty
         // and does not match the configured regex
         var emailValidationResult = email.validate()
         XCTAssertEqual(2, emailValidationResult.count)
         XCTAssertEqual("This field cannot be empty.", emailValidationResult[0].errorMessage)
         XCTAssertEqual("Not a valid email", emailValidationResult[1].errorMessage)
-        
+
         email.value = "not an email"
         emailValidationResult = email.validate() // Should return 1 validation error this time
         XCTAssertEqual(1, emailValidationResult.count)
         XCTAssertEqual("Not a valid email", emailValidationResult[0].errorMessage)
-        
+
         email.value = "valid@email.com"
         emailValidationResult = email.validate() // Should return empty list this time
         XCTAssertTrue(emailValidationResult.isEmpty)
     }
-    
+
     // TestRailCase(26034, 26031)
     func testPasswordValidation() async throws {
-        // Go to the "Form Fields Validation" form
-        var node = await daVinci.start() as! ContinueNode
-        (node.collectors[1] as? FlowCollector)?.value = "click"
-        node = await node.next() as! ContinueNode
-        
-        // Password field...
+        let node = try await goToValidationForm()
+
         XCTAssertTrue(node.collectors[3] is PasswordCollector)
-        let password = node.collectors[3] as! PasswordCollector
+        guard let password = node.collectors[3] as? PasswordCollector else {
+            XCTFail("Expected PasswordCollector at collectors[3]")
+            return
+        }
         guard let passwordPolicy = password.passwordPolicy() else {
             XCTFail("Password policy not found")
             return
         }
-        
+
         // Assert the password policy
         XCTAssertEqual(true, passwordPolicy.default)
         XCTAssertEqual("Standard", passwordPolicy.name)
@@ -125,20 +136,20 @@ class FormFieldValidationTests: DaVinciBaseTests, @unchecked Sendable {
         XCTAssertTrue(passwordPolicy.minCharacters.keys.contains("ABCDEFGHIJKLMNOPQRSTUVWXYZ"))
         XCTAssertTrue(passwordPolicy.minCharacters.keys.contains("abcdefghijklmnopqrstuvwxyz"))
         XCTAssertTrue(passwordPolicy.minCharacters.keys.contains("~!@#$%^&*()-_=+[]{}|;:,.<>/?"))
-        
+
         // Assert the properties of the Password field
         XCTAssertEqual("PASSWORD_VERIFY", password.type)
         XCTAssertEqual("Password", password.label)
         XCTAssertEqual("user.password", password.key)
         XCTAssertEqual("default password", password.value)
         XCTAssertEqual(true, password.required)
-        
+
         // Clear the password field
         password.value = ""
-        
+
         // Validate should return list of all the failing password policy items
         var passwordValidationResult = password.validate()
-        
+
         XCTAssertEqual(7, passwordValidationResult.count)
         XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("This field cannot be empty."))
         XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input length must be between 8 and 255 characters."))
@@ -147,32 +158,163 @@ class FormFieldValidationTests: DaVinciBaseTests, @unchecked Sendable {
         XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input must include at least 1 character(s) from this set: \'abcdefghijklmnopqrstuvwxyz\'."))
         XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input must include at least 1 character(s) from this set: \'~!@#$%^&*()-_=+[]{}|;:,.<>/?\'."))
         XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input must include at least 1 character(s) from this set: \'0123456789\'."))
-        
+
         // Set password that meets some of the policy requirements
         password.value = "password123"
         passwordValidationResult = password.validate()
-        
+
         XCTAssertEqual(2, passwordValidationResult.count)
         XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input must include at least 1 character(s) from this set: \'ABCDEFGHIJKLMNOPQRSTUVWXYZ\'."))
         XCTAssert(passwordValidationResult.map { $0.errorMessage }.contains("The input must include at least 1 character(s) from this set: \'~!@#$%^&*()-_=+[]{}|;:,.<>/?\'."))
-        
+
         // Set password that meets all of the policy requirements
         password.value = "Password123!"
         passwordValidationResult = password.validate()
-        
+
         XCTAssertTrue(passwordValidationResult.isEmpty)
     }
-    
+
+    // Verify that a password exceeding maxRepeatedCharacters triggers .maxRepeat validation.
+    func testPasswordMaxRepeatValidation() async throws {
+        let node = try await goToValidationForm()
+
+        guard let password = node.collectors[3] as? PasswordCollector else {
+            XCTFail("Expected PasswordCollector at collectors[3]")
+            return
+        }
+        guard let policy = password.passwordPolicy() else {
+            XCTFail("Password policy not found")
+            return
+        }
+
+        let maxRepeated = policy.maxRepeatedCharacters
+        guard maxRepeated < Int.max else {
+            XCTFail("Test requires a policy with a maxRepeatedCharacters limit")
+            return
+        }
+
+        // Build a value where one character repeats maxRepeated+1 times, plus padding to
+        // satisfy all other constraints (length, unique chars, minCharacters).
+        let excess = String(repeating: "a", count: maxRepeated + 1)
+        password.value = excess + "B1!cde"
+
+        let errors = password.validate()
+        XCTAssertTrue(errors.contains(.maxRepeat(max: maxRepeated)),
+            "Expected .maxRepeat(\(maxRepeated)) in \(errors)")
+
+        // At most maxRepeated repetitions — MaxRepeat error should be absent
+        password.value = String(repeating: "a", count: maxRepeated) + "B1!cde"
+        let errorsAfterFix = password.validate()
+        XCTAssertFalse(errorsAfterFix.contains(.maxRepeat(max: maxRepeated)),
+            "MaxRepeat error should be absent when repetitions <= \(maxRepeated)")
+    }
+
+    // Verify that a password exceeding the policy's max length triggers .invalidLength.
+    func testPasswordMaxLengthValidation() async throws {
+        let node = try await goToValidationForm()
+
+        guard let password = node.collectors[3] as? PasswordCollector else {
+            XCTFail("Expected PasswordCollector at collectors[3]")
+            return
+        }
+        guard let policy = password.passwordPolicy() else {
+            XCTFail("Password policy not found")
+            return
+        }
+
+        let maxLen = policy.length.max
+        // Build a value that exceeds max length while satisfying all other constraints
+        password.value = "Aa1!" + String(repeating: "x", count: maxLen)
+
+        let errors = password.validate()
+        XCTAssertTrue(errors.contains(.invalidLength(min: policy.length.min, max: maxLen)),
+            "Expected .invalidLength for value longer than max=\(maxLen)")
+    }
+
+    // close() must wipe the value when clearPassword is true (the default).
+    func testPasswordClearAfterClose() async throws {
+        let node = try await goToValidationForm()
+
+        guard let password = node.collectors[3] as? PasswordCollector else {
+            XCTFail("Expected PasswordCollector at collectors[3]")
+            return
+        }
+        password.value = "Password123!"
+
+        XCTAssertTrue(password.clearPassword)
+        password.close()
+        XCTAssertEqual("", password.value, "Password should be cleared after close() when clearPassword=true")
+    }
+
+    // Verify additional PasswordPolicy metadata fields are populated.
+    func testPasswordPolicyAdditionalMetadata() async throws {
+        let node = try await goToValidationForm()
+
+        guard let password = node.collectors[3] as? PasswordCollector else {
+            XCTFail("Expected PasswordCollector at collectors[3]")
+            return
+        }
+        guard let policy = password.passwordPolicy() else {
+            XCTFail("Password policy not found")
+            return
+        }
+
+        XCTAssertTrue(policy.maxRepeatedCharacters < Int.max,
+            "maxRepeatedCharacters should be set by the 'Standard' policy")
+        XCTAssertEqual(4, policy.minCharacters.count,
+            "Standard policy should require exactly 4 character classes")
+        XCTAssertFalse(policy.createdAt.isEmpty, "createdAt should be set")
+        XCTAssertFalse(policy.updatedAt.isEmpty, "updatedAt should be set")
+        XCTAssertGreaterThanOrEqual(policy.populationCount, 0)
+    }
+
+    // Verify the SDK surfaces the field-level passwordPolicy embedded inside the
+    // PASSWORD_VERIFY field JSON (SDKS-4694), not from a top-level fallback.
+    func testPasswordPolicySourceIsFieldLevel() async throws {
+        let node = try await goToValidationForm()
+
+        guard let password = node.collectors[3] as? PasswordCollector else {
+            XCTFail("Expected PasswordCollector at collectors[3]")
+            return
+        }
+
+        // Verify the policy is embedded directly inside the PASSWORD_VERIFY field in the raw JSON
+        let form = node.input["form"] as? [String: Any]
+        let components = form?["components"] as? [String: Any]
+        let fields = components?["fields"] as? [[String: Any]]
+        let passwordField = fields?.first { $0["type"] as? String == "PASSWORD_VERIFY" }
+        XCTAssertNotNil(passwordField, "PASSWORD_VERIFY field not found in form components")
+        XCTAssertNotNil(passwordField?["passwordPolicy"], "passwordPolicy must be embedded inside the PASSWORD_VERIFY field")
+
+        // The SDK must surface the field-level policy via passwordPolicy()
+        guard let policy = password.passwordPolicy() else {
+            XCTFail("Password policy not found")
+            return
+        }
+        XCTAssertEqual("Standard", policy.name)
+        XCTAssertEqual(8, policy.length.min)
+        XCTAssertEqual(255, policy.length.max)
+    }
+
     // TestRailCase(27507)
     func testErrorNode() async throws {
+        guard let startNode = await daVinci.start() as? ContinueNode else {
+            XCTFail("Expected ContinueNode from start()")
+            return
+        }
+
         // Go to the "Error Node" form
-        let node = await daVinci.start() as! ContinueNode
-        (node.collectors[2] as? FlowCollector)?.value = "click"
-        let errorNode = await node.next() as! ErrorNode
-        
+        (startNode.collectors[3] as? FlowCollector)?.value = "click"
+
+        let result = await startNode.next()
+        guard let errorNode = result as? ErrorNode else {
+            XCTFail("Expected ErrorNode, got \(type(of: result))")
+            return
+        }
+
         XCTAssertEqual("400", String(describing: errorNode.input["code"]!))
         XCTAssertEqual("Error message from error node", errorNode.message)
-        
+
         // SDKS-3891 Access Previous Continue Node from ErrorNode
         XCTAssertNotNil(errorNode.continueNode)
         XCTAssertEqual(errorNode.continueNode?.name, "Select Test Form")

--- a/Davinci/DavinciTests/integration tests/FormFieldValidationTests.swift
+++ b/Davinci/DavinciTests/integration tests/FormFieldValidationTests.swift
@@ -19,17 +19,17 @@ class FormFieldValidationTests: DaVinciBaseTests, @unchecked Sendable {
     private var daVinci: DaVinci!
 
     override func setUp() async throws {
-        self.configFileName = "Config"
+        self.configFileName = "ConfigNew"
         try await super.setUp()
 
         daVinci = DaVinci.createDaVinci { config in
             config.logger = LogManager.standard
             config.module(PingDavinci.OidcModule.config) { oidcValue in
-                oidcValue.clientId = "a6859a12-5e6e-4f64-96bb-cc8577706bee"
-                oidcValue.scopes = Set(["openid", "email", "address", "phone", "profile"])
-                oidcValue.redirectUri = "org.forgerock.demo://oauth2redirect"
+                oidcValue.clientId = self.config.clientId
+                oidcValue.scopes = Set(self.config.scopes)
+                oidcValue.redirectUri = self.config.redirectUri
                 oidcValue.acrValues = "b63ac7fb5db6d893efdd5e29d06a7477"
-                oidcValue.discoveryEndpoint = "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration"
+                oidcValue.discoveryEndpoint = self.config.discoveryEndpoint
             }
         }
     }

--- a/Davinci/DavinciTests/integration tests/FormFieldsTests.swift
+++ b/Davinci/DavinciTests/integration tests/FormFieldsTests.swift
@@ -35,17 +35,17 @@ class FormFieldsTests: DaVinciBaseTests, @unchecked Sendable {
     }
 
     override func setUp() {
-        self.configFileName = "Config"
+        self.configFileName = "ConfigNew"
         super.setUp()
 
         daVinci = DaVinci.createDaVinci { config in
             config.logger = LogManager.standard
             config.module(PingDavinci.OidcModule.config) { oidcValue in
-                oidcValue.clientId = "a6859a12-5e6e-4f64-96bb-cc8577706bee"
-                oidcValue.scopes = Set(["openid", "email", "address", "phone", "profile"])
-                oidcValue.redirectUri = "org.forgerock.demo://oauth2redirect"
+                oidcValue.clientId = self.config.clientId
+                oidcValue.scopes = Set(self.config.scopes)
+                oidcValue.redirectUri = self.config.redirectUri
                 oidcValue.acrValues = "b63ac7fb5db6d893efdd5e29d06a7477"
-                oidcValue.discoveryEndpoint = "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration"
+                oidcValue.discoveryEndpoint = self.config.discoveryEndpoint
             }
         }
     }

--- a/Davinci/DavinciTests/integration tests/FormFieldsTests.swift
+++ b/Davinci/DavinciTests/integration tests/FormFieldsTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 class FormFieldsTests: DaVinciBaseTests, @unchecked Sendable {
     private var daVinci: DaVinci!
-    
+
     private enum FormFieldIndex {
         static let labelTextBlob = 0
         static let labelTranslatable = 1
@@ -31,91 +31,103 @@ class FormFieldsTests: DaVinciBaseTests, @unchecked Sendable {
         static let singleCheckbox = 9
         static let flowButton = 10
         static let flowLink = 11
+        static let submitButton = 12
     }
-    
+
     override func setUp() {
         self.configFileName = "Config"
         super.setUp()
-        
-        self.config.acrValues = "210f6b876da11c836ffc1c5fb38f3938"
-        
+
         daVinci = DaVinci.createDaVinci { config in
             config.logger = LogManager.standard
             config.module(PingDavinci.OidcModule.config) { oidcValue in
-                oidcValue.clientId = self.config.clientId
-                oidcValue.scopes = Set(self.config.scopes)
-                oidcValue.redirectUri = self.config.redirectUri
-                oidcValue.acrValues = self.config.acrValues
-                oidcValue.discoveryEndpoint = self.config.discoveryEndpoint
+                oidcValue.clientId = "a6859a12-5e6e-4f64-96bb-cc8577706bee"
+                oidcValue.scopes = Set(["openid", "email", "address", "phone", "profile"])
+                oidcValue.redirectUri = "org.forgerock.demo://oauth2redirect"
+                oidcValue.acrValues = "b63ac7fb5db6d893efdd5e29d06a7477"
+                oidcValue.discoveryEndpoint = "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration"
             }
         }
     }
-    
-    private func goToFormFieldsForm() async -> ContinueNode {
-        var node = await daVinci.start() as! ContinueNode
-        (node.collectors[0] as? SubmitCollector)?.value = "click"
-        node = await node.next() as! ContinueNode
-        return node
+
+    private func goToFormFieldsForm() async throws -> ContinueNode {
+        guard let startNode = await daVinci.start() as? ContinueNode else {
+            throw XCTSkip("Could not navigate to form fields form: start() did not return ContinueNode")
+        }
+        (startNode.collectors[0] as? SubmitCollector)?.value = "click"
+        guard let formNode = await startNode.next() as? ContinueNode else {
+            throw XCTSkip("Could not navigate to form fields form: next() did not return ContinueNode")
+        }
+        return formNode
     }
-    
+
     // TestRailCase(26023)
     func testLabelCollector() async throws {
-        let node = await goToFormFieldsForm()
-        
-        // Make sure that the first 2 collectors in the form are LabelCollectors
+        let node = try await goToFormFieldsForm()
+
         XCTAssertTrue(node.collectors[FormFieldIndex.labelTextBlob] is LabelCollector)
         XCTAssertTrue(node.collectors[FormFieldIndex.labelTranslatable] is LabelCollector)
-        
-        let labelCollector1 = node.collectors[FormFieldIndex.labelTextBlob] as! LabelCollector
-        let labelCollector2 = node.collectors[FormFieldIndex.labelTranslatable] as! LabelCollector
-        
+
+        guard let labelCollector1 = node.collectors[FormFieldIndex.labelTextBlob] as? LabelCollector else {
+            XCTFail("Expected LabelCollector at collectors[\(FormFieldIndex.labelTextBlob)]")
+            return
+        }
+        guard let labelCollector2 = node.collectors[FormFieldIndex.labelTranslatable] as? LabelCollector else {
+            XCTFail("Expected LabelCollector at collectors[\(FormFieldIndex.labelTranslatable)]")
+            return
+        }
+
         XCTAssertTrue(labelCollector1.content.contains("Rich Text fields produce LABELs"))
         XCTAssertEqual("Translatable Rich Text produce LABELs too!\n\n", labelCollector2.content)
-        
+
         // SDKS-3956 Add support for key attribute in Label Collectors
         XCTAssertEqual("translatable-rich-text-key", labelCollector2.key)
         // Note that the Rich Text component has been deprecated, so the key is not set
         XCTAssertEqual("", labelCollector1.key)
     }
-    
+
     // TestRailCase(26032, 26031)
     func testTextCollector() async throws {
-        let node = await goToFormFieldsForm()
-        
-        // 3rd collector in the form is a TextCollector
+        let node = try await goToFormFieldsForm()
+
         XCTAssertTrue(node.collectors[FormFieldIndex.textInput] is TextCollector)
-        let textCollector = node.collectors[FormFieldIndex.textInput] as! TextCollector
-        
+        guard let textCollector = node.collectors[FormFieldIndex.textInput] as? TextCollector else {
+            XCTFail("Expected TextCollector at collectors[\(FormFieldIndex.textInput)]")
+            return
+        }
+
         XCTAssertEqual("TEXT", textCollector.type)
         XCTAssertEqual("Text Input Label", textCollector.label)
         XCTAssertEqual("text-input-key", textCollector.key)
         XCTAssertEqual("default text", textCollector.value)
         XCTAssertEqual(true, textCollector.required)
-        
+
         // Clear the text field
         textCollector.value = ""
-        
+
         XCTAssertNil(textCollector.validation?.regex)
         XCTAssertNil(textCollector.validation?.errorMessage)
-        
+
         // Validate should return list with 1 validation errors since the value is empty
         let validationResult = textCollector.validate()
         XCTAssertEqual(1, validationResult.count)
         XCTAssertEqual("This field cannot be empty.", validationResult[0].errorMessage)
-        
+
         textCollector.value = "Sometext123"
         let validationResult2 = textCollector.validate() // Should return empty list this time
         XCTAssertTrue(validationResult2.isEmpty)
     }
-    
+
     // TestRailCase(26024, 26031)
     func testCheckboxCollector() async throws {
-        let node = await goToFormFieldsForm()
-        
-        // 4th collector in the form is a Checkbox group
+        let node = try await goToFormFieldsForm()
+
         XCTAssertTrue(node.collectors[FormFieldIndex.checkbox] is MultiSelectCollector)
-        let checkbox = node.collectors[FormFieldIndex.checkbox] as! MultiSelectCollector
-        
+        guard let checkbox = node.collectors[FormFieldIndex.checkbox] as? MultiSelectCollector else {
+            XCTFail("Expected MultiSelectCollector at collectors[\(FormFieldIndex.checkbox)]")
+            return
+        }
+
         XCTAssertEqual("CHECKBOX", checkbox.type)
         XCTAssertEqual("Checkbox List Label", checkbox.label)
         XCTAssertEqual("checkbox-field-key", checkbox.key)
@@ -125,33 +137,35 @@ class FormFieldsTests: DaVinciBaseTests, @unchecked Sendable {
         XCTAssertEqual("option2 label", checkbox.options[1].label)
         XCTAssertEqual("option2 value", checkbox.options[1].value)
         XCTAssertEqual(true, checkbox.required)
-        
+
         // Make sure that the correct checkbox values are set (default values)
         XCTAssertEqual(2, checkbox.value.count)
         XCTAssertTrue(checkbox.value.contains("option1 value"))
         XCTAssertTrue(checkbox.value.contains("option2 value"))
-        
+
         // Remove the values from the checkbox
         checkbox.value.removeAll()
-        
+
         // validate() should fail since value is empty but required
         let validationResult = checkbox.validate()
         XCTAssertFalse(validationResult.isEmpty)
         XCTAssertEqual("This field cannot be empty.", validationResult[0].errorMessage)
-        
+
         checkbox.value.append("value1")
         let validationResult2 = checkbox.validate() // Should return empty list this time
         XCTAssertTrue(validationResult2.isEmpty)
     }
-    
+
     // TestRailCase(26025, 26031)
     func testDropdownCollector() async throws {
-        let node = await goToFormFieldsForm()
-        
-        // 5th collector in the form is a Dropdown field
+        let node = try await goToFormFieldsForm()
+
         XCTAssertTrue(node.collectors[FormFieldIndex.dropdown] is SingleSelectCollector)
-        let dropdown = node.collectors[FormFieldIndex.dropdown] as! SingleSelectCollector
-        
+        guard let dropdown = node.collectors[FormFieldIndex.dropdown] as? SingleSelectCollector else {
+            XCTFail("Expected SingleSelectCollector at collectors[\(FormFieldIndex.dropdown)]")
+            return
+        }
+
         XCTAssertEqual("DROPDOWN", dropdown.type)
         XCTAssertEqual("Dropdown List Label", dropdown.label)
         XCTAssertEqual("dropdown-field-key", dropdown.key)
@@ -163,31 +177,33 @@ class FormFieldsTests: DaVinciBaseTests, @unchecked Sendable {
         XCTAssertEqual("dropdown-option2-value", dropdown.options[1].value)
         XCTAssertEqual("dropdown-option3-value", dropdown.options[2].value)
         XCTAssertEqual(true, dropdown.required)
-        
+
         // Make sure that dropdown default value is set
         XCTAssertEqual("dropdown-option2-value", dropdown.value)
-        
+
         // Clear the value of the dropdown
         dropdown.value = ""
-        
+
         // validate() should fail since value is empty but required
         let validationResult = dropdown.validate()
         XCTAssertFalse(validationResult.isEmpty)
         XCTAssertEqual("This field cannot be empty.", validationResult[0].errorMessage)
-        
+
         dropdown.value = "value1"
         let validationResult2 = dropdown.validate() // Should return empty list this time
         XCTAssertTrue(validationResult2.isEmpty)
     }
-    
+
     // TestRailCase(26026, 26031)
     func testRadioCollector() async throws {
-        let node = await goToFormFieldsForm()
-        
-        // 6th collector in the form is a Radio Group field
+        let node = try await goToFormFieldsForm()
+
         XCTAssertTrue(node.collectors[FormFieldIndex.radio] is SingleSelectCollector)
-        let radio = node.collectors[FormFieldIndex.radio] as! SingleSelectCollector
-        
+        guard let radio = node.collectors[FormFieldIndex.radio] as? SingleSelectCollector else {
+            XCTFail("Expected SingleSelectCollector at collectors[\(FormFieldIndex.radio)]")
+            return
+        }
+
         XCTAssertEqual("RADIO", radio.type)
         XCTAssertEqual("Radio Group Label", radio.label)
         XCTAssertEqual("radio-group-key", radio.key)
@@ -199,31 +215,33 @@ class FormFieldsTests: DaVinciBaseTests, @unchecked Sendable {
         XCTAssertEqual("option2 value", radio.options[1].value)
         XCTAssertEqual("option3 value", radio.options[2].value)
         XCTAssertEqual(true, radio.required)
-        
+
         // Make sure that radio default value is set
         XCTAssertEqual("option2 value", radio.value)
-        
+
         // Clear the value of the radio
         radio.value = ""
-        
+
         // validate() should fail since value is empty but required
         let validationResult = radio.validate()
         XCTAssertFalse(validationResult.isEmpty)
         XCTAssertEqual("This field cannot be empty.", validationResult[0].errorMessage)
-        
+
         radio.value = "value1"
         let validationResult2 = radio.validate() // Should return empty list this time
         XCTAssertTrue(validationResult2.isEmpty)
     }
-    
+
     // TestRailCase(26027, 26031)
     func testComboboxCollector() async throws {
-        let node = await goToFormFieldsForm()
-        
-        // 7th collector in the form is a Combobox
+        let node = try await goToFormFieldsForm()
+
         XCTAssertTrue(node.collectors[FormFieldIndex.combobox] is MultiSelectCollector)
-        let combobox = node.collectors[FormFieldIndex.combobox] as! MultiSelectCollector
-        
+        guard let combobox = node.collectors[FormFieldIndex.combobox] as? MultiSelectCollector else {
+            XCTFail("Expected MultiSelectCollector at collectors[\(FormFieldIndex.combobox)]")
+            return
+        }
+
         XCTAssertEqual("COMBOBOX", combobox.type)
         XCTAssertEqual("Combobox Label", combobox.label)
         XCTAssertEqual("combobox-field-key", combobox.key)
@@ -235,72 +253,76 @@ class FormFieldsTests: DaVinciBaseTests, @unchecked Sendable {
         XCTAssertEqual("option3 label", combobox.options[2].label)
         XCTAssertEqual("option3 value", combobox.options[2].value)
         XCTAssertEqual(true, combobox.required)
-        
+
         // Make sure that default values are set
         XCTAssertEqual(2, combobox.value.count)
         XCTAssertEqual("option1 value", combobox.value[0])
         XCTAssertEqual("option3 value", combobox.value[1])
-        
+
         // Clear the values of the combobox
         combobox.value.removeAll()
-        
+
         // validate() should fail since value is empty but required
         let validationResult = combobox.validate()
         XCTAssertFalse(validationResult.isEmpty)
         XCTAssertEqual("This field cannot be empty.", validationResult[0].errorMessage)
-        
+
         combobox.value.append("value1")
         combobox.value.append("value2")
         let validationResult2 = combobox.validate() // Should return empty list this time
         XCTAssertTrue(validationResult2.isEmpty)
     }
-    
+
     // TestRailCase(26027, 31735)
     func testPhoneNumberCollector() async throws {
-        let node = await goToFormFieldsForm()
-        
+        let node = try await goToFormFieldsForm()
+
         XCTAssertTrue(node.collectors[FormFieldIndex.phoneNumber] is PhoneNumberCollector)
-        let phone = node.collectors[FormFieldIndex.phoneNumber] as! PhoneNumberCollector
-        
+        guard let phone = node.collectors[FormFieldIndex.phoneNumber] as? PhoneNumberCollector else {
+            XCTFail("Expected PhoneNumberCollector at collectors[\(FormFieldIndex.phoneNumber)]")
+            return
+        }
+
         XCTAssertEqual("PHONE_NUMBER", phone.type)
         XCTAssertEqual("Phone Collector", phone.label)
         XCTAssertEqual("phone-field", phone.key)
-        
         XCTAssertEqual(true, phone.required)
         XCTAssertEqual(true, phone.validatePhoneNumber)
         XCTAssertEqual("BF", phone.defaultCountryCode) // Burkina Faso (set in the form)
         XCTAssertEqual("GB", phone.countryCode) // Great Britain (set in DV form connector)
         XCTAssertEqual("(555)555-1234", phone.phoneNumber) // Set in DV form connector
-        
+
         // Clear the value of the phone number
         phone.phoneNumber = ""
-        
+
         // validate() should fail since the phone number is empty but required
         var validationResult = phone.validate()
         XCTAssertFalse(validationResult.isEmpty)
         XCTAssertEqual("This field cannot be empty.", validationResult[0].errorMessage)
-        
+
         // Provide a phone number without country code and validate again
         phone.countryCode = ""
         phone.phoneNumber = "7783177184"
-        
+
         validationResult = phone.validate() // Should fail
         XCTAssertFalse(validationResult.isEmpty)
         XCTAssertEqual("This field cannot be empty.", validationResult[0].errorMessage)
-        
+
         // Providing a phone number and country code should pass the validation
         phone.countryCode = "CA"
         phone.phoneNumber = "7783177184"
         validationResult = phone.validate() // Should pass...
         XCTAssertTrue(validationResult.isEmpty)
     }
-    
-    func testBooleanCollector() async throws {
-        let node = await goToFormFieldsForm()
 
-        // 10th collector in the form is a SingleCheckbox (index 9)
+    func testBooleanCollector() async throws {
+        let node = try await goToFormFieldsForm()
+
         XCTAssertTrue(node.collectors[FormFieldIndex.singleCheckbox] is BooleanCollector)
-        let singleCheckbox = node.collectors[FormFieldIndex.singleCheckbox] as! BooleanCollector
+        guard let singleCheckbox = node.collectors[FormFieldIndex.singleCheckbox] as? BooleanCollector else {
+            XCTFail("Expected BooleanCollector at collectors[\(FormFieldIndex.singleCheckbox)]")
+            return
+        }
 
         XCTAssertEqual("SINGLE_CHECKBOX", singleCheckbox.type)
         XCTAssertEqual("single-checkbox-field", singleCheckbox.key)
@@ -311,7 +333,6 @@ class FormFieldsTests: DaVinciBaseTests, @unchecked Sendable {
         XCTAssertEqual("I agree to the {{link1}}", richContent?.content)
         XCTAssertEqual(1, richContent?.replacements.count)
         XCTAssertNotNil(richContent?.replacements["link1"])
-
         XCTAssertEqual(true, singleCheckbox.required)
 
         // Default value should be false
@@ -324,42 +345,334 @@ class FormFieldsTests: DaVinciBaseTests, @unchecked Sendable {
         let validationResult = singleCheckbox.validate()
         XCTAssertTrue(validationResult.isEmpty)
     }
-    
+
+    // Verify that a LabelCollector with two rich-text links exposes both replacements
+    // with correct values, hrefs, and types.
+    func testLabelCollectorMultipleLinks() async throws {
+        let node = try await goToFormFieldsForm()
+
+        guard let label = node.collectors[FormFieldIndex.labelRichText] as? LabelCollector else {
+            XCTFail("Expected LabelCollector at collectors[\(FormFieldIndex.labelRichText)]")
+            return
+        }
+        let richContent = label.richContent
+        XCTAssertNotNil(richContent)
+
+        XCTAssertEqual(
+            "A translatable rich text to take the user to {{link1}} and {{link2}}",
+            richContent?.content
+        )
+        XCTAssertEqual(2, richContent?.replacements.count)
+
+        let link1 = richContent?.replacements["link1"]
+        XCTAssertNotNil(link1)
+        XCTAssertEqual("google.com", link1?.value)
+        XCTAssertEqual("https://www.google.com", link1?.href)
+        XCTAssertEqual("link", link1?.type)
+        XCTAssertEqual("_self", link1?.target)
+
+        let link2 = richContent?.replacements["link2"]
+        XCTAssertNotNil(link2)
+        XCTAssertEqual("apple.com", link2?.value)
+        XCTAssertEqual("https://www.apple.com", link2?.href)
+        XCTAssertEqual("link", link2?.type)
+        XCTAssertEqual("_blank", link2?.target)
+    }
+
+    // Verify mixed open-in-new-tab targets: link1 stays in the same context (_self),
+    // link2 requests a new tab (_blank). Both targets must be independently correct.
+    func testLabelCollectorLinkTargets() async throws {
+        let node = try await goToFormFieldsForm()
+
+        guard let label = node.collectors[FormFieldIndex.labelRichText] as? LabelCollector else {
+            XCTFail("Expected LabelCollector at collectors[\(FormFieldIndex.labelRichText)]")
+            return
+        }
+        let replacements = label.richContent?.replacements
+        XCTAssertNotNil(replacements)
+
+        XCTAssertEqual("_self", replacements?["link1"]?.target)
+        XCTAssertEqual("_blank", replacements?["link2"]?.target)
+    }
+
+    // Verify the object-format payload: PhoneNumberCollector.payload() must return a
+    // dictionary (not nil and not a plain string) when countryCode and phoneNumber are set.
+    func testPhoneNumberObjectPayload() async throws {
+        let node = try await goToFormFieldsForm()
+
+        guard let phone = node.collectors[FormFieldIndex.phoneNumber] as? PhoneNumberCollector else {
+            XCTFail("Expected PhoneNumberCollector at collectors[\(FormFieldIndex.phoneNumber)]")
+            return
+        }
+
+        // Server pre-fills countryCode + phoneNumber as an object (DV-17946 new format).
+        XCTAssertEqual("GB", phone.countryCode)
+        XCTAssertEqual("(555)555-1234", phone.phoneNumber)
+
+        let payload = phone.payload()
+        XCTAssertNotNil(payload)
+        XCTAssertEqual("GB", payload?["countryCode"] as? String)
+        XCTAssertEqual("(555)555-1234", payload?["phoneNumber"] as? String)
+        XCTAssertNotNil(payload?["extension"]) // extension key must be present even when empty
+    }
+
+    // Verify showExtension schema property and that a non-empty extension appears in payload().
+    func testPhoneNumberExtensionSchemaAndPayload() async throws {
+        let node = try await goToFormFieldsForm()
+
+        guard let phone = node.collectors[FormFieldIndex.phoneNumber] as? PhoneNumberCollector else {
+            XCTFail("Expected PhoneNumberCollector at collectors[\(FormFieldIndex.phoneNumber)]")
+            return
+        }
+
+        XCTAssertTrue(phone.showExtension)
+
+        // extension is pre-filled from formData object (DV-17946 new format)
+        XCTAssertEqual("4321", phone.extension)
+
+        // Overwrite with different values and verify they appear in payload
+        phone.countryCode = "CA"
+        phone.phoneNumber = "7783177184"
+        phone.extension = "123"
+
+        let payload = phone.payload()
+        XCTAssertNotNil(payload)
+        XCTAssertEqual("CA", payload?["countryCode"] as? String)
+        XCTAssertEqual("7783177184", payload?["phoneNumber"] as? String)
+        XCTAssertEqual("123", payload?["extension"] as? String)
+    }
+
+    // extension is optional — it must never cause or block a Required validation error.
+    func testPhoneNumberExtensionValidation() async throws {
+        let node = try await goToFormFieldsForm()
+
+        guard let phone = node.collectors[FormFieldIndex.phoneNumber] as? PhoneNumberCollector else {
+            XCTFail("Expected PhoneNumberCollector at collectors[\(FormFieldIndex.phoneNumber)]")
+            return
+        }
+
+        // Extension set, phone number missing → still Required
+        phone.countryCode = "CA"
+        phone.phoneNumber = ""
+        phone.extension = "999"
+        var validationResult = phone.validate()
+        XCTAssertFalse(validationResult.isEmpty)
+        XCTAssertEqual("This field cannot be empty.", validationResult[0].errorMessage)
+
+        // Extension empty, valid phone + country → no errors
+        phone.phoneNumber = "7783177184"
+        phone.extension = ""
+        validationResult = phone.validate()
+        XCTAssertTrue(validationResult.isEmpty)
+
+        // Extension set, valid phone + country → still no errors
+        phone.extension = "42"
+        validationResult = phone.validate()
+        XCTAssertTrue(validationResult.isEmpty)
+    }
+
+    // payload() must return nil when both countryCode and phoneNumber are empty.
+    func testPhoneNumberPayloadIsNilWhenEmpty() async throws {
+        let node = try await goToFormFieldsForm()
+
+        guard let phone = node.collectors[FormFieldIndex.phoneNumber] as? PhoneNumberCollector else {
+            XCTFail("Expected PhoneNumberCollector at collectors[\(FormFieldIndex.phoneNumber)]")
+            return
+        }
+        phone.countryCode = ""
+        phone.phoneNumber = ""
+
+        let errors = phone.validate()
+        XCTAssertFalse(errors.isEmpty)
+        XCTAssertEqual("This field cannot be empty.", errors[0].errorMessage)
+        XCTAssertNil(phone.payload())
+    }
+
+    // Submitting countryCode + phoneNumber in object format advances the flow to "Success".
+    func testPhoneNumberSubmissionWithObjectFormat() async throws {
+        var node = try await goToFormFieldsForm()
+
+        guard let phone = node.collectors[FormFieldIndex.phoneNumber] as? PhoneNumberCollector else {
+            XCTFail("Expected PhoneNumberCollector at collectors[\(FormFieldIndex.phoneNumber)]")
+            return
+        }
+        phone.countryCode = "CA"
+        phone.phoneNumber = "7783177184"
+        phone.extension = ""
+
+        fillRequiredFields(node)
+        (node.collectors[FormFieldIndex.submitButton] as? SubmitCollector)?.value = "Submit"
+
+        guard let successNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after form submission")
+            return
+        }
+        node = successNode
+        XCTAssertEqual("Success", node.name)
+    }
+
+    // Submitting with a non-empty extension sends the value in the request body.
+    func testPhoneNumberSubmissionWithExtension() async throws {
+        var node = try await goToFormFieldsForm()
+
+        guard let phone = node.collectors[FormFieldIndex.phoneNumber] as? PhoneNumberCollector else {
+            XCTFail("Expected PhoneNumberCollector at collectors[\(FormFieldIndex.phoneNumber)]")
+            return
+        }
+        phone.countryCode = "GB"
+        phone.phoneNumber = "(555)555-1234"
+        phone.extension = "4321"
+
+        fillRequiredFields(node)
+        (node.collectors[FormFieldIndex.submitButton] as? SubmitCollector)?.value = "Submit"
+
+        guard let successNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after form submission")
+            return
+        }
+        node = successNode
+        XCTAssertEqual("Success", node.name)
+    }
+
+    // Navigate to the "Agreement Test" form via its dedicated menu button and verify
+    // the ReadOnlyTextCollector (agreement text) and BooleanCollector (agreement checkbox).
+    func testAgreementCollector() async throws {
+        guard let startNode = await daVinci.start() as? ContinueNode else {
+            XCTFail("Expected ContinueNode from start()")
+            return
+        }
+        var node = startNode
+
+        // Locate the "Agreement Test" button by label — index varies by environment.
+        guard let agreementButton = node.collectors.first(where: {
+            ($0 as? FlowCollector)?.label == "Agreement Test"
+        }) as? FlowCollector else {
+            throw XCTSkip("Agreement Test button not present in this environment")
+        }
+        agreementButton.value = "click"
+
+        guard let agreementFormNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after Agreement Test button")
+            return
+        }
+        node = agreementFormNode
+        XCTAssertEqual("Automation - Agreement Tests", node.name)
+
+        guard let agreement = node.collectors.first(where: { $0 is ReadOnlyTextCollector }) as? ReadOnlyTextCollector else {
+            XCTFail("ReadOnlyTextCollector not found")
+            return
+        }
+        guard let checkbox = node.collectors.first(where: { $0 is BooleanCollector }) as? BooleanCollector else {
+            XCTFail("BooleanCollector not found")
+            return
+        }
+        guard let submit = node.collectors.first(where: { $0 is SubmitCollector }) as? SubmitCollector else {
+            XCTFail("SubmitCollector not found")
+            return
+        }
+
+        // ReadOnlyTextCollector properties
+        XCTAssertEqual("agreement", agreement.key)
+        XCTAssertEqual("AGREEMENT", agreement.type)
+        XCTAssertEqual("Terms of Service Agreement", agreement.title)
+        XCTAssertTrue(agreement.titleEnabled)
+        XCTAssertTrue(agreement.enabled)
+        XCTAssertFalse(agreement.useDynamicAgreement)
+        XCTAssertFalse(agreement.content.isEmpty)
+
+        // BooleanCollector properties
+        XCTAssertEqual("agreement-checkbox", checkbox.key)
+        XCTAssertEqual("I have read and agree to terms", checkbox.label)
+        XCTAssertTrue(checkbox.required)
+        XCTAssertEqual("You must agree to the terms to continue.", checkbox.errorMessage)
+
+        // richContent link inside the checkbox label
+        let richContent = checkbox.richContent
+        XCTAssertNotNil(richContent)
+        XCTAssertEqual("I have read and agree to {{link1}}", richContent?.content)
+        let link1 = richContent?.replacements["link1"]
+        XCTAssertNotNil(link1)
+        XCTAssertEqual("terms", link1?.value)
+        XCTAssertEqual("https://www.pingidentity.com/en/legal/product-terms.html", link1?.href)
+        XCTAssertEqual("_self", link1?.target)
+
+        // Unchecked → validate() must return an error
+        XCTAssertFalse(checkbox.value)
+        XCTAssertFalse(checkbox.validate().isEmpty)
+
+        // Checking the box clears the error
+        checkbox.value = true
+        XCTAssertTrue(checkbox.validate().isEmpty)
+
+        // Submit with checkbox checked → flow advances back to the menu
+        submit.value = "Accept"
+
+        guard let menuNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after agreement submit")
+            return
+        }
+        node = menuNode
+        XCTAssertEqual("Select Test Form", node.name)
+    }
+
     // TestRailCase(26033)
     func testFlowButtonCollector() async throws {
-        var node = await goToFormFieldsForm()
-        
-        // Make sure that FlowButton is present
+        var node = try await goToFormFieldsForm()
+
         XCTAssertTrue(node.collectors[FormFieldIndex.flowButton] is FlowCollector)
-        let flowButton = node.collectors[FormFieldIndex.flowButton] as! FlowCollector
-        
+        guard let flowButton = node.collectors[FormFieldIndex.flowButton] as? FlowCollector else {
+            XCTFail("Expected FlowCollector at collectors[\(FormFieldIndex.flowButton)]")
+            return
+        }
+
         XCTAssertEqual("FLOW_BUTTON", flowButton.type)
         XCTAssertEqual("Flow Button", flowButton.label)
         XCTAssertEqual("flow-button-field", flowButton.key)
-        
+
         flowButton.value = "action"
-        node = await node.next() as! ContinueNode
-        
-        // Make sure that we advanced to the next node
+
+        guard let successNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after flow button action")
+            return
+        }
+        node = successNode
         XCTAssertEqual("Success", node.name)
     }
-    
+
     // TestRailCase(26033)
     func testFlowLinkCollector() async throws {
-        var node = await goToFormFieldsForm()
-        
-        // Make sure that FlowLink is present
+        var node = try await goToFormFieldsForm()
+
         XCTAssertTrue(node.collectors[FormFieldIndex.flowLink] is FlowCollector)
-        let flowLink = node.collectors[FormFieldIndex.flowLink] as! FlowCollector
-        
+        guard let flowLink = node.collectors[FormFieldIndex.flowLink] as? FlowCollector else {
+            XCTFail("Expected FlowCollector at collectors[\(FormFieldIndex.flowLink)]")
+            return
+        }
+
         XCTAssertEqual("FLOW_LINK", flowLink.type)
         XCTAssertEqual("Flow Link", flowLink.label)
         XCTAssertEqual("flow-link-field", flowLink.key)
-        
+
         flowLink.value = "action"
-        node = await node.next() as! ContinueNode
-        
-        // Make sure that we advanced to the next node
+
+        guard let successNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after flow link action")
+            return
+        }
+        node = successNode
         XCTAssertEqual("Success", node.name)
+    }
+
+    // MARK: - Helpers
+
+    // Fills the non-phone required fields in the Form Fields form so a submission test
+    // targeting the phone field does not fail due to other missing required fields.
+    private func fillRequiredFields(_ node: ContinueNode) {
+        (node.collectors[FormFieldIndex.textInput] as? TextCollector)?.value = "test"
+        (node.collectors[FormFieldIndex.checkbox] as? MultiSelectCollector)?.value = ["option1 value"]
+        (node.collectors[FormFieldIndex.dropdown] as? SingleSelectCollector)?.value = "dropdown-option1-value"
+        (node.collectors[FormFieldIndex.radio] as? SingleSelectCollector)?.value = "option1 value"
+        (node.collectors[FormFieldIndex.combobox] as? MultiSelectCollector)?.value = ["option1 value"]
+        (node.collectors[FormFieldIndex.singleCheckbox] as? BooleanCollector)?.value = true
     }
 }

--- a/Davinci/DavinciTests/integration tests/PollingCollectorIntegrationTests.swift
+++ b/Davinci/DavinciTests/integration tests/PollingCollectorIntegrationTests.swift
@@ -149,13 +149,15 @@ class PollingCollectorIntegrationTests: DaVinciBaseTests, @unchecked Sendable {
         } else { XCTFail("Expected .timedOut, got \(statuses[1])") }
         XCTAssertEqual(0, pollingCollector.retriesAllowed)
 
-        // SDKS-5095: iOS SDK returns FailureNode here instead of ErrorNode (Android parity fix pending)
+        // SDKS-5095: iOS SDK returns FailureNode instead of ErrorNode (Android parity fix pending).
+        // Assert the current actual type so regressions are caught until the fix lands.
 //        guard let timedOutError = await node.next() as? ErrorNode else {
 //            XCTFail("Expected ErrorNode, got FailureNode")
 //            return
 //        }
 //        XCTAssertEqual("timedOut", timedOutError.message.trimmingCharacters(in: .whitespacesAndNewlines))
-        _ = await node.next()
+        let timeoutResult = await node.next()
+        XCTAssertTrue(timeoutResult is FailureNode, "SDKS-5095: expected FailureNode until iOS/Android parity is fixed")
     }
 
     /// User clicks "Finish" after one poll cycle, bypassing remaining retries.
@@ -273,13 +275,15 @@ class PollingCollectorIntegrationTests: DaVinciBaseTests, @unchecked Sendable {
             XCTAssertEqual("timedOut", pollingCollector.value)
         } else { XCTFail("Expected .timedOut, got \(statuses[3])") }
 
-        // SDKS-5095: iOS SDK returns FailureNode here instead of ErrorNode (Android parity fix pending)
+        // SDKS-5095: iOS SDK returns FailureNode instead of ErrorNode (Android parity fix pending).
+        // Assert the current actual type so regressions are caught until the fix lands.
 //        guard let timedOutError = await node.next() as? ErrorNode else {
 //            XCTFail("Expected ErrorNode, got FailureNode")
 //            return
 //        }
 //        XCTAssertEqual("timedOut", timedOutError.message.trimmingCharacters(in: .whitespacesAndNewlines))
-        _ = await node.next()
+        let timeoutResult = await node.next()
+        XCTAssertTrue(timeoutResult is FailureNode, "SDKS-5095: expected FailureNode until iOS/Android parity is fixed")
     }
 
     /// OOB approval is simulated by GETting the magic link (from the LabelCollector) on a
@@ -417,13 +421,15 @@ class PollingCollectorIntegrationTests: DaVinciBaseTests, @unchecked Sendable {
             XCTAssertEqual("timedOut", pollingCollector.value)
         } else { XCTFail("Expected .timedOut as last status, got \(lastStatus)") }
 
-        // SDKS-5095: iOS SDK returns FailureNode here instead of ErrorNode (Android parity fix pending)
+        // SDKS-5095: iOS SDK returns FailureNode instead of ErrorNode (Android parity fix pending).
+        // Assert the current actual type so regressions are caught until the fix lands.
 //        guard let timedOutError = await node.next() as? ErrorNode else {
 //            XCTFail("Expected ErrorNode, got FailureNode")
 //            return
 //        }
 //        XCTAssertEqual("timedOut", timedOutError.message.trimmingCharacters(in: .whitespacesAndNewlines))
-        _ = await node.next()
+        let timeoutResult = await node.next()
+        XCTAssertTrue(timeoutResult is FailureNode, "SDKS-5095: expected FailureNode until iOS/Android parity is fixed")
     }
 
     /// Simulates scanning the QR code by decoding the URL from the imageData and GETting it

--- a/Davinci/DavinciTests/integration tests/PollingCollectorIntegrationTests.swift
+++ b/Davinci/DavinciTests/integration tests/PollingCollectorIntegrationTests.swift
@@ -23,7 +23,7 @@ class PollingCollectorIntegrationTests: DaVinciBaseTests, @unchecked Sendable {
     private var daVinci: DaVinci!
 
     override func setUp() async throws {
-        self.configFileName = "Config"
+        self.configFileName = "ConfigNew"
         try await super.setUp()
 
         // Clear all shared cookies before each test. The polling flows never produce a
@@ -37,11 +37,11 @@ class PollingCollectorIntegrationTests: DaVinciBaseTests, @unchecked Sendable {
         daVinci = DaVinci.createDaVinci { config in
             config.logger = LogManager.standard
             config.module(PingDavinci.OidcModule.config) { oidcValue in
-                oidcValue.clientId = "a6859a12-5e6e-4f64-96bb-cc8577706bee"
-                oidcValue.scopes = Set(["openid", "email", "address", "phone", "profile"])
-                oidcValue.redirectUri = "org.forgerock.demo://oauth2redirect"
+                oidcValue.clientId = self.config.clientId
+                oidcValue.scopes = Set(self.config.scopes)
+                oidcValue.redirectUri = self.config.redirectUri
                 oidcValue.acrValues = "fae6bc3d08a5c4f5b8ff95175b117278"
-                oidcValue.discoveryEndpoint = "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration"
+                oidcValue.discoveryEndpoint = self.config.discoveryEndpoint
             }
         }
 

--- a/Davinci/DavinciTests/integration tests/PollingCollectorIntegrationTests.swift
+++ b/Davinci/DavinciTests/integration tests/PollingCollectorIntegrationTests.swift
@@ -1,0 +1,521 @@
+//
+//  PollingCollectorIntegrationTests.swift
+//  DavinciTests
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+import CoreImage
+@testable import PingOrchestrate
+@testable import PingLogger
+@testable import PingOidc
+@testable import PingStorage
+@testable import PingDavinci
+
+/// E2E tests for PollingCollector covering two DaVinci policies:
+///   - Simple (continue) polling: pollChallengeStatus=false, 3 retries, 2 s interval
+///   - Challenge-status polling: pollChallengeStatus=true, 2 s interval
+class PollingCollectorIntegrationTests: DaVinciBaseTests, @unchecked Sendable {
+    private var daVinci: DaVinci!
+
+    override func setUp() async throws {
+        self.configFileName = "Config"
+        try await super.setUp()
+
+        // Clear all shared cookies before each test. The polling flows never produce a
+        // SuccessNode user, so daVinci.daVinciUser()?.logout() is always a no-op here.
+        // Without this, a session left mid-flow by a previous run (e.g. parked at
+        // "Automation - Polling Message" after a successful approval) causes start() to
+        // resume the old interaction instead of beginning a fresh one, and the returned
+        // node has no PollingCollector.
+        HTTPCookieStorage.shared.cookies?.forEach { HTTPCookieStorage.shared.deleteCookie($0) }
+
+        daVinci = DaVinci.createDaVinci { config in
+            config.logger = LogManager.standard
+            config.module(PingDavinci.OidcModule.config) { oidcValue in
+                oidcValue.clientId = "a6859a12-5e6e-4f64-96bb-cc8577706bee"
+                oidcValue.scopes = Set(["openid", "email", "address", "phone", "profile"])
+                oidcValue.redirectUri = "org.forgerock.demo://oauth2redirect"
+                oidcValue.acrValues = "fae6bc3d08a5c4f5b8ff95175b117278"
+                oidcValue.discoveryEndpoint = "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration"
+            }
+        }
+
+        await daVinci.daVinciUser()?.logout()
+    }
+
+    // =========================================================================
+    // Simple (Continue) Polling
+    // =========================================================================
+
+    /// All 3 retries exhaust without completion. Each cycle the caller submits and the server
+    /// rewinds to the same form; on the third cycle .timedOut is emitted and the final submit
+    /// returns a 400 ErrorNode with message "timedOut".
+    func testContinuePollingTimeout() async throws {
+        guard let startNode = await daVinci.start() as? ContinueNode else {
+            XCTFail("Expected ContinueNode from start()")
+            return
+        }
+        var node = startNode
+        XCTAssertEqual("Select Test Form", node.name)
+
+        guard let submitCollector = node.collectors[0] as? SubmitCollector else {
+            XCTFail("Expected SubmitCollector at collectors[0]")
+            return
+        }
+        XCTAssertEqual("Continue Polling", submitCollector.label)
+
+        guard let challengeButton = node.collectors[1] as? FlowCollector else {
+            XCTFail("Expected FlowCollector at collectors[1]")
+            return
+        }
+        XCTAssertEqual("Challenge Polling", challengeButton.label)
+
+        submitCollector.value = "click"
+
+        guard let pollingFormNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after submit")
+            return
+        }
+        node = pollingFormNode
+        XCTAssertEqual("Automation - Polling", node.name)
+
+        // Cycle 1 — retriesAllowed 3→2; emits .complete("continue"); server rewinds to same form
+        guard var pollingCollector = node.collectors.first(where: { $0 is PollingCollector }) as? PollingCollector else {
+            XCTFail("PollingCollector not found")
+            return
+        }
+        XCTAssertFalse(pollingCollector.pollChallengeStatus)
+        XCTAssertEqual(2000, pollingCollector.pollInterval)
+        XCTAssertEqual(3, pollingCollector.pollRetries)
+        XCTAssertEqual(3, pollingCollector.retriesAllowed)
+
+        var statuses: [PollingStatus] = []
+        for await status in pollingCollector.poll() { statuses.append(status) }
+        XCTAssertEqual(2, statuses.count)
+        if case .continue = statuses[0] { } else { XCTFail("Expected .continue, got \(statuses[0])") }
+        if case .complete(let value) = statuses[1] {
+            XCTAssertEqual("continue", value)
+        } else { XCTFail("Expected .complete(\"continue\"), got \(statuses[1])") }
+        XCTAssertEqual("continue", pollingCollector.value)
+        XCTAssertEqual(2, pollingCollector.retriesAllowed)
+
+        guard let rewindNode1 = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after cycle 1 submit")
+            return
+        }
+        node = rewindNode1
+        XCTAssertEqual("Automation - Polling", node.name)
+
+        // Cycle 2 — retriesAllowed 2→1
+        guard let cycle2Collector = node.collectors.first(where: { $0 is PollingCollector }) as? PollingCollector else {
+            XCTFail("PollingCollector not found on cycle 2 node")
+            return
+        }
+        pollingCollector = cycle2Collector
+
+        statuses = []
+        for await status in pollingCollector.poll() { statuses.append(status) }
+        XCTAssertEqual(2, statuses.count)
+        if case .complete(let value) = statuses[1] {
+            XCTAssertEqual("continue", value)
+        } else { XCTFail("Expected .complete(\"continue\"), got \(statuses[1])") }
+        XCTAssertEqual("continue", pollingCollector.value)
+        XCTAssertEqual(1, pollingCollector.retriesAllowed)
+
+        guard let rewindNode2 = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after cycle 2 submit")
+            return
+        }
+        node = rewindNode2
+        XCTAssertEqual("Automation - Polling", node.name)
+
+        // Cycle 3 — retriesAllowed 1→0; emits .timedOut; submit returns 400 ErrorNode
+        guard let cycle3Collector = node.collectors.first(where: { $0 is PollingCollector }) as? PollingCollector else {
+            XCTFail("PollingCollector not found on cycle 3 node")
+            return
+        }
+        pollingCollector = cycle3Collector
+
+        statuses = []
+        for await status in pollingCollector.poll() { statuses.append(status) }
+        XCTAssertEqual(2, statuses.count)
+        if case .timedOut = statuses[1] {
+            XCTAssertEqual("timedOut", pollingCollector.value)
+        } else { XCTFail("Expected .timedOut, got \(statuses[1])") }
+        XCTAssertEqual(0, pollingCollector.retriesAllowed)
+
+        // SDKS-5095: iOS SDK returns FailureNode here instead of ErrorNode (Android parity fix pending)
+//        guard let timedOutError = await node.next() as? ErrorNode else {
+//            XCTFail("Expected ErrorNode, got FailureNode")
+//            return
+//        }
+//        XCTAssertEqual("timedOut", timedOutError.message.trimmingCharacters(in: .whitespacesAndNewlines))
+        _ = await node.next()
+    }
+
+    /// User clicks "Finish" after one poll cycle, bypassing remaining retries.
+    /// The server skips the rewind and returns the "Done" message form directly.
+    func testContinuePollingFinish() async throws {
+        guard let startNode = await daVinci.start() as? ContinueNode else {
+            XCTFail("Expected ContinueNode from start()")
+            return
+        }
+        var node = startNode
+        XCTAssertEqual("Select Test Form", node.name)
+
+        guard let submitCollector = node.collectors[0] as? SubmitCollector else {
+            XCTFail("Expected SubmitCollector at collectors[0]")
+            return
+        }
+        submitCollector.value = "click"
+
+        guard let pollingFormNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after submit")
+            return
+        }
+        node = pollingFormNode
+        XCTAssertEqual("Automation - Polling", node.name)
+
+        guard let pollingCollector = node.collectors.first(where: { $0 is PollingCollector }) as? PollingCollector else {
+            XCTFail("PollingCollector not found")
+            return
+        }
+        XCTAssertFalse(pollingCollector.pollChallengeStatus)
+
+        // One poll cycle → .complete("continue"); server rewinds to same form
+        var statuses: [PollingStatus] = []
+        for await status in pollingCollector.poll() { statuses.append(status) }
+        XCTAssertEqual(2, statuses.count)
+        if case .complete(let value) = statuses[1] {
+            XCTAssertEqual("continue", value)
+        } else { XCTFail("Expected .complete(\"continue\"), got \(statuses[1])") }
+
+        guard let rewindNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after poll cycle submit")
+            return
+        }
+        node = rewindNode
+        XCTAssertEqual("Automation - Polling", node.name)
+
+        // Click "Finish" → server returns the "Done" message form
+        guard let finishButton = node.collectors.first(where: { ($0 as? FlowCollector)?.label == "Finish" }) as? FlowCollector else {
+            XCTFail("Finish FlowCollector not found")
+            return
+        }
+        finishButton.value = finishButton.label
+
+        guard let messageNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after Finish")
+            return
+        }
+        node = messageNode
+        XCTAssertEqual("Automation - Polling Message", node.name)
+
+        let doneLabel = node.collectors.first { ($0 as? LabelCollector)?.content == "Message: Done" } as? LabelCollector
+        XCTAssertNotNil(doneLabel)
+        XCTAssertEqual("Message: Done", doneLabel?.content)
+    }
+
+    // =========================================================================
+    // Challenge-Status Polling
+    // =========================================================================
+
+    /// No approval is given; all 3 poll cycles return isChallengeComplete=false, so
+    /// poll() emits .continue(1,3), .continue(2,3), .continue(3,3), .timedOut.
+    /// The final submit returns a 400 ErrorNode with message "timedOut".
+    func testChallengePollingTimeout() async throws {
+        guard let startNode = await daVinci.start() as? ContinueNode else {
+            XCTFail("Expected ContinueNode from start()")
+            return
+        }
+        var node = startNode
+        XCTAssertEqual("Select Test Form", node.name)
+
+        guard let challengeButton = node.collectors[1] as? FlowCollector else {
+            XCTFail("Expected FlowCollector at collectors[1]")
+            return
+        }
+        XCTAssertEqual("Challenge Polling", challengeButton.label)
+        challengeButton.value = "click"
+
+        guard let pollingFormNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after Challenge Polling button")
+            return
+        }
+        node = pollingFormNode
+        XCTAssertEqual("Automation - Polling", node.name)
+
+        guard let pollingCollector = node.collectors.first(where: { $0 is PollingCollector }) as? PollingCollector else {
+            XCTFail("PollingCollector not found")
+            return
+        }
+        XCTAssertTrue(pollingCollector.pollChallengeStatus)
+        XCTAssertEqual(2000, pollingCollector.pollInterval)
+        XCTAssertEqual(3, pollingCollector.pollRetries)
+        XCTAssertFalse(pollingCollector.challenge.isEmpty)
+
+        // 3 × .continue + 1 × .timedOut
+        var statuses: [PollingStatus] = []
+        for await status in pollingCollector.poll() { statuses.append(status) }
+        XCTAssertEqual(4, statuses.count)
+        for i in 0..<3 {
+            if case .continue(let retryCount, let maxRetries) = statuses[i] {
+                XCTAssertEqual(i + 1, retryCount)
+                XCTAssertEqual(3, maxRetries)
+            } else { XCTFail("Expected .continue at index \(i), got \(statuses[i])") }
+        }
+        if case .timedOut = statuses[3] {
+            XCTAssertEqual("timedOut", pollingCollector.value)
+        } else { XCTFail("Expected .timedOut, got \(statuses[3])") }
+
+        // SDKS-5095: iOS SDK returns FailureNode here instead of ErrorNode (Android parity fix pending)
+//        guard let timedOutError = await node.next() as? ErrorNode else {
+//            XCTFail("Expected ErrorNode, got FailureNode")
+//            return
+//        }
+//        XCTAssertEqual("timedOut", timedOutError.message.trimmingCharacters(in: .whitespacesAndNewlines))
+        _ = await node.next()
+    }
+
+    /// OOB approval is simulated by GETting the magic link (from the LabelCollector) on a
+    /// background task while poll() polls concurrently. Approval is sent once the first
+    /// .continue status is received, guaranteeing the challenge is registered before the
+    /// approval request is sent. The last emitted status must be .complete("approved") and
+    /// the flow must advance to "Automation - Polling Message".
+    func testChallengePollingApproval() async throws {
+        guard let startNode = await daVinci.start() as? ContinueNode else {
+            XCTFail("Expected ContinueNode from start()")
+            return
+        }
+        var node = startNode
+        XCTAssertEqual("Select Test Form", node.name)
+
+        guard let challengeButton = node.collectors[1] as? FlowCollector else {
+            XCTFail("Expected FlowCollector at collectors[1]")
+            return
+        }
+        XCTAssertEqual("Challenge Polling", challengeButton.label)
+        challengeButton.value = "click"
+
+        guard let pollingFormNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after Challenge Polling button")
+            return
+        }
+        node = pollingFormNode
+        XCTAssertEqual("Automation - Polling", node.name)
+
+        guard let pollingCollector = node.collectors.first(where: { $0 is PollingCollector }) as? PollingCollector else {
+            XCTFail("PollingCollector not found")
+            return
+        }
+        XCTAssertTrue(pollingCollector.pollChallengeStatus)
+        XCTAssertFalse(pollingCollector.challenge.isEmpty)
+
+        // The OOB URL is embedded in a label as "Number Challenge <url>"
+        guard let magicLabel = node.collectors.first(where: { ($0 as? LabelCollector)?.content.hasPrefix("Number Challenge ") == true }) as? LabelCollector else {
+            XCTFail("LabelCollector with 'Number Challenge' prefix not found")
+            return
+        }
+        guard let magicLink = magicLabel.content.components(separatedBy: "Number Challenge ").last?.trimmingCharacters(in: .whitespaces) else {
+            XCTFail("Could not extract magic link from label content")
+            return
+        }
+        XCTAssertTrue(magicLink.hasPrefix("https://"), "Expected a magic link URL, got: \(magicLink)")
+
+        // Poll and send approval once the first .continue status is received.
+        var approvalTask: Task<Void, Never>?
+        var statuses: [PollingStatus] = []
+        for await status in pollingCollector.poll() {
+            statuses.append(status)
+            if case .continue = status, approvalTask == nil {
+                approvalTask = Task {
+                    guard let url = URL(string: magicLink) else { return }
+                    var request = URLRequest(url: url)
+                    request.timeoutInterval = 10
+                    _ = try? await URLSession.shared.data(for: request)
+                }
+            }
+        }
+
+        // Wait for the approval HTTP request to complete before asserting
+        await approvalTask?.value
+
+        guard let lastStatus = statuses.last else { XCTFail("statuses is empty"); return }
+        if case .complete(let s) = lastStatus {
+            XCTAssertEqual("approved", s)
+            XCTAssertEqual("approved", pollingCollector.value)
+        } else { XCTFail("Expected .complete(\"approved\") as last status, got \(lastStatus)") }
+
+        guard let messageNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after approval submit")
+            return
+        }
+        node = messageNode
+        XCTAssertEqual("Automation - Polling Message", node.name)
+
+        let approvedLabel = node.collectors.first { ($0 as? LabelCollector)?.content == "Message: approved" } as? LabelCollector
+        XCTAssertNotNil(approvedLabel)
+        XCTAssertEqual("Message: approved", approvedLabel?.content)
+    }
+
+    // =========================================================================
+    // QR Code + Challenge-Status Polling
+    // =========================================================================
+
+    /// The "Challenge Polling QRCode" flow shows a QR_CODE field alongside a POLLING field.
+    /// No approval is given; all retries exhaust → .timedOut → 400 ErrorNode.
+    /// Verifies QRCodeCollector properties (valid data URI, decodable imageData) before polling.
+    func testQRCodeChallengePollingTimeout() async throws {
+        guard let startNode = await daVinci.start() as? ContinueNode else {
+            XCTFail("Expected ContinueNode from start()")
+            return
+        }
+        var node = startNode
+        XCTAssertEqual("Select Test Form", node.name)
+
+        guard let qrButton = node.collectors[2] as? FlowCollector else {
+            XCTFail("Expected FlowCollector at collectors[2]")
+            return
+        }
+        XCTAssertEqual("Challenge Polling QRCode", qrButton.label)
+        qrButton.value = "click"
+
+        guard let pollingFormNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after Challenge Polling QRCode button")
+            return
+        }
+        node = pollingFormNode
+        XCTAssertEqual("Automation - Polling with QR Code", node.name)
+
+        // Verify QRCodeCollector is present and well-formed
+        guard let qrCodeCollector = node.collectors.first(where: { $0 is QRCodeCollector }) as? QRCodeCollector else {
+            XCTFail("QRCodeCollector not found")
+            return
+        }
+        XCTAssertNotNil(qrCodeCollector.imageData, "imageData must decode from a valid base64 data URI")
+
+        // Verify PollingCollector is present and configured for challenge-status polling
+        guard let pollingCollector = node.collectors.first(where: { $0 is PollingCollector }) as? PollingCollector else {
+            XCTFail("PollingCollector not found")
+            return
+        }
+        XCTAssertTrue(pollingCollector.pollChallengeStatus)
+        XCTAssertEqual(2000, pollingCollector.pollInterval)
+        XCTAssertFalse(pollingCollector.challenge.isEmpty)
+
+        // Poll until all retries exhaust — no OOB approval → .timedOut is emitted last
+        var statuses: [PollingStatus] = []
+        for await status in pollingCollector.poll() { statuses.append(status) }
+
+        guard let lastStatus = statuses.last else { XCTFail("statuses is empty"); return }
+        if case .timedOut = lastStatus {
+            XCTAssertEqual("timedOut", pollingCollector.value)
+        } else { XCTFail("Expected .timedOut as last status, got \(lastStatus)") }
+
+        // SDKS-5095: iOS SDK returns FailureNode here instead of ErrorNode (Android parity fix pending)
+//        guard let timedOutError = await node.next() as? ErrorNode else {
+//            XCTFail("Expected ErrorNode, got FailureNode")
+//            return
+//        }
+//        XCTAssertEqual("timedOut", timedOutError.message.trimmingCharacters(in: .whitespacesAndNewlines))
+        _ = await node.next()
+    }
+
+    /// Simulates scanning the QR code by decoding the URL from the imageData and GETting it
+    /// on a background task while poll() polls concurrently. The approval is sent once the
+    /// first .continue status is received; the last status must be .complete("approved") and
+    /// the flow must advance to "Automation - Polling Message".
+    ///
+    /// Note: The QR code encodes a URL that, when fetched via GET, approves the challenge.
+    /// On iOS the encoded URL is read from `imageData` using CoreImage's QR detector.
+    func testQRCodeChallengePollingApproval() async throws {
+        guard let startNode = await daVinci.start() as? ContinueNode else {
+            XCTFail("Expected ContinueNode from start()")
+            return
+        }
+        var node = startNode
+        XCTAssertEqual("Select Test Form", node.name)
+
+        guard let qrButton = node.collectors[2] as? FlowCollector else {
+            XCTFail("Expected FlowCollector at collectors[2]")
+            return
+        }
+        XCTAssertEqual("Challenge Polling QRCode", qrButton.label)
+        qrButton.value = "click"
+
+        guard let pollingFormNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after Challenge Polling QRCode button")
+            return
+        }
+        node = pollingFormNode
+        XCTAssertEqual("Automation - Polling with QR Code", node.name)
+
+        guard let qrCodeCollector = node.collectors.first(where: { $0 is QRCodeCollector }) as? QRCodeCollector,
+              let imageData = qrCodeCollector.imageData,
+              let approvalUrl = Self.decodeQRCode(from: imageData) else {
+            XCTFail("Could not get QRCodeCollector or decode URL from QR code imageData")
+            return
+        }
+        XCTAssertTrue(approvalUrl.hasPrefix("https://"), "Expected an HTTPS URL in QR code, got: \(approvalUrl)")
+
+        guard let pollingCollector = node.collectors.first(where: { $0 is PollingCollector }) as? PollingCollector else {
+            XCTFail("PollingCollector not found")
+            return
+        }
+        XCTAssertTrue(pollingCollector.pollChallengeStatus)
+        XCTAssertFalse(pollingCollector.challenge.isEmpty)
+
+        // Poll and send approval once the first .continue status is received.
+        var approvalTask: Task<Void, Never>?
+        var statuses: [PollingStatus] = []
+        for await status in pollingCollector.poll() {
+            statuses.append(status)
+            if case .continue = status, approvalTask == nil {
+                approvalTask = Task {
+                    guard let url = URL(string: approvalUrl) else { return }
+                    var request = URLRequest(url: url)
+                    request.timeoutInterval = 10
+                    _ = try? await URLSession.shared.data(for: request)
+                }
+            }
+        }
+        await approvalTask?.value
+
+        guard let lastStatus = statuses.last else { XCTFail("statuses is empty"); return }
+        if case .complete(let s) = lastStatus {
+            XCTAssertEqual("approved", s)
+            XCTAssertEqual("approved", pollingCollector.value)
+        } else { XCTFail("Expected .complete(\"approved\") as last status, got \(lastStatus)") }
+
+        guard let messageNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after approval submit")
+            return
+        }
+        node = messageNode
+        XCTAssertEqual("Automation - Polling Message", node.name)
+
+        let approvedLabel = node.collectors.first { ($0 as? LabelCollector)?.content == "Message: approved" } as? LabelCollector
+        XCTAssertNotNil(approvedLabel)
+        XCTAssertEqual("Message: approved", approvedLabel?.content)
+    }
+
+    // MARK: - Private helpers
+
+    /// Decodes the URL text encoded in a QR code image using CoreImage's built-in detector.
+    /// Returns nil if the image cannot be decoded or no QR code is found.
+    private static func decodeQRCode(from data: Data) -> String? {
+        guard let ciImage = CIImage(data: data) else { return nil }
+        let detector = CIDetector(
+            ofType: CIDetectorTypeQRCode,
+            context: nil,
+            options: [CIDetectorAccuracy: CIDetectorAccuracyHigh]
+        )
+        let features = detector?.features(in: ciImage) ?? []
+        return (features.first as? CIQRCodeFeature)?.messageString
+    }
+}


### PR DESCRIPTION
# JIRA Ticket

[SDKS-4249](https://pingidentity.atlassian.net/browse/SDKS-4249) [QA] Support for new DaVinci collectors

# Description

New tests added covering the following collectors/features:
- `ReadOnlyTextCollector` (agreement text)
- `BooleanCollector` (required "I agree" checkbox)
- `PhoneNumberCollector` (object payload format, extension field, end-to-end submission)
- `LabelCollector` (multiple rich text links, target field for open-in-new-tab)
- `PollingCollector` (timeout, completion, challenge approval, QR code challenge)
- Password policy validation (max repeat, max length, field-level policy source)