### PR TITLE
Add unified JSON configuration support to iOS SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,7 @@ AGENTS.md
 # Merge / Finder leftovers
 *.orig
 **/* copy.xcodeproj/
+/SourcePackages
+
+# Local JSON configs — not committed, discovered at runtime via folder reference
+SampleApps/PingExample/PingExample/Configs/

--- a/Davinci/Davinci.xcodeproj/project.pbxproj
+++ b/Davinci/Davinci.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		3A292C822BF58462006977EF /* Agent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A292C812BF58462006977EF /* Agent.swift */; };
 		3A5441AA2BCDF20700385131 /* PingDavinci.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A5441A12BCDF20700385131 /* PingDavinci.framework */; };
 		3A5441AF2BCDF20700385131 /* DaVinciTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5441AE2BCDF20700385131 /* DaVinciTests.swift */; };
+		SDKS50660003000000000002 /* DaVinciJsonConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS50660003000000000001 /* DaVinciJsonConfigTests.swift */; };
 		AA4785031F0000000000AA01 /* DaVinciDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4785021F0000000000AA01 /* DaVinciDeviceTests.swift */; };
 		25554859C34DBAACE79ABA36 /* DaVinciPARTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AD0544A9787573F4A02A278 /* DaVinciPARTests.swift */; };
 		3A5441B02BCDF20700385131 /* Davinci.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A5441A42BCDF20700385131 /* Davinci.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -118,6 +119,7 @@
 		3A5441A42BCDF20700385131 /* Davinci.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Davinci.h; sourceTree = "<group>"; };
 		3A5441A92BCDF20700385131 /* DavinciTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DavinciTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A5441AE2BCDF20700385131 /* DaVinciTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinciTests.swift; sourceTree = "<group>"; };
+		SDKS50660003000000000001 /* DaVinciJsonConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinciJsonConfigTests.swift; sourceTree = "<group>"; };
 		AA4785021F0000000000AA01 /* DaVinciDeviceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinciDeviceTests.swift; sourceTree = "<group>"; };
 		2AD0544A9787573F4A02A278 /* DaVinciPARTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinciPARTests.swift; sourceTree = "<group>"; };
 		3A57CB612C44D688001EC9A0 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
@@ -261,6 +263,7 @@
 				A51D4CF12C65729A00FE09E0 /* DaVinciErrorTests.swift */,
 				EC7279B32DF9B289005D9E28 /* DaVinciBaseTests.swift */,
 				3A5441AE2BCDF20700385131 /* DaVinciTests.swift */,
+				SDKS50660003000000000001 /* DaVinciJsonConfigTests.swift */,
 				2AD0544A9787573F4A02A278 /* DaVinciPARTests.swift */,
 				AA4785021F0000000000AA01 /* DaVinciDeviceTests.swift */,
 				EC92B3A22DA52DA200E4246D /* DeviceAuthenticatorCollectorTests.swift */,
@@ -530,6 +533,7 @@
 				A51D4CF42C6572E600FE09E0 /* MockURLProtocol.swift in Sources */,
 				A51D4CF82C65978300FE09E0 /* DaVinciIntegrationTests.swift in Sources */,
 				3A5441AF2BCDF20700385131 /* DaVinciTests.swift in Sources */,
+				SDKS50660003000000000002 /* DaVinciJsonConfigTests.swift in Sources */,
 				25554859C34DBAACE79ABA36 /* DaVinciPARTests.swift in Sources */,
 				AA4785031F0000000000AA01 /* DaVinciDeviceTests.swift in Sources */,
 				A51D4CF22C65729A00FE09E0 /* DaVinciErrorTests.swift in Sources */,

--- a/Davinci/Davinci/DaVinci.swift
+++ b/Davinci/Davinci/DaVinci.swift
@@ -15,6 +15,7 @@ import PingOidc
 import PingDavinciPlugin
 import PingCommons
 import PingNetwork
+import PingLogger
 
 public typealias DaVinci = Workflow
 public typealias DaVinciConfig = WorkflowConfig
@@ -120,5 +121,40 @@ extension DaVinci {
         block(config)
         
         return DaVinci(config: config)
+    }
+
+    /// Creates a DaVinci instance from a JSON dictionary.
+    ///
+    /// This factory parses and validates a platform-neutral JSON configuration and
+    /// delegates to `createDaVinci(block:)` with the extracted values. Unknown fields
+    /// (including `serverUrl`, `realm`, and `cookie`, which are Journey-specific) are
+    /// silently ignored for forward compatibility.
+    ///
+    /// - Parameter json: A `[String: Any]` dictionary conforming to the unified SDK
+    ///   configuration schema (see design doc for field reference).
+    /// - Returns: `.success(DaVinci)` on valid input, `.failure(JsonConfigError)` if a
+    ///   required field is absent or a field has the wrong type.
+    public static func createDaVinci(json: [String: Any]) -> Result<DaVinci, Error> {
+        do {
+            let p = JsonConfigParser(json)
+            let timeout = try p.timeoutSeconds()
+            let logger  = try p.logLevel()
+            let oidcDict: [String: Any] = try p.required(JsonConfigKey.oidc, field: JsonConfigKey.oidc)
+
+            let oidcConfig = OidcClientConfig()
+            oidcConfig.logger = logger
+            try oidcConfig.apply(json: oidcDict)
+
+            let daVinci = DaVinci.createDaVinci { daVinciConfig in
+                daVinciConfig.timeout = timeout
+                daVinciConfig.logger = logger
+                daVinciConfig.module(OidcModule.config) { moduleOidcConfig in
+                    moduleOidcConfig.update(with: oidcConfig)
+                }
+            }
+            return .success(daVinci)
+        } catch {
+            return .failure(error)
+        }
     }
 }

--- a/Davinci/Davinci/DaVinci.swift
+++ b/Davinci/Davinci/DaVinci.swift
@@ -138,12 +138,10 @@ extension DaVinci {
         do {
             let p = JsonConfigParser(json)
             let timeout = try p.timeoutSeconds()
-            let logger  = try p.logLevel()
+            let logger  = p.logLevel()
             let oidcDict: [String: Any] = try p.required(JsonConfigKey.oidc, field: JsonConfigKey.oidc)
 
-            let oidcConfig = OidcClientConfig()
-            oidcConfig.logger = logger
-            try oidcConfig.apply(json: oidcDict)
+            let oidcConfig = try OidcClientConfig.from(oidcJson: oidcDict, logger: logger)
 
             let daVinci = DaVinci.createDaVinci { daVinciConfig in
                 daVinciConfig.timeout = timeout

--- a/Davinci/DavinciTests/DaVinciDeviceTests.swift
+++ b/Davinci/DavinciTests/DaVinciDeviceTests.swift
@@ -24,14 +24,14 @@ final class PopulateDeviceFlowVerificationRequestTests: XCTestCase {
     private func makeConfig(deviceAuthEndpoint: String, clientId: String = "my-client") -> OidcClientConfig {
         let config = OidcClientConfig()
         config.clientId = clientId
-        config.openId = OpenIdConfiguration(
+        config.setOpenId(OpenIdConfiguration(
             authorizationEndpoint: "https://auth.example.com/authorize",
             tokenEndpoint: "https://auth.example.com/token",
             userinfoEndpoint: "https://auth.example.com/userinfo",
             endSessionEndpoint: "https://auth.example.com/signoff",
             revocationEndpoint: "https://auth.example.com/revoke",
             deviceAuthorizationEndpoint: deviceAuthEndpoint
-        )
+        ))
         return config
     }
 

--- a/Davinci/DavinciTests/DaVinciJsonConfigTests.swift
+++ b/Davinci/DavinciTests/DaVinciJsonConfigTests.swift
@@ -1,0 +1,335 @@
+//
+//  DaVinciJsonConfigTests.swift
+//  DavinciTests
+//
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+@testable import PingDavinci
+@testable import PingOidc
+@testable import PingLogger
+
+final class DaVinciJsonConfigTests: XCTestCase, @unchecked Sendable {
+
+    private var minimalJson: [String: Any] {
+        [
+            "oidc": [
+                "clientId": "my-client",
+                "discoveryEndpoint": "https://example.com/.well-known/openid-configuration",
+                "scopes": ["openid"],
+                "redirectUri": "myapp://callback"
+            ] as [String: Any]
+        ]
+    }
+
+    private var fullJson: [String: Any] {
+        [
+            "timeout": 5000,
+            "log": "DEBUG",
+            "oidc": [
+                "clientId": "my-client",
+                "discoveryEndpoint": "https://example.com/.well-known/openid-configuration",
+                "scopes": ["openid", "profile"],
+                "redirectUri": "myapp://callback",
+                "refreshThreshold": 30,
+                "loginHint": "user@example.com",
+                "state": "my-state",
+                "nonce": "my-nonce",
+                "display": "page",
+                "prompt": "login",
+                "uiLocales": "en-US",
+                "acrValues": "Level3",
+                "additionalParameters": ["custom": "value"]
+            ] as [String: Any]
+        ]
+    }
+
+    // MARK: - Success cases
+
+    func testCreateDaVinci_success_minimalRequiredFields() {
+        let result = DaVinci.createDaVinci(json: minimalJson)
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            XCTFail("Expected success, got failure: \(error)")
+        }
+    }
+
+    func testCreateDaVinci_success_allFields() {
+        let result = DaVinci.createDaVinci(json: fullJson)
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            XCTFail("Expected success, got failure: \(error)")
+        }
+    }
+
+    func testCreateDaVinci_serverUrlIgnored() {
+        var json = minimalJson
+        json["serverUrl"] = "https://example.com/am"
+        json["realm"] = "alpha"
+
+        let result = DaVinci.createDaVinci(json: json)
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            XCTFail("serverUrl should be silently ignored for DaVinci, got: \(error)")
+        }
+    }
+
+    func testCreateDaVinci_unknownFieldsSilentlyIgnored() {
+        var json = minimalJson
+        json["unknownField"] = "ignored"
+
+        let result = DaVinci.createDaVinci(json: json)
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            XCTFail("Unknown fields should be ignored, got: \(error)")
+        }
+    }
+
+    // MARK: - timeout
+
+    func testCreateDaVinci_timeoutConversion() {
+        var json = minimalJson
+        json["timeout"] = 5000
+
+        let result = DaVinci.createDaVinci(json: json)
+        guard case .success(let daVinci) = result else {
+            XCTFail("Expected success"); return
+        }
+        XCTAssertEqual(daVinci.config.timeout, 5.0, accuracy: 0.001)
+    }
+
+    func testCreateDaVinci_timeoutDefault() {
+        let result = DaVinci.createDaVinci(json: minimalJson)
+        guard case .success(let daVinci) = result else {
+            XCTFail("Expected success"); return
+        }
+        XCTAssertEqual(daVinci.config.timeout, 15.0, accuracy: 0.001)
+    }
+
+    func testCreateDaVinci_failure_timeoutWrongType() {
+        var json = minimalJson
+        json["timeout"] = "5000"
+
+        let result = DaVinci.createDaVinci(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(timeout), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "timeout")
+    }
+
+    // MARK: - log
+
+    func testCreateDaVinci_logMapping_error() {
+        var json = minimalJson
+        json["log"] = "ERROR"
+
+        let result = DaVinci.createDaVinci(json: json)
+        guard case .success(let daVinci) = result else {
+            XCTFail("Expected success"); return
+        }
+        XCTAssertTrue(daVinci.config.logger is WarningLogger)
+    }
+
+    func testCreateDaVinci_logMapping_debug() {
+        var json = minimalJson
+        json["log"] = "DEBUG"
+
+        let result = DaVinci.createDaVinci(json: json)
+        guard case .success(let daVinci) = result else {
+            XCTFail("Expected success"); return
+        }
+        XCTAssertTrue(daVinci.config.logger is StandardLogger)
+    }
+
+    func testCreateDaVinci_failure_logWrongType() {
+        var json = minimalJson
+        json["log"] = 1
+
+        let result = DaVinci.createDaVinci(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(log), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "log")
+    }
+
+    // MARK: - oidc (required)
+
+    func testCreateDaVinci_failure_missingOidc() {
+        var json = minimalJson
+        json.removeValue(forKey: "oidc")
+
+        let result = DaVinci.createDaVinci(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(oidc), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "oidc")
+    }
+
+    func testCreateDaVinci_failure_oidcWrongType() {
+        var json = minimalJson
+        json["oidc"] = "not-an-object"
+
+        let result = DaVinci.createDaVinci(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(oidc), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "oidc")
+    }
+
+    func testCreateDaVinci_failure_missingClientId() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc.removeValue(forKey: "clientId")
+        json["oidc"] = oidc
+
+        let result = DaVinci.createDaVinci(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(oidc.clientId), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "oidc.clientId")
+    }
+
+    func testCreateDaVinci_failure_missingDiscoveryEndpoint() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc.removeValue(forKey: "discoveryEndpoint")
+        json["oidc"] = oidc
+
+        let result = DaVinci.createDaVinci(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(oidc.discoveryEndpoint), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "oidc.discoveryEndpoint")
+    }
+
+    func testCreateDaVinci_failure_missingScopes() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc.removeValue(forKey: "scopes")
+        json["oidc"] = oidc
+
+        let result = DaVinci.createDaVinci(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(oidc.scopes), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "oidc.scopes")
+    }
+
+    func testCreateDaVinci_failure_missingRedirectUri() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc.removeValue(forKey: "redirectUri")
+        json["oidc"] = oidc
+
+        let result = DaVinci.createDaVinci(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(oidc.redirectUri), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "oidc.redirectUri")
+    }
+
+    func testCreateDaVinci_failure_scopesNotStringArray() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["scopes"] = [1, 2, 3]
+        json["oidc"] = oidc
+
+        let result = DaVinci.createDaVinci(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(oidc.scopes), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "oidc.scopes")
+    }
+
+    func testCreateDaVinci_failure_additionalParametersNonStringValue() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["additionalParameters"] = ["key": 123]
+        json["oidc"] = oidc
+
+        let result = DaVinci.createDaVinci(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType for additionalParameters, got: \(result)")
+            return
+        }
+        XCTAssertTrue(field.hasPrefix("oidc.additionalParameters"))
+    }
+
+    func testCreateDaVinci_refreshThresholdSet() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["refreshThreshold"] = 30
+        json["oidc"] = oidc
+
+        let result = DaVinci.createDaVinci(json: json)
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            XCTFail("Expected success, got: \(error)")
+        }
+    }
+
+    // MARK: - par
+
+    func testCreateDaVinci_par_true_accepted() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["par"] = true
+        json["oidc"] = oidc
+
+        let result = DaVinci.createDaVinci(json: json)
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            XCTFail("Expected success with par=true, got: \(error)")
+        }
+    }
+
+    func testCreateDaVinci_failure_par_wrongType() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["par"] = "yes"
+        json["oidc"] = oidc
+
+        let result = DaVinci.createDaVinci(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(oidc.par), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "oidc.par")
+    }
+}

--- a/Davinci/DavinciTests/DaVinciJsonConfigTests.swift
+++ b/Davinci/DavinciTests/DaVinciJsonConfigTests.swift
@@ -155,17 +155,17 @@ final class DaVinciJsonConfigTests: XCTestCase, @unchecked Sendable {
         XCTAssertTrue(daVinci.config.logger is StandardLogger)
     }
 
-    func testCreateDaVinci_failure_logWrongType() {
+    func testCreateDaVinci_logWrongType_softFault_succeeds() {
         var json = minimalJson
         json["log"] = 1
 
         let result = DaVinci.createDaVinci(json: json)
-        guard case .failure(let error) = result,
-              case .invalidType(let field, _) = error as? JsonConfigError else {
-            XCTFail("Expected invalidType(log), got: \(result)")
-            return
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            XCTFail("Expected success when log has wrong type (soft fault), got: \(error)")
         }
-        XCTAssertEqual(field, "log")
     }
 
     // MARK: - oidc (required)

--- a/Davinci/README.md
+++ b/Davinci/README.md
@@ -403,6 +403,48 @@ await user?.logout()
 
 ```
 
+## JSON Configuration
+
+`DaVinci.createDaVinci(json:)` initialises a `DaVinci` instance from a platform-neutral dictionary, enabling config-file-driven setup without writing Swift initialisation code.
+
+```swift
+let json: [String: Any] = [
+    "timeout": 30000,          // milliseconds — optional, default 15 s
+    "log": "DEBUG",            // optional — NONE | ERROR | WARN | INFO | DEBUG
+    "oidc": [
+        "clientId": "your-client-id",
+        "discoveryEndpoint": "https://auth.example.com/.well-known/openid-configuration",
+        "redirectUri": "myapp://callback",
+        "scopes": ["openid", "profile", "email"],
+        // --- optional ---
+        "acrValues": "policy-id",
+        "par": true,
+        "refreshThreshold": 60,
+        "signOutRedirectUri": "myapp://logout",
+        "additionalParameters": ["custom_key": "custom_value"],
+        "openId": [            // endpoint overrides, applied after discovery
+            "tokenEndpoint": "https://auth.example.com/token"
+        ]
+    ] as [String: Any]
+]
+
+switch DaVinci.createDaVinci(json: json) {
+case .success(let daVinci):
+    // use daVinci
+case .failure(let error):
+    print("Configuration error: \(error.localizedDescription)")
+}
+```
+
+### Error handling
+
+On invalid input `createDaVinci(json:)` returns `.failure(JsonConfigError)`:
+
+| Error | Cause |
+|-------|-------|
+| `missingRequiredField(String)` | A required field is absent |
+| `invalidType(field:expected:)` | A field has the wrong type |
+
 ## License
 
 This software may be modified and distributed under the terms of the MIT license. See the LICENSE file for details.

--- a/Journey/Journey.xcodeproj/project.pbxproj
+++ b/Journey/Journey.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		EC727A2E2E019243005D9E28 /* PingJourney.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC727A242E019243005D9E28 /* PingJourney.framework */; };
 		EC727A5D2E019254005D9E28 /* Journey.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC727A5B2E019254005D9E28 /* Journey.swift */; };
 		EC727A602E019258005D9E28 /* JourneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC727A5E2E019258005D9E28 /* JourneyTests.swift */; };
+		SDKS50660002000000000002 /* JourneyJsonConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS50660002000000000001 /* JourneyJsonConfigTests.swift */; };
 		EC727A652E0192FA005D9E28 /* Journey.h in Headers */ = {isa = PBXBuildFile; fileRef = EC727A642E0192FA005D9E28 /* Journey.h */; };
 		EC727A662E0192FA005D9E28 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = EC727A632E0192FA005D9E28 /* PrivacyInfo.xcprivacy */; };
 		EC727A922E02DCA9005D9E28 /* PingOidc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC727A912E02DCA9005D9E28 /* PingOidc.framework */; };
@@ -209,6 +210,7 @@
 		EC727A2D2E019243005D9E28 /* JourneyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JourneyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC727A5B2E019254005D9E28 /* Journey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Journey.swift; sourceTree = "<group>"; };
 		EC727A5E2E019258005D9E28 /* JourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JourneyTests.swift; sourceTree = "<group>"; };
+		SDKS50660002000000000001 /* JourneyJsonConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JourneyJsonConfigTests.swift; sourceTree = "<group>"; };
 		EC727A632E0192FA005D9E28 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		EC727A642E0192FA005D9E28 /* Journey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Journey.h; sourceTree = "<group>"; };
 		EC727A912E02DCA9005D9E28 /* PingOidc.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingOidc.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -356,6 +358,7 @@
 				EC2326A32E0D670D00634A50 /* JourneyContinueNodeTests.swift */,
 				ECEFDC242ED4AF3C00B56E87 /* MetadataCallbackSpecializationTests.swift */,
 				EC727A5E2E019258005D9E28 /* JourneyTests.swift */,
+				SDKS50660002000000000001 /* JourneyJsonConfigTests.swift */,
 				EC2326A52E0D744A00634A50 /* JourneyUserTests.swift */,
 				AA4785051F0000000000AA05 /* OidcDeviceApprovalTests.swift */,
 				A5CFC86A2E42920A00CBFC3B /* Callbacks */,
@@ -618,6 +621,7 @@
 				A5CFC8A42E43A35300CBFC3B /* ValidatedUsernameCallbackTests.swift in Sources */,
 				EC2326A22E0D65A800634A50 /* PasswordCallbackTests.swift in Sources */,
 				EC727A602E019258005D9E28 /* JourneyTests.swift in Sources */,
+				SDKS50660002000000000002 /* JourneyJsonConfigTests.swift in Sources */,
 				A5CFC89E2E43A0E600CBFC3B /* TextInputCallbackTests.swift in Sources */,
 				A50585152E3D05FC004813B5 /* ConfirmationCallbackTests.swift in Sources */,
 				A5CFC87E2E439D3800CBFC3B /* StringAttributeInputCallbackTests.swift in Sources */,

--- a/Journey/Journey/Journey.swift
+++ b/Journey/Journey/Journey.swift
@@ -194,6 +194,46 @@ public extension Journey {
         return await signOff()
     }
     
+    /// Creates a Journey instance from a JSON dictionary.
+    ///
+    /// This factory parses and validates a platform-neutral JSON configuration and
+    /// delegates to `createJourney(block:)` with the extracted values. Unknown fields
+    /// are silently ignored for forward compatibility.
+    ///
+    /// - Parameter json: A `[String: Any]` dictionary conforming to the unified SDK
+    ///   configuration schema (see design doc for field reference).
+    /// - Returns: `.success(Journey)` on valid input, `.failure(JsonConfigError)` if a
+    ///   required field is absent or a field has the wrong type.
+    static func createJourney(json: [String: Any]) -> Result<Journey, Error> {
+        do {
+            let p = JsonConfigParser(json)
+            let serverUrl: String = try p.required(JsonConfigKey.serverUrl, field: JsonConfigKey.serverUrl)
+            let realm      = try p.optional(JsonConfigKey.realm,      field: JsonConfigKey.realm,      default: JourneyConstants.realm)
+            let cookieName = try p.optional(JsonConfigKey.cookieName, field: JsonConfigKey.cookieName, default: JourneyConstants.cookie)
+            let timeout    = try p.timeoutSeconds()
+            let logger     = try p.logLevel()
+            let oidcDict: [String: Any] = try p.required(JsonConfigKey.oidc, field: JsonConfigKey.oidc)
+
+            let oidcConfig = OidcClientConfig()
+            oidcConfig.logger = logger
+            try oidcConfig.apply(json: oidcDict)
+
+            let journey = Journey.createJourney { journeyConfig in
+                journeyConfig.serverUrl = serverUrl
+                journeyConfig.realm = realm
+                journeyConfig.cookie = cookieName
+                journeyConfig.timeout = timeout
+                journeyConfig.logger = logger
+                journeyConfig.module(OidcModule.config) { moduleOidcConfig in
+                    moduleOidcConfig.update(with: oidcConfig)
+                }
+            }
+            return .success(journey)
+        } catch {
+            return .failure(error)
+        }
+    }
+
     /// Sends a request using the configured HTTP client and wraps the response.
     ///
     /// - Parameter request: The request to send.

--- a/Journey/Journey/Journey.swift
+++ b/Journey/Journey/Journey.swift
@@ -213,16 +213,12 @@ public extension Journey {
             let realm      = try jp.optional(JsonConfigKey.realm,      field: "\(JsonConfigKey.journey).\(JsonConfigKey.realm)",      default: JourneyConstants.realm)
             let cookieName = try jp.optional(JsonConfigKey.cookieName, field: "\(JsonConfigKey.journey).\(JsonConfigKey.cookieName)", default: JourneyConstants.cookie)
             let timeout    = try p.timeoutSeconds()
-            let logger     = try p.logLevel()
+            let logger     = p.logLevel()
             let oidcDict: [String: Any]? = try p.optionalValue(JsonConfigKey.oidc, field: JsonConfigKey.oidc)
 
-            let oidcConfig: OidcClientConfig? = try {
-                guard let oidcDict else { return nil }
-                let config = OidcClientConfig()
-                config.logger = logger
-                try config.apply(json: oidcDict)
-                return config
-            }()
+            let oidcConfig: OidcClientConfig? = try oidcDict.map {
+                try OidcClientConfig.from(oidcJson: $0, logger: logger)
+            }
 
             let journey = Journey.createJourney { journeyConfig in
                 journeyConfig.serverUrl = serverUrl

--- a/Journey/Journey/Journey.swift
+++ b/Journey/Journey/Journey.swift
@@ -207,16 +207,22 @@ public extension Journey {
     static func createJourney(json: [String: Any]) -> Result<Journey, Error> {
         do {
             let p = JsonConfigParser(json)
-            let serverUrl: String = try p.required(JsonConfigKey.serverUrl, field: JsonConfigKey.serverUrl)
-            let realm      = try p.optional(JsonConfigKey.realm,      field: JsonConfigKey.realm,      default: JourneyConstants.realm)
-            let cookieName = try p.optional(JsonConfigKey.cookieName, field: JsonConfigKey.cookieName, default: JourneyConstants.cookie)
+            let journeyDict: [String: Any] = try p.required(JsonConfigKey.journey, field: JsonConfigKey.journey)
+            let jp = JsonConfigParser(journeyDict)
+            let serverUrl: String = try jp.required(JsonConfigKey.serverUrl, field: "\(JsonConfigKey.journey).\(JsonConfigKey.serverUrl)")
+            let realm      = try jp.optional(JsonConfigKey.realm,      field: "\(JsonConfigKey.journey).\(JsonConfigKey.realm)",      default: JourneyConstants.realm)
+            let cookieName = try jp.optional(JsonConfigKey.cookieName, field: "\(JsonConfigKey.journey).\(JsonConfigKey.cookieName)", default: JourneyConstants.cookie)
             let timeout    = try p.timeoutSeconds()
             let logger     = try p.logLevel()
-            let oidcDict: [String: Any] = try p.required(JsonConfigKey.oidc, field: JsonConfigKey.oidc)
+            let oidcDict: [String: Any]? = try p.optionalValue(JsonConfigKey.oidc, field: JsonConfigKey.oidc)
 
-            let oidcConfig = OidcClientConfig()
-            oidcConfig.logger = logger
-            try oidcConfig.apply(json: oidcDict)
+            let oidcConfig: OidcClientConfig? = try {
+                guard let oidcDict else { return nil }
+                let config = OidcClientConfig()
+                config.logger = logger
+                try config.apply(json: oidcDict)
+                return config
+            }()
 
             let journey = Journey.createJourney { journeyConfig in
                 journeyConfig.serverUrl = serverUrl
@@ -224,8 +230,10 @@ public extension Journey {
                 journeyConfig.cookie = cookieName
                 journeyConfig.timeout = timeout
                 journeyConfig.logger = logger
-                journeyConfig.module(OidcModule.config) { moduleOidcConfig in
-                    moduleOidcConfig.update(with: oidcConfig)
+                if let oidcConfig {
+                    journeyConfig.module(OidcModule.config) { moduleOidcConfig in
+                        moduleOidcConfig.update(with: oidcConfig)
+                    }
                 }
             }
             return .success(journey)

--- a/Journey/JourneyTests/AgentTests.swift
+++ b/Journey/JourneyTests/AgentTests.swift
@@ -37,7 +37,7 @@ final class AgentTests: XCTestCase {
         clientConfig.clientId = "test-client"
         clientConfig.redirectUri = "https://example.com/callback"
         clientConfig.scopes = ["openid", "profile"]
-        clientConfig.openId = OpenIdConfiguration(authorizationEndpoint: "https://auth.example.com/authorize", tokenEndpoint: "https://auth.example.com/token", userinfoEndpoint: "https://auth.example.com/userInfo", endSessionEndpoint: "https://auth.example.com/endSession", revocationEndpoint: "https://auth.example.com/revoke", pingEndsessionEndpoint: "https://auth.example.com/authorized/ping/endSession")
+        clientConfig.setOpenId(OpenIdConfiguration(authorizationEndpoint: "https://auth.example.com/authorize", tokenEndpoint: "https://auth.example.com/token", userinfoEndpoint: "https://auth.example.com/userInfo", endSessionEndpoint: "https://auth.example.com/endSession", revocationEndpoint: "https://auth.example.com/revoke", pingEndsessionEndpoint: "https://auth.example.com/authorized/ping/endSession"))
         oidcConfig = OidcConfig(oidcClientConfig: clientConfig, config: ())
     }
     

--- a/Journey/JourneyTests/JourneyJsonConfigTests.swift
+++ b/Journey/JourneyTests/JourneyJsonConfigTests.swift
@@ -1,0 +1,454 @@
+//
+//  JourneyJsonConfigTests.swift
+//  JourneyTests
+//
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+@testable import PingJourney
+@testable import PingOidc
+@testable import PingLogger
+
+final class JourneyJsonConfigTests: XCTestCase, @unchecked Sendable {
+
+    // MARK: - Minimal valid JSON
+
+    private var minimalJson: [String: Any] {
+        [
+            "serverUrl": "https://example.com/am",
+            "oidc": [
+                "clientId": "my-client",
+                "discoveryEndpoint": "https://example.com/.well-known/openid-configuration",
+                "scopes": ["openid"],
+                "redirectUri": "myapp://callback"
+            ] as [String: Any]
+        ]
+    }
+
+    private var fullJson: [String: Any] {
+        [
+            "serverUrl": "https://example.com/am",
+            "realm": "alpha",
+            "timeout": 30000,
+            "log": "DEBUG",
+            "oidc": [
+                "clientId": "my-client",
+                "discoveryEndpoint": "https://example.com/.well-known/openid-configuration",
+                "scopes": ["openid", "profile", "email"],
+                "redirectUri": "myapp://callback",
+                "signOutRedirectUri": "myapp://logout",
+                "refreshThreshold": 60,
+                "loginHint": "user@example.com",
+                "state": "my-state",
+                "nonce": "my-nonce",
+                "display": "page",
+                "prompt": "login",
+                "uiLocales": "en-US",
+                "acrValues": "Level3",
+                "additionalParameters": ["custom_param": "custom_value"]
+            ] as [String: Any]
+        ]
+    }
+
+    // MARK: - Success cases
+
+    func testCreateJourney_success_minimalRequiredFields() {
+        let result = Journey.createJourney(json: minimalJson)
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            XCTFail("Expected success, got failure: \(error)")
+        }
+    }
+
+    func testCreateJourney_success_allFields() {
+        let result = Journey.createJourney(json: fullJson)
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            XCTFail("Expected success, got failure: \(error)")
+        }
+    }
+
+    func testCreateJourney_unknownFieldsSilentlyIgnored() {
+        var json = minimalJson
+        json["unknownTopLevel"] = "ignored"
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["unknownOidc"] = 42
+        json["oidc"] = oidc
+
+        let result = Journey.createJourney(json: json)
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            XCTFail("Expected success for unknown fields, got: \(error)")
+        }
+    }
+
+    // MARK: - serverUrl
+
+    func testCreateJourney_failure_missingServerUrl() {
+        var json = minimalJson
+        json.removeValue(forKey: "serverUrl")
+
+        let result = Journey.createJourney(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(serverUrl), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "serverUrl")
+    }
+
+    func testCreateJourney_failure_serverUrlWrongType() {
+        var json = minimalJson
+        json["serverUrl"] = 12345
+
+        let result = Journey.createJourney(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(serverUrl), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "serverUrl")
+    }
+
+    // MARK: - realm
+
+    func testCreateJourney_realmDefault() {
+        let result = Journey.createJourney(json: minimalJson)
+        guard case .success(let journey) = result else {
+            XCTFail("Expected success")
+            return
+        }
+        let journeyConfig = journey.config as? JourneyConfig
+        XCTAssertEqual(journeyConfig?.realm, "root")
+    }
+
+    func testCreateJourney_failure_realmWrongType() {
+        var json = minimalJson
+        json["realm"] = 999
+
+        let result = Journey.createJourney(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(realm), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "realm")
+    }
+
+    // MARK: - cookieName
+
+    func testCreateJourney_cookieNameDefault() {
+        let result = Journey.createJourney(json: minimalJson)
+        guard case .success(let journey) = result else {
+            XCTFail("Expected success")
+            return
+        }
+        let journeyConfig = journey.config as? JourneyConfig
+        XCTAssertEqual(journeyConfig?.cookie, "iPlanetDirectoryPro")
+    }
+
+    func testCreateJourney_cookieNameCustom() {
+        var json = minimalJson
+        json["cookieName"] = "myCustomCookie"
+
+        let result = Journey.createJourney(json: json)
+        guard case .success(let journey) = result else {
+            XCTFail("Expected success")
+            return
+        }
+        let journeyConfig = journey.config as? JourneyConfig
+        XCTAssertEqual(journeyConfig?.cookie, "myCustomCookie")
+    }
+
+    func testCreateJourney_failure_cookieNameWrongType() {
+        var json = minimalJson
+        json["cookieName"] = 123
+
+        let result = Journey.createJourney(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(cookieName), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "cookieName")
+    }
+
+    // MARK: - timeout
+
+    func testCreateJourney_timeoutConversion() {
+        var json = minimalJson
+        json["timeout"] = 30000
+
+        let result = Journey.createJourney(json: json)
+        guard case .success(let journey) = result else {
+            XCTFail("Expected success")
+            return
+        }
+        XCTAssertEqual(journey.config.timeout, 30.0, accuracy: 0.001)
+    }
+
+    func testCreateJourney_timeoutDefault() {
+        let result = Journey.createJourney(json: minimalJson)
+        guard case .success(let journey) = result else {
+            XCTFail("Expected success")
+            return
+        }
+        XCTAssertEqual(journey.config.timeout, 15.0, accuracy: 0.001)
+    }
+
+    func testCreateJourney_failure_timeoutWrongType() {
+        var json = minimalJson
+        json["timeout"] = "30000"
+
+        let result = Journey.createJourney(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(timeout), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "timeout")
+    }
+
+    // MARK: - log
+
+    func testCreateJourney_logMapping_none() {
+        var json = minimalJson
+        json["log"] = "NONE"
+
+        let result = Journey.createJourney(json: json)
+        guard case .success(let journey) = result else {
+            XCTFail("Expected success"); return
+        }
+        XCTAssertTrue(journey.config.logger is NoneLogger)
+    }
+
+    func testCreateJourney_logMapping_debug() {
+        var json = minimalJson
+        json["log"] = "DEBUG"
+
+        let result = Journey.createJourney(json: json)
+        guard case .success(let journey) = result else {
+            XCTFail("Expected success"); return
+        }
+        XCTAssertTrue(journey.config.logger is StandardLogger)
+    }
+
+    func testCreateJourney_logMapping_info() {
+        var json = minimalJson
+        json["log"] = "INFO"
+
+        let result = Journey.createJourney(json: json)
+        guard case .success(let journey) = result else {
+            XCTFail("Expected success"); return
+        }
+        XCTAssertTrue(journey.config.logger is StandardLogger)
+    }
+
+    func testCreateJourney_logMapping_warn() {
+        var json = minimalJson
+        json["log"] = "WARN"
+
+        let result = Journey.createJourney(json: json)
+        guard case .success(let journey) = result else {
+            XCTFail("Expected success"); return
+        }
+        XCTAssertTrue(journey.config.logger is WarningLogger)
+    }
+
+    func testCreateJourney_logMapping_error() {
+        var json = minimalJson
+        json["log"] = "ERROR"
+
+        let result = Journey.createJourney(json: json)
+        guard case .success(let journey) = result else {
+            XCTFail("Expected success"); return
+        }
+        XCTAssertTrue(journey.config.logger is WarningLogger)
+    }
+
+    func testCreateJourney_failure_logWrongType() {
+        var json = minimalJson
+        json["log"] = 1
+
+        let result = Journey.createJourney(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(log), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "log")
+    }
+
+    // MARK: - oidc (required)
+
+    func testCreateJourney_failure_missingOidc() {
+        var json = minimalJson
+        json.removeValue(forKey: "oidc")
+
+        let result = Journey.createJourney(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(oidc), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "oidc")
+    }
+
+    func testCreateJourney_failure_oidcWrongType() {
+        var json = minimalJson
+        json["oidc"] = "not-an-object"
+
+        let result = Journey.createJourney(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(oidc), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "oidc")
+    }
+
+    // MARK: - oidc required fields
+
+    func testCreateJourney_failure_missingClientId() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc.removeValue(forKey: "clientId")
+        json["oidc"] = oidc
+
+        let result = Journey.createJourney(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(oidc.clientId), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "oidc.clientId")
+    }
+
+    func testCreateJourney_failure_missingDiscoveryEndpoint() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc.removeValue(forKey: "discoveryEndpoint")
+        json["oidc"] = oidc
+
+        let result = Journey.createJourney(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(oidc.discoveryEndpoint), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "oidc.discoveryEndpoint")
+    }
+
+    func testCreateJourney_failure_missingScopes() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc.removeValue(forKey: "scopes")
+        json["oidc"] = oidc
+
+        let result = Journey.createJourney(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(oidc.scopes), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "oidc.scopes")
+    }
+
+    func testCreateJourney_failure_missingRedirectUri() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc.removeValue(forKey: "redirectUri")
+        json["oidc"] = oidc
+
+        let result = Journey.createJourney(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(oidc.redirectUri), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "oidc.redirectUri")
+    }
+
+    func testCreateJourney_failure_scopesNotStringArray() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["scopes"] = [1, 2, 3]
+        json["oidc"] = oidc
+
+        let result = Journey.createJourney(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(oidc.scopes), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "oidc.scopes")
+    }
+
+    func testCreateJourney_failure_additionalParametersNonStringValue() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["additionalParameters"] = ["key": 123]
+        json["oidc"] = oidc
+
+        let result = Journey.createJourney(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType for additionalParameters, got: \(result)")
+            return
+        }
+        XCTAssertTrue(field.hasPrefix("oidc.additionalParameters"))
+    }
+
+    // MARK: - refreshThreshold default
+
+    func testCreateJourney_refreshThresholdDefault() {
+        let result = Journey.createJourney(json: minimalJson)
+        guard case .success = result else {
+            XCTFail("Expected success"); return
+        }
+        // Just verifying creation succeeded — refreshThreshold is set on OidcClientConfig
+        // which is internal to the module config and not directly inspectable here.
+    }
+
+    // MARK: - par
+
+    func testCreateJourney_par_true_accepted() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["par"] = true
+        json["oidc"] = oidc
+
+        let result = Journey.createJourney(json: json)
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            XCTFail("Expected success with par=true, got: \(error)")
+        }
+    }
+
+    func testCreateJourney_failure_par_wrongType() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["par"] = "yes"
+        json["oidc"] = oidc
+
+        let result = Journey.createJourney(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(oidc.par), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "oidc.par")
+    }
+}

--- a/Journey/JourneyTests/JourneyJsonConfigTests.swift
+++ b/Journey/JourneyTests/JourneyJsonConfigTests.swift
@@ -301,17 +301,17 @@ final class JourneyJsonConfigTests: XCTestCase, @unchecked Sendable {
         XCTAssertTrue(journey.config.logger is WarningLogger)
     }
 
-    func testCreateJourney_failure_logWrongType() {
+    func testCreateJourney_logWrongType_softFault_succeeds() {
         var json = minimalJson
         json["log"] = 1
 
         let result = Journey.createJourney(json: json)
-        guard case .failure(let error) = result,
-              case .invalidType(let field, _) = error as? JsonConfigError else {
-            XCTFail("Expected invalidType(log), got: \(result)")
-            return
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            XCTFail("Expected success when log has wrong type (soft fault), got: \(error)")
         }
-        XCTAssertEqual(field, "log")
     }
 
     // MARK: - oidc (optional)

--- a/Journey/JourneyTests/JourneyJsonConfigTests.swift
+++ b/Journey/JourneyTests/JourneyJsonConfigTests.swift
@@ -15,11 +15,23 @@ import XCTest
 
 final class JourneyJsonConfigTests: XCTestCase, @unchecked Sendable {
 
-    // MARK: - Minimal valid JSON
+    // MARK: - Minimal valid JSON (Journey-only, no OIDC)
 
     private var minimalJson: [String: Any] {
         [
-            "serverUrl": "https://example.com/am",
+            "journey": [
+                "serverUrl": "https://example.com/am"
+            ] as [String: Any]
+        ]
+    }
+
+    // MARK: - Minimal valid JSON with OIDC
+
+    private var minimalJsonWithOidc: [String: Any] {
+        [
+            "journey": [
+                "serverUrl": "https://example.com/am"
+            ] as [String: Any],
             "oidc": [
                 "clientId": "my-client",
                 "discoveryEndpoint": "https://example.com/.well-known/openid-configuration",
@@ -31,8 +43,11 @@ final class JourneyJsonConfigTests: XCTestCase, @unchecked Sendable {
 
     private var fullJson: [String: Any] {
         [
-            "serverUrl": "https://example.com/am",
-            "realm": "alpha",
+            "journey": [
+                "serverUrl": "https://example.com/am",
+                "realm": "alpha",
+                "cookieName": "iPlanetDirectoryPro"
+            ] as [String: Any],
             "timeout": 30000,
             "log": "DEBUG",
             "oidc": [
@@ -77,7 +92,7 @@ final class JourneyJsonConfigTests: XCTestCase, @unchecked Sendable {
     }
 
     func testCreateJourney_unknownFieldsSilentlyIgnored() {
-        var json = minimalJson
+        var json = minimalJsonWithOidc
         json["unknownTopLevel"] = "ignored"
         var oidc = json["oidc"] as! [String: Any]
         oidc["unknownOidc"] = 42
@@ -92,32 +107,42 @@ final class JourneyJsonConfigTests: XCTestCase, @unchecked Sendable {
         }
     }
 
-    // MARK: - serverUrl
+    // MARK: - journey sub-dict
+
+    func testCreateJourney_failure_missingJourneyDict() {
+        let result = Journey.createJourney(json: [:])
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(journey), got: \(result)")
+            return
+        }
+        XCTAssertEqual(field, "journey")
+    }
 
     func testCreateJourney_failure_missingServerUrl() {
         var json = minimalJson
-        json.removeValue(forKey: "serverUrl")
+        json["journey"] = [String: Any]()
 
         let result = Journey.createJourney(json: json)
         guard case .failure(let error) = result,
               case .missingRequiredField(let field) = error as? JsonConfigError else {
-            XCTFail("Expected missingRequiredField(serverUrl), got: \(result)")
+            XCTFail("Expected missingRequiredField(journey.serverUrl), got: \(result)")
             return
         }
-        XCTAssertEqual(field, "serverUrl")
+        XCTAssertEqual(field, "journey.serverUrl")
     }
 
     func testCreateJourney_failure_serverUrlWrongType() {
         var json = minimalJson
-        json["serverUrl"] = 12345
+        json["journey"] = ["serverUrl": 12345]
 
         let result = Journey.createJourney(json: json)
         guard case .failure(let error) = result,
               case .invalidType(let field, _) = error as? JsonConfigError else {
-            XCTFail("Expected invalidType(serverUrl), got: \(result)")
+            XCTFail("Expected invalidType(journey.serverUrl), got: \(result)")
             return
         }
-        XCTAssertEqual(field, "serverUrl")
+        XCTAssertEqual(field, "journey.serverUrl")
     }
 
     // MARK: - realm
@@ -134,15 +159,15 @@ final class JourneyJsonConfigTests: XCTestCase, @unchecked Sendable {
 
     func testCreateJourney_failure_realmWrongType() {
         var json = minimalJson
-        json["realm"] = 999
+        json["journey"] = ["serverUrl": "https://example.com/am", "realm": 999]
 
         let result = Journey.createJourney(json: json)
         guard case .failure(let error) = result,
               case .invalidType(let field, _) = error as? JsonConfigError else {
-            XCTFail("Expected invalidType(realm), got: \(result)")
+            XCTFail("Expected invalidType(journey.realm), got: \(result)")
             return
         }
-        XCTAssertEqual(field, "realm")
+        XCTAssertEqual(field, "journey.realm")
     }
 
     // MARK: - cookieName
@@ -159,7 +184,7 @@ final class JourneyJsonConfigTests: XCTestCase, @unchecked Sendable {
 
     func testCreateJourney_cookieNameCustom() {
         var json = minimalJson
-        json["cookieName"] = "myCustomCookie"
+        json["journey"] = ["serverUrl": "https://example.com/am", "cookieName": "myCustomCookie"]
 
         let result = Journey.createJourney(json: json)
         guard case .success(let journey) = result else {
@@ -172,15 +197,15 @@ final class JourneyJsonConfigTests: XCTestCase, @unchecked Sendable {
 
     func testCreateJourney_failure_cookieNameWrongType() {
         var json = minimalJson
-        json["cookieName"] = 123
+        json["journey"] = ["serverUrl": "https://example.com/am", "cookieName": 123]
 
         let result = Journey.createJourney(json: json)
         guard case .failure(let error) = result,
               case .invalidType(let field, _) = error as? JsonConfigError else {
-            XCTFail("Expected invalidType(cookieName), got: \(result)")
+            XCTFail("Expected invalidType(journey.cookieName), got: \(result)")
             return
         }
-        XCTAssertEqual(field, "cookieName")
+        XCTAssertEqual(field, "journey.cookieName")
     }
 
     // MARK: - timeout
@@ -289,23 +314,20 @@ final class JourneyJsonConfigTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(field, "log")
     }
 
-    // MARK: - oidc (required)
+    // MARK: - oidc (optional)
 
-    func testCreateJourney_failure_missingOidc() {
-        var json = minimalJson
-        json.removeValue(forKey: "oidc")
-
-        let result = Journey.createJourney(json: json)
-        guard case .failure(let error) = result,
-              case .missingRequiredField(let field) = error as? JsonConfigError else {
-            XCTFail("Expected missingRequiredField(oidc), got: \(result)")
-            return
+    func testCreateJourney_success_withoutOidc() {
+        let result = Journey.createJourney(json: minimalJson)
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            XCTFail("Expected success without oidc, got: \(error)")
         }
-        XCTAssertEqual(field, "oidc")
     }
 
     func testCreateJourney_failure_oidcWrongType() {
-        var json = minimalJson
+        var json = minimalJsonWithOidc
         json["oidc"] = "not-an-object"
 
         let result = Journey.createJourney(json: json)
@@ -320,7 +342,7 @@ final class JourneyJsonConfigTests: XCTestCase, @unchecked Sendable {
     // MARK: - oidc required fields
 
     func testCreateJourney_failure_missingClientId() {
-        var json = minimalJson
+        var json = minimalJsonWithOidc
         var oidc = json["oidc"] as! [String: Any]
         oidc.removeValue(forKey: "clientId")
         json["oidc"] = oidc
@@ -335,7 +357,7 @@ final class JourneyJsonConfigTests: XCTestCase, @unchecked Sendable {
     }
 
     func testCreateJourney_failure_missingDiscoveryEndpoint() {
-        var json = minimalJson
+        var json = minimalJsonWithOidc
         var oidc = json["oidc"] as! [String: Any]
         oidc.removeValue(forKey: "discoveryEndpoint")
         json["oidc"] = oidc
@@ -350,7 +372,7 @@ final class JourneyJsonConfigTests: XCTestCase, @unchecked Sendable {
     }
 
     func testCreateJourney_failure_missingScopes() {
-        var json = minimalJson
+        var json = minimalJsonWithOidc
         var oidc = json["oidc"] as! [String: Any]
         oidc.removeValue(forKey: "scopes")
         json["oidc"] = oidc
@@ -365,7 +387,7 @@ final class JourneyJsonConfigTests: XCTestCase, @unchecked Sendable {
     }
 
     func testCreateJourney_failure_missingRedirectUri() {
-        var json = minimalJson
+        var json = minimalJsonWithOidc
         var oidc = json["oidc"] as! [String: Any]
         oidc.removeValue(forKey: "redirectUri")
         json["oidc"] = oidc
@@ -380,7 +402,7 @@ final class JourneyJsonConfigTests: XCTestCase, @unchecked Sendable {
     }
 
     func testCreateJourney_failure_scopesNotStringArray() {
-        var json = minimalJson
+        var json = minimalJsonWithOidc
         var oidc = json["oidc"] as! [String: Any]
         oidc["scopes"] = [1, 2, 3]
         json["oidc"] = oidc
@@ -395,7 +417,7 @@ final class JourneyJsonConfigTests: XCTestCase, @unchecked Sendable {
     }
 
     func testCreateJourney_failure_additionalParametersNonStringValue() {
-        var json = minimalJson
+        var json = minimalJsonWithOidc
         var oidc = json["oidc"] as! [String: Any]
         oidc["additionalParameters"] = ["key": 123]
         json["oidc"] = oidc
@@ -423,7 +445,7 @@ final class JourneyJsonConfigTests: XCTestCase, @unchecked Sendable {
     // MARK: - par
 
     func testCreateJourney_par_true_accepted() {
-        var json = minimalJson
+        var json = minimalJsonWithOidc
         var oidc = json["oidc"] as! [String: Any]
         oidc["par"] = true
         json["oidc"] = oidc
@@ -438,7 +460,7 @@ final class JourneyJsonConfigTests: XCTestCase, @unchecked Sendable {
     }
 
     func testCreateJourney_failure_par_wrongType() {
-        var json = minimalJson
+        var json = minimalJsonWithOidc
         var oidc = json["oidc"] as! [String: Any]
         oidc["par"] = "yes"
         json["oidc"] = oidc

--- a/Journey/README.md
+++ b/Journey/README.md
@@ -548,6 +548,46 @@ Callbacks below will be supported by other modules:
 | SelectIdpCallback                | External Identity provider selection.                                          |
 | IdpCallback                      | External Identity provider authentication.                                     |
 
+## JSON Configuration
+
+`Journey.createJourney(json:)` initialises a `Journey` instance from a platform-neutral dictionary. The `oidc` block is **optional** — Journey can run without OIDC token exchange.
+
+```swift
+let json: [String: Any] = [
+    "journey": [                   // required
+        "serverUrl": "https://example.am.com/am",
+        "realm": "alpha",          // optional, default "root"
+        "cookieName": "iPlanetDirectoryPro"  // optional
+    ] as [String: Any],
+    "timeout": 30000,              // milliseconds — optional, default 15 s
+    "log": "DEBUG",                // optional
+    "oidc": [                      // optional — include to enable OIDC token exchange
+        "clientId": "your-client-id",
+        "discoveryEndpoint": "https://example.am.com/am/oauth2/alpha/.well-known/openid-configuration",
+        "redirectUri": "myapp://callback",
+        "scopes": ["openid", "profile"],
+        "par": true,               // optional
+        "acrValues": "policy-id"   // optional
+    ] as [String: Any]
+]
+
+switch Journey.createJourney(json: json) {
+case .success(let journey):
+    let node = await journey.start("LoginTree")
+case .failure(let error):
+    print("Configuration error: \(error.localizedDescription)")
+}
+```
+
+### Error handling
+
+On invalid input `createJourney(json:)` returns `.failure(JsonConfigError)`:
+
+| Error | Cause |
+|-------|-------|
+| `missingRequiredField(String)` | A required field is absent (e.g. `"journey"`, `"journey.serverUrl"`) |
+| `invalidType(field:expected:)` | A field has the wrong type |
+
 ## License
 
 This software may be modified and distributed under the terms of the MIT license. See the LICENSE file for details.

--- a/Logger/Logger/StandardLogger.swift
+++ b/Logger/Logger/StandardLogger.swift
@@ -2,7 +2,7 @@
 //  StandardLogger.swift
 //  PingLogger
 //
-//  Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -74,4 +74,25 @@ extension LogManager {
     public static var standard: Logger { return StandardLogger() }
     /// Static logger of `WarningLogger` type
     public static var warning: Logger { return WarningLogger() }
+
+    /// Returns a `Logger` for the given log-level string from the unified JSON configuration.
+    ///
+    /// | Value          | Logger          |
+    /// |----------------|-----------------|
+    /// | `"NONE"` / nil | `NoneLogger`    |
+    /// | `"ERROR"`      | `WarningLogger` |
+    /// | `"WARN"`       | `WarningLogger` |
+    /// | `"INFO"`       | `StandardLogger`|
+    /// | `"DEBUG"`      | `StandardLogger`|
+    /// | unknown        | `NoneLogger`    |
+    public static func logger(forLevel level: String) -> Logger {
+        switch level.uppercased() {
+        case "ERROR", "WARN":
+            return warning
+        case "INFO", "DEBUG":
+            return standard
+        default:
+            return none
+        }
+    }
 }

--- a/Oidc/Oidc.xcodeproj/project.pbxproj
+++ b/Oidc/Oidc.xcodeproj/project.pbxproj
@@ -11,16 +11,12 @@
 		3AB1CA162BD6F99C003FCE3C /* Oidc.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB1CA0A2BD6F99C003FCE3C /* Oidc.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3AB1CA2D2BD7727B003FCE3C /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB1CA2A2BD7727B003FCE3C /* Token.swift */; };
 		3AB1CA2E2BD7727B003FCE3C /* Pkce.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB1CA2B2BD7727B003FCE3C /* Pkce.swift */; };
-		SDKS4785A001 /* DeviceAuthorizationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS4785F001 /* DeviceAuthorizationResponse.swift */; };
-		SDKS4785A002 /* DeviceFlowStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS4785F002 /* DeviceFlowStatus.swift */; };
-		SDKS4785A003 /* OidcDeviceClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS4785F003 /* OidcDeviceClientTests.swift */; };
-		SDKS4785A005 /* OidcDeviceClientAdditionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS4785F005 /* OidcDeviceClientAdditionalTests.swift */; };
-		SDKS4785A004 /* OidcDeviceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS4785F004 /* OidcDeviceClient.swift */; };
 		3AB1CA312BD859BC003FCE3C /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB1CA302BD859BC003FCE3C /* User.swift */; };
 		3AB1CA332BD8823C003FCE3C /* Agent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB1CA322BD8823C003FCE3C /* Agent.swift */; };
 		3AB1CA352BD884E4003FCE3C /* OidcClientConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB1CA342BD884E4003FCE3C /* OidcClientConfig.swift */; };
 		3AB1CA3B2BD96089003FCE3C /* OidcUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB1CA3A2BD96089003FCE3C /* OidcUser.swift */; };
 		3AB1CA3D2BD961A2003FCE3C /* OidcClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB1CA3C2BD961A2003FCE3C /* OidcClient.swift */; };
+		700AADB6B22EDCF175F25320 /* OidcClientPARTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7101980CC54DBB835D4F7DB3 /* OidcClientPARTests.swift */; };
 		951773A82EA932A10081AEDE /* PingBrowser.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 951773A72EA932A10081AEDE /* PingBrowser.framework */; };
 		951773A92EA932A10081AEDE /* PingBrowser.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 951773A72EA932A10081AEDE /* PingBrowser.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A50966B62C4C342800A4E5B5 /* OidcError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50966B52C4C342800A4E5B5 /* OidcError.swift */; };
@@ -32,8 +28,6 @@
 		A50966DF2C4DF3CD00A4E5B5 /* OidcClientConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50966DE2C4DF3CD00A4E5B5 /* OidcClientConfigTests.swift */; };
 		A50966E12C4F1D9D00A4E5B5 /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50966E02C4F1D9D00A4E5B5 /* MockURLProtocol.swift */; };
 		A50966E32C4F2F4300A4E5B5 /* OidcClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50966E22C4F2F4300A4E5B5 /* OidcClientTests.swift */; };
-		700AADB6B22EDCF175F25320 /* OidcClientPARTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7101980CC54DBB835D4F7DB3 /* OidcClientPARTests.swift */; };
-		CE68EBE71BABE65295E0CFCA /* OidcAdditionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E2E5250895DD43A8388F8A /* OidcAdditionalTests.swift */; };
 		A50966EF2C4FF75400A4E5B5 /* MockStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50966EE2C4FF75400A4E5B5 /* MockStorage.swift */; };
 		A50967092C50843E00A4E5B5 /* MockAPIEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50967082C50843E00A4E5B5 /* MockAPIEndpoint.swift */; };
 		A50981BE2CEBDF1700F4B487 /* PingOrchestrate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A50981BD2CEBDF1700F4B487 /* PingOrchestrate.framework */; };
@@ -42,9 +36,18 @@
 		A5A712442CAC520500B7DD58 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A5A712432CAC520500B7DD58 /* PrivacyInfo.xcprivacy */; };
 		A5COM0012F0100000000001 /* PingCommons.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5COM0002F0100000000001 /* PingCommons.framework */; };
 		A5COM0022F0100000000001 /* PingCommons.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A5COM0002F0100000000001 /* PingCommons.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		CE68EBE71BABE65295E0CFCA /* OidcAdditionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E2E5250895DD43A8388F8A /* OidcAdditionalTests.swift */; };
 		EC0CB5952E266F3900A82D6C /* Oidc.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0CB5942E266F3400A82D6C /* Oidc.swift */; };
 		EC23D5132E295AAE00C43D42 /* Web.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC23D5122E295AAB00C43D42 /* Web.swift */; };
 		EC23D5152E2E7A1700C43D42 /* OidcWebClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC23D5142E2E7A1100C43D42 /* OidcWebClientTests.swift */; };
+		SDKS4785A001 /* DeviceAuthorizationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS4785F001 /* DeviceAuthorizationResponse.swift */; };
+		SDKS4785A002 /* DeviceFlowStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS4785F002 /* DeviceFlowStatus.swift */; };
+		SDKS4785A003 /* OidcDeviceClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS4785F003 /* OidcDeviceClientTests.swift */; };
+		SDKS4785A004 /* OidcDeviceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS4785F004 /* OidcDeviceClient.swift */; };
+		SDKS4785A005 /* OidcDeviceClientAdditionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS4785F005 /* OidcDeviceClientAdditionalTests.swift */; };
+		SDKS50660004000000000002 /* JsonConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS50660004000000000001 /* JsonConfig.swift */; };
+		SDKS50660007000000000002 /* OidcWebClientJsonConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS50660007000000000001 /* OidcWebClientJsonConfigTests.swift */; };
+		SDKS50660008000000000002 /* OidcDeviceClientJsonConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS50660008000000000001 /* OidcDeviceClientJsonConfigTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -84,6 +87,8 @@
 		3AB1CA342BD884E4003FCE3C /* OidcClientConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcClientConfig.swift; sourceTree = "<group>"; };
 		3AB1CA3A2BD96089003FCE3C /* OidcUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcUser.swift; sourceTree = "<group>"; };
 		3AB1CA3C2BD961A2003FCE3C /* OidcClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcClient.swift; sourceTree = "<group>"; };
+		7101980CC54DBB835D4F7DB3 /* OidcClientPARTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcClientPARTests.swift; sourceTree = "<group>"; };
+		77E2E5250895DD43A8388F8A /* OidcAdditionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcAdditionalTests.swift; sourceTree = "<group>"; };
 		951773A72EA932A10081AEDE /* PingBrowser.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingBrowser.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A50966B52C4C342800A4E5B5 /* OidcError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcError.swift; sourceTree = "<group>"; };
 		A50966B72C4C34CB00A4E5B5 /* AuthCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCode.swift; sourceTree = "<group>"; };
@@ -94,8 +99,6 @@
 		A50966DE2C4DF3CD00A4E5B5 /* OidcClientConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcClientConfigTests.swift; sourceTree = "<group>"; };
 		A50966E02C4F1D9D00A4E5B5 /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
 		A50966E22C4F2F4300A4E5B5 /* OidcClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcClientTests.swift; sourceTree = "<group>"; };
-		7101980CC54DBB835D4F7DB3 /* OidcClientPARTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcClientPARTests.swift; sourceTree = "<group>"; };
-		77E2E5250895DD43A8388F8A /* OidcAdditionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcAdditionalTests.swift; sourceTree = "<group>"; };
 		A50966EE2C4FF75400A4E5B5 /* MockStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStorage.swift; sourceTree = "<group>"; };
 		A50967082C50843E00A4E5B5 /* MockAPIEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAPIEndpoint.swift; sourceTree = "<group>"; };
 		A50981BD2CEBDF1700F4B487 /* PingOrchestrate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingOrchestrate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -109,8 +112,11 @@
 		SDKS4785F001 /* DeviceAuthorizationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceAuthorizationResponse.swift; sourceTree = "<group>"; };
 		SDKS4785F002 /* DeviceFlowStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceFlowStatus.swift; sourceTree = "<group>"; };
 		SDKS4785F003 /* OidcDeviceClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcDeviceClientTests.swift; sourceTree = "<group>"; };
-		SDKS4785F005 /* OidcDeviceClientAdditionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcDeviceClientAdditionalTests.swift; sourceTree = "<group>"; };
 		SDKS4785F004 /* OidcDeviceClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcDeviceClient.swift; sourceTree = "<group>"; };
+		SDKS4785F005 /* OidcDeviceClientAdditionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcDeviceClientAdditionalTests.swift; sourceTree = "<group>"; };
+		SDKS50660004000000000001 /* JsonConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonConfig.swift; sourceTree = "<group>"; };
+		SDKS50660007000000000001 /* OidcWebClientJsonConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcWebClientJsonConfigTests.swift; sourceTree = "<group>"; };
+		SDKS50660008000000000001 /* OidcDeviceClientJsonConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OidcDeviceClientJsonConfigTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -175,6 +181,7 @@
 				A50966B72C4C34CB00A4E5B5 /* AuthCode.swift */,
 				SDKS4785F001 /* DeviceAuthorizationResponse.swift */,
 				SDKS4785F002 /* DeviceFlowStatus.swift */,
+				SDKS50660004000000000001 /* JsonConfig.swift */,
 				SDKS4785F004 /* OidcDeviceClient.swift */,
 				3AB1CA3C2BD961A2003FCE3C /* OidcClient.swift */,
 				3AB1CA342BD884E4003FCE3C /* OidcClientConfig.swift */,
@@ -195,11 +202,13 @@
 				A509D1CC2C6D04E9003A0006 /* mock */,
 				A50966DE2C4DF3CD00A4E5B5 /* OidcClientConfigTests.swift */,
 				A50966E22C4F2F4300A4E5B5 /* OidcClientTests.swift */,
-						7101980CC54DBB835D4F7DB3 /* OidcClientPARTests.swift */,
-						77E2E5250895DD43A8388F8A /* OidcAdditionalTests.swift */,
+				7101980CC54DBB835D4F7DB3 /* OidcClientPARTests.swift */,
+				77E2E5250895DD43A8388F8A /* OidcAdditionalTests.swift */,
 				SDKS4785F003 /* OidcDeviceClientTests.swift */,
 				SDKS4785F005 /* OidcDeviceClientAdditionalTests.swift */,
+				SDKS50660008000000000001 /* OidcDeviceClientJsonConfigTests.swift */,
 				EC23D5142E2E7A1100C43D42 /* OidcWebClientTests.swift */,
+				SDKS50660007000000000001 /* OidcWebClientJsonConfigTests.swift */,
 				A50966DA2C4DDFAE00A4E5B5 /* PkceTests.swift */,
 				A50966D42C4DD79000A4E5B5 /* TokenTests.swift */,
 			);
@@ -355,6 +364,7 @@
 				A50966B62C4C342800A4E5B5 /* OidcError.swift in Sources */,
 				3AB1CA2D2BD7727B003FCE3C /* Token.swift in Sources */,
 				3AB1CA352BD884E4003FCE3C /* OidcClientConfig.swift in Sources */,
+				SDKS50660004000000000002 /* JsonConfig.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -365,16 +375,18 @@
 				A50967092C50843E00A4E5B5 /* MockAPIEndpoint.swift in Sources */,
 				A50966DB2C4DDFAE00A4E5B5 /* PkceTests.swift in Sources */,
 				EC23D5152E2E7A1700C43D42 /* OidcWebClientTests.swift in Sources */,
+				SDKS50660007000000000002 /* OidcWebClientJsonConfigTests.swift in Sources */,
 				A50966EF2C4FF75400A4E5B5 /* MockStorage.swift in Sources */,
 				A50966DF2C4DF3CD00A4E5B5 /* OidcClientConfigTests.swift in Sources */,
 				A50966E12C4F1D9D00A4E5B5 /* MockURLProtocol.swift in Sources */,
 				A50966DD2C4DE4D700A4E5B5 /* MockResponse.swift in Sources */,
 				A50966D52C4DD79000A4E5B5 /* TokenTests.swift in Sources */,
 				A50966E32C4F2F4300A4E5B5 /* OidcClientTests.swift in Sources */,
-						700AADB6B22EDCF175F25320 /* OidcClientPARTests.swift in Sources */,
-						CE68EBE71BABE65295E0CFCA /* OidcAdditionalTests.swift in Sources */,
+				700AADB6B22EDCF175F25320 /* OidcClientPARTests.swift in Sources */,
+				CE68EBE71BABE65295E0CFCA /* OidcAdditionalTests.swift in Sources */,
 				SDKS4785A003 /* OidcDeviceClientTests.swift in Sources */,
 				SDKS4785A005 /* OidcDeviceClientAdditionalTests.swift in Sources */,
+				SDKS50660008000000000002 /* OidcDeviceClientJsonConfigTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -539,7 +551,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = "2.0.0";
+				MARKETING_VERSION = 2.0.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pingidentity.Oidc;
@@ -573,7 +585,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = "2.0.0";
+				MARKETING_VERSION = 2.0.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pingidentity.Oidc;
@@ -595,7 +607,7 @@
 				DEVELOPMENT_TEAM = 9QSE66762D;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				MARKETING_VERSION = "2.0.0";
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pingidentity.OidcTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -616,7 +628,7 @@
 				DEVELOPMENT_TEAM = 9QSE66762D;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				MARKETING_VERSION = "2.0.0";
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pingidentity.OidcTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;

--- a/Oidc/Oidc/JsonConfig.swift
+++ b/Oidc/Oidc/JsonConfig.swift
@@ -114,12 +114,12 @@ public struct JsonConfigParser {
         return value
     }
 
-    /// Parses `"log"` as a log-level string and returns the matching `Logger`. Defaults to `LogManager.none` when absent.
-    public func logLevel() throws -> Logger {
+    /// Parses `"log"` as a log-level string and returns the matching `Logger`. Defaults to `LogManager.logger` when absent.
+    /// A present but wrong-type value is silently ignored (falls back to `LogManager.none`) rather than throwing,
+    /// because log level is advisory and should never block SDK initialisation.
+    public func logLevel() -> Logger {
         guard let raw = json[JsonConfigKey.log] else { return LogManager.logger }
-        guard let level = raw as? String else {
-            throw JsonConfigError.invalidType(field: JsonConfigKey.log, expected: "string")
-        }
+        guard let level = raw as? String else { return LogManager.none }
         return LogManager.logger(forLevel: level)
     }
 

--- a/Oidc/Oidc/JsonConfig.swift
+++ b/Oidc/Oidc/JsonConfig.swift
@@ -15,8 +15,11 @@ import PingLogger
 public enum JsonConfigKey {
     // MARK: - Top-level
     public static let oidc = "oidc"
+    public static let journey = "journey"
     public static let log = "log"
     public static let timeout = "timeout"
+
+    // MARK: - journey sub-dict
     public static let serverUrl = "serverUrl"
     public static let realm = "realm"
     public static let cookieName = "cookieName"

--- a/Oidc/Oidc/JsonConfig.swift
+++ b/Oidc/Oidc/JsonConfig.swift
@@ -1,0 +1,131 @@
+//
+//  JsonConfig.swift
+//  PingOidc
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import Foundation
+import PingLogger
+
+/// Keys used in the unified SDK JSON configuration schema.
+public enum JsonConfigKey {
+    // MARK: - Top-level
+    public static let oidc = "oidc"
+    public static let log = "log"
+    public static let timeout = "timeout"
+    public static let serverUrl = "serverUrl"
+    public static let realm = "realm"
+    public static let cookieName = "cookieName"
+
+    // MARK: - oidc sub-dict — required
+    public static let clientId = "clientId"
+    public static let discoveryEndpoint = "discoveryEndpoint"
+    public static let redirectUri = "redirectUri"
+    public static let scopes = "scopes"
+
+    // MARK: - oidc sub-dict — optional
+    public static let signOutRedirectUri = "signOutRedirectUri"
+    public static let refreshThreshold = "refreshThreshold"
+    public static let par = "par"
+    public static let loginHint = "loginHint"
+    public static let state = "state"
+    public static let nonce = "nonce"
+    public static let display = "display"
+    public static let prompt = "prompt"
+    public static let uiLocales = "uiLocales"
+    public static let acrValues = "acrValues"
+    public static let additionalParameters = "additionalParameters"
+    public static let openId = "openId"
+
+    // MARK: - openId endpoint overrides
+    public static let authorizationEndpoint = "authorizationEndpoint"
+    public static let tokenEndpoint = "tokenEndpoint"
+    public static let userinfoEndpoint = "userinfoEndpoint"
+    public static let endSessionEndpoint = "endSessionEndpoint"
+    public static let revocationEndpoint = "revocationEndpoint"
+    public static let pushedAuthorizationRequestEndpoint = "pushedAuthorizationRequestEndpoint"
+    public static let deviceAuthorizationEndpoint = "deviceAuthorizationEndpoint"
+    public static let pingEndsessionEndpoint = "pingEndsessionEndpoint"
+}
+
+/// Errors thrown during JSON-based SDK configuration parsing.
+public enum JsonConfigError: Error, LocalizedError, Sendable {
+    /// A required field is absent from the JSON configuration.
+    case missingRequiredField(String)
+    /// A field is present but has an unexpected type.
+    case invalidType(field: String, expected: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingRequiredField(let field):
+            return "Missing required configuration field: '\(field)'"
+        case .invalidType(let field, let expected):
+            return "Invalid type for configuration field '\(field)': expected \(expected)"
+        }
+    }
+}
+
+// MARK: - JSON parsing
+
+/// Parses a unified SDK configuration dictionary.
+///
+/// Wraps a `[String: Any]` dictionary and provides typed accessors that throw
+/// `JsonConfigError` on missing or incorrectly-typed fields.
+public struct JsonConfigParser {
+    private let json: [String: Any]
+
+    public init(_ json: [String: Any]) {
+        self.json = json
+    }
+
+    /// Returns the value for `key` cast to `T`. Throws `.missingRequiredField` when absent, `.invalidType` on wrong type.
+    public func required<T>(_ key: String, field: String) throws -> T {
+        guard let raw = json[key] else {
+            throw JsonConfigError.missingRequiredField(field)
+        }
+        guard let value = raw as? T else {
+            throw JsonConfigError.invalidType(field: field, expected: String(describing: T.self))
+        }
+        return value
+    }
+
+    /// Returns the value for `key` cast to `T`, or `defaultValue` when absent. Throws `.invalidType` on wrong type.
+    public func optional<T>(_ key: String, field: String, default defaultValue: T) throws -> T {
+        guard let raw = json[key] else { return defaultValue }
+        guard let value = raw as? T else {
+            throw JsonConfigError.invalidType(field: field, expected: String(describing: T.self))
+        }
+        return value
+    }
+
+    /// Returns the value for `key` cast to `T`, or `nil` when absent. Throws `.invalidType` on wrong type.
+    public func optionalValue<T>(_ key: String, field: String) throws -> T? {
+        guard let raw = json[key] else { return nil }
+        guard let value = raw as? T else {
+            throw JsonConfigError.invalidType(field: field, expected: String(describing: T.self))
+        }
+        return value
+    }
+
+    /// Parses `"log"` as a log-level string and returns the matching `Logger`. Defaults to `LogManager.none` when absent.
+    public func logLevel() throws -> Logger {
+        guard let raw = json[JsonConfigKey.log] else { return LogManager.logger }
+        guard let level = raw as? String else {
+            throw JsonConfigError.invalidType(field: JsonConfigKey.log, expected: "string")
+        }
+        return LogManager.logger(forLevel: level)
+    }
+
+    /// Parses `"timeout"` as milliseconds and returns a `TimeInterval` in seconds. Defaults to `defaultValue` when absent.
+    public func timeoutSeconds(default defaultValue: TimeInterval = 15.0) throws -> TimeInterval {
+        guard let raw = json[JsonConfigKey.timeout] else { return defaultValue }
+        guard let ms = raw as? Int else {
+            throw JsonConfigError.invalidType(field: JsonConfigKey.timeout, expected: "int")
+        }
+        return Double(ms) / 1000.0
+    }
+}

--- a/Oidc/Oidc/OidcClientConfig.swift
+++ b/Oidc/Oidc/OidcClientConfig.swift
@@ -20,8 +20,19 @@ import PingStorage
 ///   Configure all properties before passing the instance to any client or workflow — do
 ///   not mutate it afterwards, as it may be read concurrently from background threads.
 public class OidcClientConfig: @unchecked Sendable {
+    nonisolated(unsafe) private static let endpointSetters: [(String, (inout OpenIdConfiguration, String) -> Void)] = [
+        (JsonConfigKey.authorizationEndpoint,              { $0.authorizationEndpoint = $1 }),
+        (JsonConfigKey.tokenEndpoint,                      { $0.tokenEndpoint = $1 }),
+        (JsonConfigKey.userinfoEndpoint,                   { $0.userinfoEndpoint = $1 }),
+        (JsonConfigKey.endSessionEndpoint,                 { $0.endSessionEndpoint = $1 }),
+        (JsonConfigKey.revocationEndpoint,                 { $0.revocationEndpoint = $1 }),
+        (JsonConfigKey.pushedAuthorizationRequestEndpoint, { $0.pushedAuthorizationRequestEndpoint = $1 }),
+        (JsonConfigKey.deviceAuthorizationEndpoint,        { $0.deviceAuthorizationEndpoint = $1 }),
+        (JsonConfigKey.pingEndsessionEndpoint,             { $0.pingEndsessionEndpoint = $1 }),
+    ]
+
     /// OpenID configuration.
-    public var openId: OpenIdConfiguration?
+    public private(set) var openId: OpenIdConfiguration?
     /// Token refresh threshold in seconds.
     public var refreshThreshold: Int64 = 0
     /// Agent delegate for handling OIDC operations.
@@ -83,6 +94,12 @@ public class OidcClientConfig: @unchecked Sendable {
         self.agent = AgentDelegate<T>(agent: agent, agentConfig: agent.config()(), oidcClientConfig: self)
     }
     
+    /// Injects a pre-built `OpenIdConfiguration`, skipping network discovery.
+    /// Intended for unit tests only — use `openIdOverride` for production endpoint patching.
+    func setOpenId(_ openId: OpenIdConfiguration?) {
+        self.openId = openId
+    }
+
     /// Initializes the lazy properties to their default values.
     public func oidcInitialize() async throws {
         if httpClient == nil {
@@ -123,6 +140,15 @@ public class OidcClientConfig: @unchecked Sendable {
         return configuration
     }
     
+    /// Creates an `OidcClientConfig` from an `oidc` sub-dictionary and a pre-resolved logger.
+    /// Used by all `createXxx(json:)` factories to avoid repeating the same construction sequence.
+    public static func from(oidcJson: [String: Any], logger: Logger) throws -> OidcClientConfig {
+        let config = OidcClientConfig()
+        config.logger = logger
+        try config.apply(json: oidcJson)
+        return config
+    }
+
     /// Clones the current configuration.
     /// - Returns: A new instance of OidcClientConfig with the same properties.
     public func clone() -> OidcClientConfig {
@@ -132,6 +158,12 @@ public class OidcClientConfig: @unchecked Sendable {
     }
     
     /// Merges another configuration into this one.
+    ///
+    /// - Important: This method is intended for **module wiring only** — it is called by the
+    ///   `createXxx(json:)` and `createXxx(block:)` factories to propagate a parsed config into
+    ///   a workflow module. Do **not** call this on an `OidcClientConfig` that has already been
+    ///   passed to a running workflow or client: it replaces every field including `storage` and
+    ///   `openId`, which can cause in-flight token reads to hit an unexpected (empty) keychain slot.
     /// - Parameter other: The other configuration to merge.
     public func update(with other: OidcClientConfig) {
         self.openId = other.openId
@@ -161,10 +193,11 @@ public class OidcClientConfig: @unchecked Sendable {
     /// Validates all required fields and writes every recognised field directly to `self`.
     /// Unknown fields (including `signOutRedirectUri`) are silently ignored for forward compatibility.
     ///
-    /// - Important: If the JSON contains an `openId` sub-object, this method **replaces**
-    ///   `openIdOverride` with a new closure derived from those values. Any `openIdOverride`
-    ///   set before calling this method will be lost. If the JSON contains no `openId` key,
-    ///   `openIdOverride` is left unchanged.
+    /// - Important: If the JSON contains an `openId` sub-object, this method **merges** the
+    ///   JSON-derived endpoint overrides with any existing `openIdOverride`. The existing closure
+    ///   runs first, then the JSON-derived overrides are applied on top, so the JSON values win
+    ///   for any endpoint key they cover. If the JSON contains no `openId` key, `openIdOverride`
+    ///   is left unchanged.
     ///
     /// - Parameter json: The `oidc` sub-dictionary from the unified SDK configuration schema.
     /// - Throws: `JsonConfigError` if a required field is absent or a field has the wrong type.
@@ -212,21 +245,10 @@ public class OidcClientConfig: @unchecked Sendable {
 
         // --- openId endpoint overrides (optional) ---
         // Maps to `openIdOverride` — applied after discovery completes (see oidcInitialize).
-        // To add a new endpoint: add one entry to this table; no other change required.
-        let endpointSetters: [(String, (inout OpenIdConfiguration, String) -> Void)] = [
-            (JsonConfigKey.authorizationEndpoint,              { $0.authorizationEndpoint = $1 }),
-            (JsonConfigKey.tokenEndpoint,                      { $0.tokenEndpoint = $1 }),
-            (JsonConfigKey.userinfoEndpoint,                   { $0.userinfoEndpoint = $1 }),
-            (JsonConfigKey.endSessionEndpoint,                 { $0.endSessionEndpoint = $1 }),
-            (JsonConfigKey.revocationEndpoint,                 { $0.revocationEndpoint = $1 }),
-            (JsonConfigKey.pushedAuthorizationRequestEndpoint, { $0.pushedAuthorizationRequestEndpoint = $1 }),
-            (JsonConfigKey.deviceAuthorizationEndpoint,        { $0.deviceAuthorizationEndpoint = $1 }),
-            (JsonConfigKey.pingEndsessionEndpoint,             { $0.pingEndsessionEndpoint = $1 }),
-        ]
-
+        // To add a new endpoint: add one entry to `endpointSetters`; no other change required.
         var parsedOpenIdOverrides = [String: String]()
         if let openIdDict: [String: Any] = try p.optionalValue(JsonConfigKey.openId, field: f(JsonConfigKey.openId)) {
-            for (key, _) in endpointSetters {
+            for (key, _) in OidcClientConfig.endpointSetters {
                 if let raw = openIdDict[key] {
                     guard let value = raw as? String else {
                         throw JsonConfigError.invalidType(field: fOpenId(key), expected: "string")
@@ -254,8 +276,10 @@ public class OidcClientConfig: @unchecked Sendable {
 
         if !parsedOpenIdOverrides.isEmpty {
             let overrides = parsedOpenIdOverrides
+            let existing = self.openIdOverride
             self.openIdOverride = { openId in
-                for (key, setter) in endpointSetters {
+                existing?(&openId)
+                for (key, setter) in OidcClientConfig.endpointSetters {
                     if let v = overrides[key] { setter(&openId, v) }
                 }
             }

--- a/Oidc/Oidc/OidcClientConfig.swift
+++ b/Oidc/Oidc/OidcClientConfig.swift
@@ -133,7 +133,7 @@ public class OidcClientConfig: @unchecked Sendable {
     
     /// Merges another configuration into this one.
     /// - Parameter other: The other configuration to merge.
-    func update(with other: OidcClientConfig) {
+    public func update(with other: OidcClientConfig) {
         self.openId = other.openId
         self.refreshThreshold = other.refreshThreshold
         self.agent = other.agent
@@ -155,4 +155,111 @@ public class OidcClientConfig: @unchecked Sendable {
         self.httpClient = other.httpClient
         self.openIdOverride = other.openIdOverride
     }
+    
+    /// Applies a unified JSON configuration dictionary to this instance.
+    ///
+    /// Validates all required fields and writes every recognised field directly to `self`.
+    /// Unknown fields (including `signOutRedirectUri`) are silently ignored for forward compatibility.
+    ///
+    /// - Important: If the JSON contains an `openId` sub-object, this method **replaces**
+    ///   `openIdOverride` with a new closure derived from those values. Any `openIdOverride`
+    ///   set before calling this method will be lost. If the JSON contains no `openId` key,
+    ///   `openIdOverride` is left unchanged.
+    ///
+    /// - Parameter json: The `oidc` sub-dictionary from the unified SDK configuration schema.
+    /// - Throws: `JsonConfigError` if a required field is absent or a field has the wrong type.
+    public func apply(json: [String: Any]) throws {
+        let p = JsonConfigParser(json)
+        let f: (String) -> String = { "\(JsonConfigKey.oidc).\($0)" }
+        let fOpenId: (String) -> String = { "\(JsonConfigKey.oidc).\(JsonConfigKey.openId).\($0)" }
+
+        // --- Required fields ---
+        let clientId: String          = try p.required(JsonConfigKey.clientId,          field: f(JsonConfigKey.clientId))
+        let discoveryEndpoint: String = try p.required(JsonConfigKey.discoveryEndpoint, field: f(JsonConfigKey.discoveryEndpoint))
+        let redirectUri: String       = try p.required(JsonConfigKey.redirectUri,       field: f(JsonConfigKey.redirectUri))
+
+        let rawScopes: [Any] = try p.required(JsonConfigKey.scopes, field: f(JsonConfigKey.scopes))
+        var parsedScopes = Set<String>()
+        for element in rawScopes {
+            guard let scope = element as? String else {
+                throw JsonConfigError.invalidType(field: f(JsonConfigKey.scopes), expected: "array of strings")
+            }
+            parsedScopes.insert(scope)
+        }
+
+        // --- Optional fields ---
+        let refreshThresholdInt: Int = try p.optional(JsonConfigKey.refreshThreshold, field: f(JsonConfigKey.refreshThreshold), default: 0)
+        let parsedPar: Bool          = try p.optional(JsonConfigKey.par,              field: f(JsonConfigKey.par),              default: false)
+
+        let loginHint:  String? = try p.optionalValue(JsonConfigKey.loginHint,  field: f(JsonConfigKey.loginHint))
+        let state:      String? = try p.optionalValue(JsonConfigKey.state,      field: f(JsonConfigKey.state))
+        let nonce:      String? = try p.optionalValue(JsonConfigKey.nonce,      field: f(JsonConfigKey.nonce))
+        let display:    String? = try p.optionalValue(JsonConfigKey.display,    field: f(JsonConfigKey.display))
+        let prompt:     String? = try p.optionalValue(JsonConfigKey.prompt,     field: f(JsonConfigKey.prompt))
+        let uiLocales:  String? = try p.optionalValue(JsonConfigKey.uiLocales,  field: f(JsonConfigKey.uiLocales))
+        let acrValues:  String? = try p.optionalValue(JsonConfigKey.acrValues,  field: f(JsonConfigKey.acrValues))
+
+        // --- additionalParameters ---
+        var parsedAdditional = [String: String]()
+        if let rawDict: [String: Any] = try p.optionalValue(JsonConfigKey.additionalParameters, field: f(JsonConfigKey.additionalParameters)) {
+            for (key, value) in rawDict {
+                guard let stringValue = value as? String else {
+                    throw JsonConfigError.invalidType(field: f("\(JsonConfigKey.additionalParameters).\(key)"), expected: "string")
+                }
+                parsedAdditional[key] = stringValue
+            }
+        }
+
+        // --- openId endpoint overrides (optional) ---
+        // Maps to `openIdOverride` — applied after discovery completes (see oidcInitialize).
+        // To add a new endpoint: add one entry to this table; no other change required.
+        let endpointSetters: [(String, (inout OpenIdConfiguration, String) -> Void)] = [
+            (JsonConfigKey.authorizationEndpoint,              { $0.authorizationEndpoint = $1 }),
+            (JsonConfigKey.tokenEndpoint,                      { $0.tokenEndpoint = $1 }),
+            (JsonConfigKey.userinfoEndpoint,                   { $0.userinfoEndpoint = $1 }),
+            (JsonConfigKey.endSessionEndpoint,                 { $0.endSessionEndpoint = $1 }),
+            (JsonConfigKey.revocationEndpoint,                 { $0.revocationEndpoint = $1 }),
+            (JsonConfigKey.pushedAuthorizationRequestEndpoint, { $0.pushedAuthorizationRequestEndpoint = $1 }),
+            (JsonConfigKey.deviceAuthorizationEndpoint,        { $0.deviceAuthorizationEndpoint = $1 }),
+            (JsonConfigKey.pingEndsessionEndpoint,             { $0.pingEndsessionEndpoint = $1 }),
+        ]
+
+        var parsedOpenIdOverrides = [String: String]()
+        if let openIdDict: [String: Any] = try p.optionalValue(JsonConfigKey.openId, field: f(JsonConfigKey.openId)) {
+            for (key, _) in endpointSetters {
+                if let raw = openIdDict[key] {
+                    guard let value = raw as? String else {
+                        throw JsonConfigError.invalidType(field: fOpenId(key), expected: "string")
+                    }
+                    parsedOpenIdOverrides[key] = value
+                }
+            }
+        }
+
+        // All validation passed — apply to self
+        self.clientId = clientId
+        self.discoveryEndpoint = discoveryEndpoint
+        self.scopes = parsedScopes
+        self.redirectUri = redirectUri
+        self.refreshThreshold = Int64(refreshThresholdInt)
+        self.par = parsedPar
+        self.loginHint = loginHint
+        self.state = state
+        self.nonce = nonce
+        self.display = display
+        self.prompt = prompt
+        self.uiLocales = uiLocales
+        self.acrValues = acrValues
+        self.additionalParameters = parsedAdditional
+
+        if !parsedOpenIdOverrides.isEmpty {
+            let overrides = parsedOpenIdOverrides
+            self.openIdOverride = { openId in
+                for (key, setter) in endpointSetters {
+                    if let v = overrides[key] { setter(&openId, v) }
+                }
+            }
+        }
+    }
+
 }

--- a/Oidc/Oidc/OidcDeviceClient.swift
+++ b/Oidc/Oidc/OidcDeviceClient.swift
@@ -37,7 +37,7 @@ public class OidcDeviceClient: @unchecked Sendable {
     }
 
     private let config: OidcClientConfig
-    private let logger: Logger
+    let logger: Logger
 
     /// Initializes a new `OidcDeviceClient`.
     /// - Parameter config: The OIDC client configuration to use.
@@ -53,6 +53,36 @@ public class OidcDeviceClient: @unchecked Sendable {
         let config = OidcClientConfig()
         block(config)
         return OidcDeviceClient(config: config)
+    }
+
+    /// Creates an `OidcDeviceClient` from a unified JSON configuration dictionary.
+    ///
+    /// Parses and validates the platform-neutral schema and delegates to
+    /// `createOidcDeviceClient(block:)` with the extracted values. Unknown fields are
+    /// silently ignored for forward compatibility.
+    ///
+    /// Endpoint overrides (e.g. `deviceAuthorizationEndpoint`) are expressed as an
+    /// `openId` sub-object inside `oidc` and applied after OIDC discovery completes,
+    /// mirroring the `openIdOverride` closure on `OidcClientConfig`.
+    ///
+    /// - Parameter json: A `[String: Any]` dictionary conforming to the unified SDK
+    ///   configuration schema.
+    /// - Returns: `.success(OidcDeviceClient)` on valid input, `.failure(JsonConfigError)`
+    ///   if a required field is absent or a field has the wrong type.
+    public static func createOidcDeviceClient(json: [String: Any]) -> Result<OidcDeviceClient, Error> {
+        do {
+            let p = JsonConfigParser(json)
+            let logger = try p.logLevel()
+            let oidcDict: [String: Any] = try p.required(JsonConfigKey.oidc, field: JsonConfigKey.oidc)
+
+            let oidcConfig = OidcClientConfig()
+            oidcConfig.logger = logger
+            try oidcConfig.apply(json: oidcDict)
+
+            return .success(OidcDeviceClient(config: oidcConfig))
+        } catch {
+            return .failure(error)
+        }
     }
 
     // MARK: - Device Authorization

--- a/Oidc/Oidc/OidcDeviceClient.swift
+++ b/Oidc/Oidc/OidcDeviceClient.swift
@@ -72,12 +72,10 @@ public class OidcDeviceClient: @unchecked Sendable {
     public static func createOidcDeviceClient(json: [String: Any]) -> Result<OidcDeviceClient, Error> {
         do {
             let p = JsonConfigParser(json)
-            let logger = try p.logLevel()
+            let logger = p.logLevel()
             let oidcDict: [String: Any] = try p.required(JsonConfigKey.oidc, field: JsonConfigKey.oidc)
 
-            let oidcConfig = OidcClientConfig()
-            oidcConfig.logger = logger
-            try oidcConfig.apply(json: oidcDict)
+            let oidcConfig = try OidcClientConfig.from(oidcJson: oidcDict, logger: logger)
 
             return .success(OidcDeviceClient(config: oidcConfig))
         } catch {

--- a/Oidc/Oidc/OidcWebClient.swift
+++ b/Oidc/Oidc/OidcWebClient.swift
@@ -9,6 +9,7 @@
 //
 
 
+import Foundation
 import PingOrchestrate
 import PingLogger
 import PingBrowser
@@ -50,6 +51,40 @@ public extension OidcWebClient {
         return OidcWebClient(config: config)
     }
     
+    /// Creates an OidcWebClient instance from a JSON dictionary.
+    ///
+    /// This factory parses and validates a platform-neutral JSON configuration and
+    /// delegates to `createOidcWebClient(block:)` with the extracted values. Unknown
+    /// fields are silently ignored for forward compatibility.
+    ///
+    /// - Parameter json: A `[String: Any]` dictionary conforming to the unified SDK
+    ///   configuration schema (see design doc for field reference).
+    /// - Returns: `.success(OidcWebClient)` on valid input, `.failure(JsonConfigError)` if a
+    ///   required field is absent or a field has the wrong type.
+    static func createOidcWebClient(json: [String: Any]) -> Result<OidcWebClient, Error> {
+        do {
+            let p = JsonConfigParser(json)
+            let timeout = try p.timeoutSeconds()
+            let logger  = try p.logLevel()
+            let oidcDict: [String: Any] = try p.required(JsonConfigKey.oidc, field: JsonConfigKey.oidc)
+
+            let oidcConfig = OidcClientConfig()
+            oidcConfig.logger = logger
+            try oidcConfig.apply(json: oidcDict)
+
+            let client = OidcWebClient.createOidcWebClient { webConfig in
+                webConfig.timeout = timeout
+                webConfig.logger = logger
+                webConfig.module(OidcModule.config) { moduleOidcConfig in
+                    moduleOidcConfig.update(with: oidcConfig)
+                }
+            }
+            return .success(client)
+        } catch {
+            return .failure(error)
+        }
+    }
+
     /// This method initializes the OIDC client and starts the login process.
     /// - Parameter configure: A closure to configure the OIDC options.
     /// - Returns: A Result containing the User or an OidcError.

--- a/Oidc/Oidc/OidcWebClient.swift
+++ b/Oidc/Oidc/OidcWebClient.swift
@@ -65,12 +65,10 @@ public extension OidcWebClient {
         do {
             let p = JsonConfigParser(json)
             let timeout = try p.timeoutSeconds()
-            let logger  = try p.logLevel()
+            let logger  = p.logLevel()
             let oidcDict: [String: Any] = try p.required(JsonConfigKey.oidc, field: JsonConfigKey.oidc)
 
-            let oidcConfig = OidcClientConfig()
-            oidcConfig.logger = logger
-            try oidcConfig.apply(json: oidcDict)
+            let oidcConfig = try OidcClientConfig.from(oidcJson: oidcDict, logger: logger)
 
             let client = OidcWebClient.createOidcWebClient { webConfig in
                 webConfig.timeout = timeout

--- a/Oidc/Oidc/OpenIdConfiguration.swift
+++ b/Oidc/Oidc/OpenIdConfiguration.swift
@@ -14,19 +14,19 @@ import Foundation
 /// Struct representing the OpenID Connect configuration.
 public struct OpenIdConfiguration: Codable, Sendable {
     /// The URL of the authorization endpoint.
-    public let authorizationEndpoint: String
+    public var authorizationEndpoint: String
     /// The URL of the token endpoint.
-    public let tokenEndpoint: String
+    public var tokenEndpoint: String
     /// The URL of the userinfo endpoint.
-    public let userinfoEndpoint: String
+    public var userinfoEndpoint: String
     /// The URL of the end session endpoint.
-    public let endSessionEndpoint: String
+    public var endSessionEndpoint: String
     /// The URL of the revocation endpoint.
-    public let revocationEndpoint: String
+    public var revocationEndpoint: String
     /// The URL of the end session endpoint.
-    public let pingEndsessionEndpoint: String?
+    public var pingEndsessionEndpoint: String?
     /// The URL of the pushed authorization request endpoint (PAR, RFC 9126).
-    public let pushedAuthorizationRequestEndpoint: String?
+    public var pushedAuthorizationRequestEndpoint: String?
     /// The URL of the device authorization endpoint (RFC 8628).
     public var deviceAuthorizationEndpoint: String?
 

--- a/Oidc/OidcTests/OidcDeviceClientAdditionalTests.swift
+++ b/Oidc/OidcTests/OidcDeviceClientAdditionalTests.swift
@@ -37,7 +37,7 @@ class OidcDeviceClientAdditionalTests: XCTestCase {
         config.redirectUri = "org.forgerock.demo://oauth2redirect"
         config.storage = MockStorage<Token>()
         config.httpClient = MockURLProtocol.makeClient()
-        config.openId = makeOpenIdConfig(includeDeviceEndpoint: includeDeviceEndpoint)
+        config.setOpenId(makeOpenIdConfig(includeDeviceEndpoint: includeDeviceEndpoint))
         return config
     }
 

--- a/Oidc/OidcTests/OidcDeviceClientJsonConfigTests.swift
+++ b/Oidc/OidcTests/OidcDeviceClientJsonConfigTests.swift
@@ -134,16 +134,17 @@ final class OidcDeviceClientJsonConfigTests: XCTestCase, @unchecked Sendable {
         XCTAssertTrue(client.logger is WarningLogger)
     }
 
-    func testCreateOidcDeviceClient_failure_logWrongType() {
+    func testCreateOidcDeviceClient_logWrongType_softFault_succeeds() {
         var json = minimalJson
         json["log"] = 1
 
         let result = OidcDeviceClient.createOidcDeviceClient(json: json)
-        guard case .failure(let error) = result,
-              case .invalidType(let field, _) = error as? JsonConfigError else {
-            XCTFail("Expected invalidType(log), got: \(result)"); return
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            XCTFail("Expected success when log has wrong type (soft fault), got: \(error)")
         }
-        XCTAssertEqual(field, "log")
     }
 
     // MARK: - oidc (required)

--- a/Oidc/OidcTests/OidcDeviceClientJsonConfigTests.swift
+++ b/Oidc/OidcTests/OidcDeviceClientJsonConfigTests.swift
@@ -1,0 +1,368 @@
+//
+//  OidcDeviceClientJsonConfigTests.swift
+//  OidcTests
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+@testable import PingOidc
+@testable import PingLogger
+
+final class OidcDeviceClientJsonConfigTests: XCTestCase, @unchecked Sendable {
+
+    private var minimalJson: [String: Any] {
+        [
+            "oidc": [
+                "clientId": "my-client",
+                "discoveryEndpoint": "https://example.com/.well-known/openid-configuration",
+                "scopes": ["openid"],
+                "redirectUri": "myapp://callback"
+            ] as [String: Any]
+        ]
+    }
+
+    private var fullJson: [String: Any] {
+        [
+            "log": "DEBUG",
+            "oidc": [
+                "clientId": "my-client",
+                "discoveryEndpoint": "https://example.com/.well-known/openid-configuration",
+                "scopes": ["openid", "profile", "email"],
+                "redirectUri": "myapp://callback",
+                "signOutRedirectUri": "myapp://logout",
+                "refreshThreshold": 30,
+                "acrValues": "Level3",
+                "additionalParameters": ["custom": "value"],
+                "openId": [
+                    "deviceAuthorizationEndpoint": "https://example.com/device/code"
+                ] as [String: Any]
+            ] as [String: Any]
+        ]
+    }
+
+    // MARK: - Success cases
+
+    func testCreateOidcDeviceClient_success_minimalRequiredFields() {
+        let result = OidcDeviceClient.createOidcDeviceClient(json: minimalJson)
+        switch result {
+        case .success: break
+        case .failure(let error): XCTFail("Expected success, got: \(error)")
+        }
+    }
+
+    func testCreateOidcDeviceClient_success_allFields() {
+        let result = OidcDeviceClient.createOidcDeviceClient(json: fullJson)
+        switch result {
+        case .success: break
+        case .failure(let error): XCTFail("Expected success, got: \(error)")
+        }
+    }
+
+    func testCreateOidcDeviceClient_unknownFieldsSilentlyIgnored() {
+        var json = minimalJson
+        json["unknownTopLevel"] = "ignored"
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["unknownOidcField"] = 42
+        json["oidc"] = oidc
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        switch result {
+        case .success: break
+        case .failure(let error): XCTFail("Unknown fields should be silently ignored, got: \(error)")
+        }
+    }
+
+    func testCreateOidcDeviceClient_journeyFieldsSilentlyIgnored() {
+        var json = minimalJson
+        json["serverUrl"] = "https://example.com/am"
+        json["realm"] = "alpha"
+        json["cookieName"] = "iPlanetDirectoryPro"
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        switch result {
+        case .success: break
+        case .failure(let error): XCTFail("Journey-specific fields should be silently ignored, got: \(error)")
+        }
+    }
+
+    // MARK: - timeout
+
+    func testCreateOidcDeviceClient_timeout_validInteger_succeeds() {
+        var json = minimalJson
+        json["timeout"] = 20000
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        switch result {
+        case .success: break
+        case .failure(let error): XCTFail("Expected success with valid timeout, got: \(error)")
+        }
+    }
+
+    func testCreateOidcDeviceClient_timeout_absent_succeeds() {
+        let result = OidcDeviceClient.createOidcDeviceClient(json: minimalJson)
+        switch result {
+        case .success: break
+        case .failure(let error): XCTFail("Expected success when timeout absent, got: \(error)")
+        }
+    }
+
+    // MARK: - log
+
+    func testCreateOidcDeviceClient_logMapping_debug() {
+        var json = minimalJson
+        json["log"] = "DEBUG"
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        guard case .success(let client) = result else {
+            XCTFail("Expected success"); return
+        }
+        XCTAssertTrue(client.logger is StandardLogger)
+    }
+
+    func testCreateOidcDeviceClient_logMapping_warn() {
+        var json = minimalJson
+        json["log"] = "WARN"
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        guard case .success(let client) = result else {
+            XCTFail("Expected success"); return
+        }
+        XCTAssertTrue(client.logger is WarningLogger)
+    }
+
+    func testCreateOidcDeviceClient_failure_logWrongType() {
+        var json = minimalJson
+        json["log"] = 1
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(log), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "log")
+    }
+
+    // MARK: - oidc (required)
+
+    func testCreateOidcDeviceClient_failure_missingOidc() {
+        var json = minimalJson
+        json.removeValue(forKey: "oidc")
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(oidc), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "oidc")
+    }
+
+    func testCreateOidcDeviceClient_failure_oidcWrongType() {
+        var json = minimalJson
+        json["oidc"] = "not-an-object"
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(oidc), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "oidc")
+    }
+
+    // MARK: - Required OIDC fields
+
+    func testCreateOidcDeviceClient_failure_missingClientId() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc.removeValue(forKey: "clientId")
+        json["oidc"] = oidc
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(oidc.clientId), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "oidc.clientId")
+    }
+
+    func testCreateOidcDeviceClient_failure_missingDiscoveryEndpoint() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc.removeValue(forKey: "discoveryEndpoint")
+        json["oidc"] = oidc
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(oidc.discoveryEndpoint), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "oidc.discoveryEndpoint")
+    }
+
+    func testCreateOidcDeviceClient_failure_missingScopes() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc.removeValue(forKey: "scopes")
+        json["oidc"] = oidc
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(oidc.scopes), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "oidc.scopes")
+    }
+
+    func testCreateOidcDeviceClient_failure_missingRedirectUri() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc.removeValue(forKey: "redirectUri")
+        json["oidc"] = oidc
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(oidc.redirectUri), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "oidc.redirectUri")
+    }
+
+    func testCreateOidcDeviceClient_failure_scopesNotStringArray() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["scopes"] = [1, 2, 3]
+        json["oidc"] = oidc
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(oidc.scopes), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "oidc.scopes")
+    }
+
+    // MARK: - openId endpoint overrides
+
+    func testCreateOidcDeviceClient_openId_absent_succeeds() {
+        let result = OidcDeviceClient.createOidcDeviceClient(json: minimalJson)
+        switch result {
+        case .success: break
+        case .failure(let error): XCTFail("Expected success when openId absent, got: \(error)")
+        }
+    }
+
+    func testCreateOidcDeviceClient_openId_deviceAuthorizationEndpoint_accepted() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["openId"] = ["deviceAuthorizationEndpoint": "https://example.com/device/code"] as [String: Any]
+        json["oidc"] = oidc
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        switch result {
+        case .success: break
+        case .failure(let error): XCTFail("Expected success with deviceAuthorizationEndpoint, got: \(error)")
+        }
+    }
+
+    func testCreateOidcDeviceClient_failure_openIdWrongType() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["openId"] = "not-an-object"
+        json["oidc"] = oidc
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(openId), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "oidc.openId")
+    }
+
+    func testCreateOidcDeviceClient_failure_openId_deviceAuthorizationEndpoint_wrongType() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["openId"] = ["deviceAuthorizationEndpoint": 123] as [String: Any]
+        json["oidc"] = oidc
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(oidc.openId.deviceAuthorizationEndpoint), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "oidc.openId.deviceAuthorizationEndpoint")
+    }
+
+    func testCreateOidcDeviceClient_openId_unknownKeysSilentlyIgnored() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["openId"] = ["unknownEndpoint": "https://example.com/unknown"] as [String: Any]
+        json["oidc"] = oidc
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        switch result {
+        case .success: break
+        case .failure(let error): XCTFail("Unknown openId keys should be silently ignored, got: \(error)")
+        }
+    }
+
+    func testCreateOidcDeviceClient_signOutRedirectUri_silentlyIgnored() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["signOutRedirectUri"] = "myapp://logout"
+        json["oidc"] = oidc
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        switch result {
+        case .success: break
+        case .failure(let error): XCTFail("signOutRedirectUri should be silently ignored, got: \(error)")
+        }
+    }
+
+    func testCreateOidcDeviceClient_failure_additionalParametersNonStringValue() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["additionalParameters"] = ["key": 123]
+        json["oidc"] = oidc
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType for additionalParameters, got: \(result)"); return
+        }
+        XCTAssertTrue(field.hasPrefix("oidc.additionalParameters"))
+    }
+
+    // MARK: - par
+
+    func testCreateOidcDeviceClient_par_true_accepted() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["par"] = true
+        json["oidc"] = oidc
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            XCTFail("Expected success with par=true, got: \(error)")
+        }
+    }
+
+    func testCreateOidcDeviceClient_failure_par_wrongType() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["par"] = "yes"
+        json["oidc"] = oidc
+
+        let result = OidcDeviceClient.createOidcDeviceClient(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(oidc.par), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "oidc.par")
+    }
+}

--- a/Oidc/OidcTests/OidcDeviceClientTests.swift
+++ b/Oidc/OidcTests/OidcDeviceClientTests.swift
@@ -140,7 +140,7 @@ class OidcDeviceClientTests: XCTestCase {
         config.storage = MockStorage<Token>()
         config.httpClient = MockURLProtocol.makeClient()
         // Set openId directly so oidcInitialize() skips real discovery
-        config.openId = makeOpenIdConfig(includeDeviceEndpoint: includeDeviceEndpoint)
+        config.setOpenId(makeOpenIdConfig(includeDeviceEndpoint: includeDeviceEndpoint))
         return config
     }
 

--- a/Oidc/OidcTests/OidcWebClientJsonConfigTests.swift
+++ b/Oidc/OidcTests/OidcWebClientJsonConfigTests.swift
@@ -129,16 +129,17 @@ final class OidcWebClientJsonConfigTests: XCTestCase, @unchecked Sendable {
         XCTAssertTrue(client.config.logger is WarningLogger)
     }
 
-    func testCreateOidcWebClient_failure_logWrongType() {
+    func testCreateOidcWebClient_logWrongType_softFault_succeeds() {
         var json = minimalJson
         json["log"] = 1
 
         let result = OidcWebClient.createOidcWebClient(json: json)
-        guard case .failure(let error) = result,
-              case .invalidType(let field, _) = error as? JsonConfigError else {
-            XCTFail("Expected invalidType(log), got: \(result)"); return
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            XCTFail("Expected success when log has wrong type (soft fault), got: \(error)")
         }
-        XCTAssertEqual(field, "log")
     }
 
     // MARK: - oidc (required)

--- a/Oidc/OidcTests/OidcWebClientJsonConfigTests.swift
+++ b/Oidc/OidcTests/OidcWebClientJsonConfigTests.swift
@@ -1,0 +1,284 @@
+//
+//  OidcWebClientJsonConfigTests.swift
+//  OidcTests
+//
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+@testable import PingOidc
+@testable import PingLogger
+
+final class OidcWebClientJsonConfigTests: XCTestCase, @unchecked Sendable {
+
+    private var minimalJson: [String: Any] {
+        [
+            "oidc": [
+                "clientId": "my-client",
+                "discoveryEndpoint": "https://example.com/.well-known/openid-configuration",
+                "scopes": ["openid"],
+                "redirectUri": "myapp://callback"
+            ] as [String: Any]
+        ]
+    }
+
+    private var fullJson: [String: Any] {
+        [
+            "timeout": 20000,
+            "log": "DEBUG",
+            "oidc": [
+                "clientId": "my-client",
+                "discoveryEndpoint": "https://example.com/.well-known/openid-configuration",
+                "scopes": ["openid", "profile", "email"],
+                "redirectUri": "myapp://callback",
+                "signOutRedirectUri": "myapp://logout",
+                "refreshThreshold": 30,
+                "acrValues": "Level3",
+                "additionalParameters": ["custom": "value"]
+            ] as [String: Any]
+        ]
+    }
+
+    // MARK: - Success cases
+
+    func testCreateOidcWebClient_success_minimalRequiredFields() {
+        let result = OidcWebClient.createOidcWebClient(json: minimalJson)
+        switch result {
+        case .success: break
+        case .failure(let error): XCTFail("Expected success, got: \(error)")
+        }
+    }
+
+    func testCreateOidcWebClient_success_allFields() {
+        let result = OidcWebClient.createOidcWebClient(json: fullJson)
+        switch result {
+        case .success: break
+        case .failure(let error): XCTFail("Expected success, got: \(error)")
+        }
+    }
+
+    func testCreateOidcWebClient_unknownFieldsSilentlyIgnored() {
+        var json = minimalJson
+        json["unknownField"] = "ignored"
+        json["serverUrl"] = "https://example.com/am"
+
+        let result = OidcWebClient.createOidcWebClient(json: json)
+        switch result {
+        case .success: break
+        case .failure(let error): XCTFail("Unknown fields should be silently ignored, got: \(error)")
+        }
+    }
+
+    // MARK: - timeout
+
+    func testCreateOidcWebClient_timeoutConversion() {
+        var json = minimalJson
+        json["timeout"] = 20000
+
+        let result = OidcWebClient.createOidcWebClient(json: json)
+        guard case .success(let client) = result else {
+            XCTFail("Expected success"); return
+        }
+        XCTAssertEqual(client.config.timeout, 20.0, accuracy: 0.001)
+    }
+
+    func testCreateOidcWebClient_timeoutDefault() {
+        let result = OidcWebClient.createOidcWebClient(json: minimalJson)
+        guard case .success(let client) = result else {
+            XCTFail("Expected success"); return
+        }
+        XCTAssertEqual(client.config.timeout, 15.0, accuracy: 0.001)
+    }
+
+    func testCreateOidcWebClient_failure_timeoutWrongType() {
+        var json = minimalJson
+        json["timeout"] = "20000"
+
+        let result = OidcWebClient.createOidcWebClient(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(timeout), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "timeout")
+    }
+
+    // MARK: - log
+
+    func testCreateOidcWebClient_logMapping_debug() {
+        var json = minimalJson
+        json["log"] = "DEBUG"
+
+        let result = OidcWebClient.createOidcWebClient(json: json)
+        guard case .success(let client) = result else {
+            XCTFail("Expected success"); return
+        }
+        XCTAssertTrue(client.config.logger is StandardLogger)
+    }
+
+    func testCreateOidcWebClient_logMapping_warn() {
+        var json = minimalJson
+        json["log"] = "WARN"
+
+        let result = OidcWebClient.createOidcWebClient(json: json)
+        guard case .success(let client) = result else {
+            XCTFail("Expected success"); return
+        }
+        XCTAssertTrue(client.config.logger is WarningLogger)
+    }
+
+    func testCreateOidcWebClient_failure_logWrongType() {
+        var json = minimalJson
+        json["log"] = 1
+
+        let result = OidcWebClient.createOidcWebClient(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(log), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "log")
+    }
+
+    // MARK: - oidc (required)
+
+    func testCreateOidcWebClient_failure_missingOidc() {
+        var json = minimalJson
+        json.removeValue(forKey: "oidc")
+
+        let result = OidcWebClient.createOidcWebClient(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(oidc), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "oidc")
+    }
+
+    func testCreateOidcWebClient_failure_oidcWrongType() {
+        var json = minimalJson
+        json["oidc"] = "not-an-object"
+
+        let result = OidcWebClient.createOidcWebClient(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(oidc), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "oidc")
+    }
+
+    func testCreateOidcWebClient_failure_missingClientId() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc.removeValue(forKey: "clientId")
+        json["oidc"] = oidc
+
+        let result = OidcWebClient.createOidcWebClient(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(oidc.clientId), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "oidc.clientId")
+    }
+
+    func testCreateOidcWebClient_failure_missingDiscoveryEndpoint() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc.removeValue(forKey: "discoveryEndpoint")
+        json["oidc"] = oidc
+
+        let result = OidcWebClient.createOidcWebClient(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(oidc.discoveryEndpoint), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "oidc.discoveryEndpoint")
+    }
+
+    func testCreateOidcWebClient_failure_missingScopes() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc.removeValue(forKey: "scopes")
+        json["oidc"] = oidc
+
+        let result = OidcWebClient.createOidcWebClient(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(oidc.scopes), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "oidc.scopes")
+    }
+
+    func testCreateOidcWebClient_failure_missingRedirectUri() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc.removeValue(forKey: "redirectUri")
+        json["oidc"] = oidc
+
+        let result = OidcWebClient.createOidcWebClient(json: json)
+        guard case .failure(let error) = result,
+              case .missingRequiredField(let field) = error as? JsonConfigError else {
+            XCTFail("Expected missingRequiredField(oidc.redirectUri), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "oidc.redirectUri")
+    }
+
+    func testCreateOidcWebClient_failure_scopesNotStringArray() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["scopes"] = [1, 2, 3]
+        json["oidc"] = oidc
+
+        let result = OidcWebClient.createOidcWebClient(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(oidc.scopes), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "oidc.scopes")
+    }
+
+    func testCreateOidcWebClient_failure_additionalParametersNonStringValue() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["additionalParameters"] = ["key": 123]
+        json["oidc"] = oidc
+
+        let result = OidcWebClient.createOidcWebClient(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType for additionalParameters, got: \(result)"); return
+        }
+        XCTAssertTrue(field.hasPrefix("oidc.additionalParameters"))
+    }
+
+    // MARK: - par
+
+    func testCreateOidcWebClient_par_true_accepted() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["par"] = true
+        json["oidc"] = oidc
+
+        let result = OidcWebClient.createOidcWebClient(json: json)
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            XCTFail("Expected success with par=true, got: \(error)")
+        }
+    }
+
+    func testCreateOidcWebClient_failure_par_wrongType() {
+        var json = minimalJson
+        var oidc = json["oidc"] as! [String: Any]
+        oidc["par"] = "yes"
+        json["oidc"] = oidc
+
+        let result = OidcWebClient.createOidcWebClient(json: json)
+        guard case .failure(let error) = result,
+              case .invalidType(let field, _) = error as? JsonConfigError else {
+            XCTFail("Expected invalidType(oidc.par), got: \(result)"); return
+        }
+        XCTAssertEqual(field, "oidc.par")
+    }
+}

--- a/Oidc/README.md
+++ b/Oidc/README.md
@@ -283,6 +283,72 @@ let oidcLogin = OidcWebClient.createOidcWebClient { config in
 }
 ```
 
+## JSON Configuration
+
+Both `OidcWebClient` and `OidcDeviceClient` can be initialised from a platform-neutral dictionary, enabling config-file-driven setup.
+
+### OidcWebClient
+
+```swift
+let json: [String: Any] = [
+    "timeout": 30000,          // milliseconds — optional, default 15 s
+    "log": "DEBUG",            // optional
+    "oidc": [
+        "clientId": "your-client-id",
+        "discoveryEndpoint": "https://auth.example.com/.well-known/openid-configuration",
+        "redirectUri": "myapp://callback",
+        "scopes": ["openid", "profile", "email"],
+        // --- optional ---
+        "par": true,
+        "acrValues": "policy-id",
+        "signOutRedirectUri": "myapp://logout"
+    ] as [String: Any]
+]
+
+switch OidcWebClient.createOidcWebClient(json: json) {
+case .success(let client):
+    let result = try await client.authorize()
+case .failure(let error):
+    print("Configuration error: \(error.localizedDescription)")
+}
+```
+
+### OidcDeviceClient
+
+```swift
+let json: [String: Any] = [
+    "log": "WARN",             // optional
+    "oidc": [
+        "clientId": "your-client-id",
+        "discoveryEndpoint": "https://auth.example.com/.well-known/openid-configuration",
+        "redirectUri": "myapp://callback",
+        "scopes": ["openid"],
+        // override the device authorization endpoint if not in discovery
+        "openId": [
+            "deviceAuthorizationEndpoint": "https://auth.example.com/device/code"
+        ] as [String: Any]
+    ] as [String: Any]
+]
+
+switch OidcDeviceClient.createOidcDeviceClient(json: json) {
+case .success(let client):
+    let stream = try await client.deviceAuthorization()
+case .failure(let error):
+    print("Configuration error: \(error.localizedDescription)")
+}
+```
+
+> **Note:** The top-level `timeout` key is not applied to `OidcDeviceClient` — the device flow HTTP client uses the framework default. Configure the device authorization endpoint via the `openId` override block if it is not advertised in the OIDC discovery document.
+
+### Error handling
+
+On invalid input both factories return `.failure(JsonConfigError)`:
+
+| Error | Cause |
+|-------|-------|
+| `missingRequiredField(String)` | A required field is absent |
+| `invalidType(field:expected:)` | A field has the wrong type |
+
 ## License
 
 This software may be modified and distributed under the terms of the MIT license. See the LICENSE file for details.

--- a/SampleApps/PingExample/PingExample.xcodeproj/project.pbxproj
+++ b/SampleApps/PingExample/PingExample.xcodeproj/project.pbxproj
@@ -118,7 +118,6 @@
 		A5E9AED62D30393F000533ED /* LoggerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E9AED52D30393B000533ED /* LoggerView.swift */; };
 		A5E9AED82D303962000533ED /* StorageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E9AED72D30395D000533ED /* StorageView.swift */; };
 		A5E9AEDB2D30A020000533ED /* LabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E9AEDA2D30A01D000533ED /* LabelView.swift */; };
-		SDKS42450002000000000001 /* RichTextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS42450002000000000000 /* RichTextBuilder.swift */; };
 		A5E9AEDD2D30A22A000533ED /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E9AEDC2D30A226000533ED /* TextView.swift */; };
 		A5E9AEDF2D30CA34000533ED /* ErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E9AEDE2D30CA2C000533ED /* ErrorMessageView.swift */; };
 		A5E9AEE12D30D304000533ED /* SubmitButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E9AEE02D30D301000533ED /* SubmitButtonView.swift */; };
@@ -132,6 +131,8 @@
 		ABCD12340001000100010001 /* TabPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCD12340001000100010002 /* TabPicker.swift */; };
 		ABCD12340002000200020001 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCD12340002000200020002 /* EmptyStateView.swift */; };
 		EC0816C12D4A833400F1AD02 /* ConfigurationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0816C02D4A833400F1AD02 /* ConfigurationViewModel.swift */; };
+		SDKS50660005000000000004 /* JsonConfigPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS50660005000000000003 /* JsonConfigPreviewView.swift */; };
+		SDKS50660005000000000002 /* JsonConfigLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS50660005000000000001 /* JsonConfigLoader.swift */; };
 		EC0816C32D4A83E200F1AD02 /* ConfigurationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0816C22D4A83E200F1AD02 /* ConfigurationManager.swift */; };
 		EC0CB5CA2E27AE4C00A82D6C /* JourneyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0CB5C82E27AE4C00A82D6C /* JourneyView.swift */; };
 		EC0CB5CB2E27AE4C00A82D6C /* JourneyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0CB5C92E27AE4C00A82D6C /* JourneyViewModel.swift */; };
@@ -183,6 +184,8 @@
 		ECF7EB862E464EDD002A5E8E /* IdpCallbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECF7EB852E464ED8002A5E8E /* IdpCallbackView.swift */; };
 		ECF7EB882E464F31002A5E8E /* SelectIdpCallbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECF7EB872E464F2C002A5E8E /* SelectIdpCallbackView.swift */; };
 		FAE66EFD02A8526178953F13 /* AuthMigrationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE27407BC6A20DE66B3B585 /* AuthMigrationViewModel.swift */; };
+		SDKS42450002000000000001 /* RichTextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS42450002000000000000 /* RichTextBuilder.swift */; };
+		SDKS50660006000000000001 /* Configs in Resources */ = {isa = PBXBuildFile; fileRef = A50FE2672FCE78D20010DC0D /* Configs */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -734,7 +737,6 @@
 		A5E9AED52D30393B000533ED /* LoggerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerView.swift; sourceTree = "<group>"; };
 		A5E9AED72D30395D000533ED /* StorageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageView.swift; sourceTree = "<group>"; };
 		A5E9AEDA2D30A01D000533ED /* LabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelView.swift; sourceTree = "<group>"; };
-		SDKS42450002000000000000 /* RichTextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichTextBuilder.swift; sourceTree = "<group>"; };
 		A5E9AEDC2D30A226000533ED /* TextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
 		A5E9AEDE2D30CA2C000533ED /* ErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMessageView.swift; sourceTree = "<group>"; };
 		A5E9AEE02D30D301000533ED /* SubmitButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitButtonView.swift; sourceTree = "<group>"; };
@@ -750,6 +752,8 @@
 		E12A2D07B7E54C26BEE15679 /* Configurations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configurations.swift; sourceTree = "<group>"; };
 		EC0816A12D4A692900F1AD02 /* Browser.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Browser.xcodeproj; path = ../../Browser/Browser.xcodeproj; sourceTree = SOURCE_ROOT; };
 		EC0816C02D4A833400F1AD02 /* ConfigurationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationViewModel.swift; sourceTree = "<group>"; };
+		SDKS50660005000000000003 /* JsonConfigPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonConfigPreviewView.swift; sourceTree = "<group>"; };
+		SDKS50660005000000000001 /* JsonConfigLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonConfigLoader.swift; sourceTree = "<group>"; };
 		EC0816C22D4A83E200F1AD02 /* ConfigurationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationManager.swift; sourceTree = "<group>"; };
 		EC0CB5A52E27AD3D00A82D6C /* Journey.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Journey.xcodeproj; path = ../../Journey/Journey.xcodeproj; sourceTree = SOURCE_ROOT; };
 		EC0CB5C82E27AE4C00A82D6C /* JourneyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JourneyView.swift; sourceTree = "<group>"; };
@@ -791,6 +795,7 @@
 		ECE2B8722DB7DBE500E2C51E /* PhoneNumberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumberView.swift; sourceTree = "<group>"; };
 		ECF7EB852E464ED8002A5E8E /* IdpCallbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdpCallbackView.swift; sourceTree = "<group>"; };
 		ECF7EB872E464F2C002A5E8E /* SelectIdpCallbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectIdpCallbackView.swift; sourceTree = "<group>"; };
+		SDKS42450002000000000000 /* RichTextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichTextBuilder.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -947,6 +952,7 @@
 				ECB7C5D02D562FAC0006F1C8 /* Info.plist */,
 				A5768CFE2E283F0C000290EE /* Callbacks */,
 				A5E9AED92D309FEF000533ED /* Collectors */,
+				A50FE2672FCE78D20010DC0D /* Configs */,
 				3A3709952BEB038200AA7B51 /* AccessTokenView.swift */,
 				A5E9AECD2D3037BC000533ED /* AccessTokenViewModel.swift */,
 				EC6F65A72EB240C800D4686D /* BindingKeysView.swift */,
@@ -979,6 +985,8 @@
 				A5E9AECF2D3037DF000533ED /* UserInfoView.swift */,
 				A5E9AED12D303804000533ED /* UserInfoViewModel.swift */,
 				EC0816C02D4A833400F1AD02 /* ConfigurationViewModel.swift */,
+				SDKS50660005000000000003 /* JsonConfigPreviewView.swift */,
+				SDKS50660005000000000001 /* JsonConfigLoader.swift */,
 				EC0816C22D4A83E200F1AD02 /* ConfigurationManager.swift */,
 				E12A2D07B7E54C26BEE15679 /* Configurations.swift */,
 				5532A35B47CF4B98B69361B4 /* ConfigurationListView.swift */,
@@ -1074,6 +1082,7 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		A50FE2672FCE78D20010DC0D /* Configs */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Configs; sourceTree = "<group>"; };
 		A525E7DF2DD7687800B02C17 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -1945,6 +1954,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3A5441382BCDF10B00385131 /* Preview Assets.xcassets in Resources */,
+				SDKS50660006000000000001 /* Configs in Resources */,
 				3A5441352BCDF10B00385131 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2041,6 +2051,8 @@
 				A5E9AEDD2D30A22A000533ED /* TextView.swift in Sources */,
 				A5768D102E2965B8000290EE /* ConfirmationCallbackView.swift in Sources */,
 				EC0816C12D4A833400F1AD02 /* ConfigurationViewModel.swift in Sources */,
+				SDKS50660005000000000004 /* JsonConfigPreviewView.swift in Sources */,
+				SDKS50660005000000000002 /* JsonConfigLoader.swift in Sources */,
 				A5EFA9772D35F2FA00F771FE /* CheckBoxView.swift in Sources */,
 				1B18D64A2EF0E7000004F205 /* PolicySelectionView.swift in Sources */,
 				ECC52B0D2E81AF5B00C468C7 /* ScenePhaseManager.swift in Sources */,

--- a/SampleApps/PingExample/PingExample/ConfigurationListView.swift
+++ b/SampleApps/PingExample/PingExample/ConfigurationListView.swift
@@ -16,6 +16,7 @@ struct ConfigurationListView: View {
     @State private var showEditor = false
     @State private var configToDelete: Configuration?
     @State private var showDeleteConfirmation = false
+    @State private var previewingJsonConfig: Configuration?
     
     var body: some View {
         ScrollView {
@@ -31,6 +32,9 @@ struct ConfigurationListView: View {
         }
         .background(Color(.systemGroupedBackground))
         .navigationTitle("Configurations")
+        .sheet(item: $previewingJsonConfig) { config in
+            JsonConfigPreviewView(config: config)
+        }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 NavigationLink {
@@ -119,7 +123,14 @@ struct ConfigurationListView: View {
             }
             .buttonStyle(PlainButtonStyle())
             
-            if config.isDefault {
+            if config.isJsonBased {
+                Button {
+                    previewingJsonConfig = config
+                } label: {
+                    configRowContent(config: config, host: host)
+                }
+                .buttonStyle(PlainButtonStyle())
+            } else if config.isDefault {
                 configRowContent(config: config, host: host)
             } else {
                 NavigationLink {
@@ -133,12 +144,14 @@ struct ConfigurationListView: View {
         .padding(16)
         .contentShape(Rectangle())
         .contextMenu {
-            Button {
-                duplicateConfiguration(config)
-            } label: {
-                Label("Duplicate", systemImage: "doc.on.doc")
+            if !config.isJsonBased {
+                Button {
+                    duplicateConfiguration(config)
+                } label: {
+                    Label("Duplicate", systemImage: "doc.on.doc")
+                }
             }
-            if !config.isDefault {
+            if !config.isDefault && !config.isJsonBased {
                 Button(role: .destructive) {
                     configToDelete = config
                     showDeleteConfirmation = true
@@ -165,9 +178,22 @@ struct ConfigurationListView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 10))
             
             VStack(alignment: .leading, spacing: 2) {
-                Text(config.name)
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(.primary)
+                HStack(spacing: 6) {
+                    Text(config.name)
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(.primary)
+                    if config.isJsonBased {
+                        Text("JSON")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(.themeButtonBackground)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 2)
+                            .background(
+                                Capsule()
+                                    .strokeBorder(Color.themeButtonBackground, lineWidth: 1)
+                            )
+                    }
+                }
                 Text(host)
                     .font(.system(size: 13))
                     .foregroundColor(.secondary)
@@ -175,9 +201,9 @@ struct ConfigurationListView: View {
                     .font(.system(size: 13))
                     .foregroundColor(.secondary)
             }
-            
+
             Spacer()
-            
+
             if !config.isDefault {
                 Image(systemName: "chevron.right")
                     .font(.system(size: 13, weight: .semibold))

--- a/SampleApps/PingExample/PingExample/ConfigurationManager.swift
+++ b/SampleApps/PingExample/PingExample/ConfigurationManager.swift
@@ -306,11 +306,13 @@ class ConfigurationManager: ObservableObject {
     /// Use this when loading configuration from a remote source, a shared file, or a CI environment.
     ///
     ///     let json: [String: Any] = [
-    ///         "serverUrl": "https://example.com/am",
-    ///         "realm": "alpha",
+    ///         "journey": [
+    ///             "serverUrl": "https://example.com/am",
+    ///             "realm": "alpha"
+    ///         ],
     ///         "timeout": 30000,
     ///         "log": "DEBUG",
-    ///         "oidc": [
+    ///         "oidc": [                          // optional for Journey
     ///             "clientId": "my-client",
     ///             "discoveryEndpoint": "https://example.com/.well-known/openid-configuration",
     ///             "scopes": ["openid", "profile", "email"],

--- a/SampleApps/PingExample/PingExample/ConfigurationManager.swift
+++ b/SampleApps/PingExample/PingExample/ConfigurationManager.swift
@@ -88,10 +88,26 @@ class ConfigurationManager: ObservableObject {
         if let c = deviceConfig { sels[.device] = c }
         self.selections = sels
 
-        self.journey = journeyConfig.map { ConfigurationManager.buildJourney($0) }
-        self.davinci = davinciConfig.map { ConfigurationManager.buildDaVinci($0) }
-        self.oidcLogin = oidcWebConfig.map { ConfigurationManager.buildOidcWebClient($0) }
-        self.deviceClient = deviceConfig.map { ConfigurationManager.buildDeviceClient($0) }
+        self.journey = journeyConfig.map { config in
+            ConfigurationManager.resolveJson(for: config)
+                .flatMap { ConfigurationManager.buildJourney(fromJSON: $0) }
+                ?? ConfigurationManager.buildJourney(config)
+        }
+        self.davinci = davinciConfig.map { config in
+            ConfigurationManager.resolveJson(for: config)
+                .flatMap { ConfigurationManager.buildDaVinci(fromJSON: $0) }
+                ?? ConfigurationManager.buildDaVinci(config)
+        }
+        self.oidcLogin = oidcWebConfig.map { config in
+            ConfigurationManager.resolveJson(for: config)
+                .flatMap { ConfigurationManager.buildOidcWebClient(fromJSON: $0) }
+                ?? ConfigurationManager.buildOidcWebClient(config)
+        }
+        self.deviceClient = deviceConfig.map { config in
+            ConfigurationManager.resolveJson(for: config)
+                .flatMap { ConfigurationManager.buildDeviceClient(fromJSON: $0) }
+                ?? ConfigurationManager.buildDeviceClient(config)
+        }
     }
     
     // MARK: - Configuration Selection
@@ -118,15 +134,20 @@ class ConfigurationManager: ObservableObject {
     }
     
     private func rebuildInstance(for config: Configuration) {
+        let json = ConfigurationManager.resolveJson(for: config)
         switch config.type {
         case .journey:
-            journey = ConfigurationManager.buildJourney(config)
+            journey = json.flatMap { ConfigurationManager.buildJourney(fromJSON: $0) }
+                ?? ConfigurationManager.buildJourney(config)
         case .davinci:
-            davinci = ConfigurationManager.buildDaVinci(config)
+            davinci = json.flatMap { ConfigurationManager.buildDaVinci(fromJSON: $0) }
+                ?? ConfigurationManager.buildDaVinci(config)
         case .oidcWeb:
-            oidcLogin = ConfigurationManager.buildOidcWebClient(config)
+            oidcLogin = json.flatMap { ConfigurationManager.buildOidcWebClient(fromJSON: $0) }
+                ?? ConfigurationManager.buildOidcWebClient(config)
         case .device:
-            deviceClient = ConfigurationManager.buildDeviceClient(config)
+            deviceClient = json.flatMap { ConfigurationManager.buildDeviceClient(fromJSON: $0) }
+                ?? ConfigurationManager.buildDeviceClient(config)
         }
     }
     
@@ -156,7 +177,7 @@ class ConfigurationManager: ObservableObject {
     
     /// Delete a configuration by name and persist.
     public func deleteConfiguration(_ config: Configuration) {
-        configurations.removeAll { $0.name == config.name }
+        configurations.removeAll { $0.name == config.name && $0.type == config.type }
         saveUserConfigurations()
         // If the deleted config was selected, fall back to the first of its type (or clear)
         if selections[config.type]?.name == config.name {
@@ -277,21 +298,118 @@ class ConfigurationManager: ObservableObject {
         }
     }
 
+    // MARK: - JSON Factory Helpers (Unified SDK Configuration)
+
+    /// Creates a Journey from a unified JSON configuration dictionary.
+    ///
+    /// Example JSON mirrors the cross-platform schema defined in the Unified SDK Configuration spec.
+    /// Use this when loading configuration from a remote source, a shared file, or a CI environment.
+    ///
+    ///     let json: [String: Any] = [
+    ///         "serverUrl": "https://example.com/am",
+    ///         "realm": "alpha",
+    ///         "timeout": 30000,
+    ///         "log": "DEBUG",
+    ///         "oidc": [
+    ///             "clientId": "my-client",
+    ///             "discoveryEndpoint": "https://example.com/.well-known/openid-configuration",
+    ///             "scopes": ["openid", "profile", "email"],
+    ///             "redirectUri": "myapp://callback"
+    ///         ]
+    ///     ]
+    ///     let result = ConfigurationManager.buildJourney(fromJSON: json)
+    static func buildJourney(fromJSON json: [String: Any]) -> Journey? {
+        switch Journey.createJourney(json: json) {
+        case .success(let journey):
+            return journey
+        case .failure(let error):
+            LogManager.logger.e("Failed to create Journey from JSON: \(error.localizedDescription)", error: error)
+            return nil
+        }
+    }
+
+    /// Creates a DaVinci from a unified JSON configuration dictionary.
+    ///
+    /// Example JSON mirrors the cross-platform schema defined in the Unified SDK Configuration spec.
+    ///
+    ///     let json: [String: Any] = [
+    ///         "timeout": 15000,
+    ///         "oidc": [
+    ///             "clientId": "my-client",
+    ///             "discoveryEndpoint": "https://example.com/.well-known/openid-configuration",
+    ///             "scopes": ["openid", "profile", "email"],
+    ///             "redirectUri": "myapp://callback"
+    ///         ]
+    ///     ]
+    ///     let result = ConfigurationManager.buildDaVinci(fromJSON: json)
+    static func buildDaVinci(fromJSON json: [String: Any]) -> DaVinci? {
+        switch DaVinci.createDaVinci(json: json) {
+        case .success(let daVinci):
+            return daVinci
+        case .failure(let error):
+            LogManager.logger.e("Failed to create DaVinci from JSON: \(error.localizedDescription)", error: error)
+            return nil
+        }
+    }
+
+    /// Creates an OidcWebClient from a unified JSON configuration dictionary.
+    static func buildOidcWebClient(fromJSON json: [String: Any]) -> OidcWebClient? {
+        switch OidcWebClient.createOidcWebClient(json: json) {
+        case .success(let client):
+            return client
+        case .failure(let error):
+            LogManager.logger.e("Failed to create OidcWebClient from JSON: \(error.localizedDescription)", error: error)
+            return nil
+        }
+    }
+
+    /// Creates an OidcDeviceClient from a unified JSON configuration dictionary.
+    static func buildDeviceClient(fromJSON json: [String: Any]) -> OidcDeviceClient? {
+        switch OidcDeviceClient.createOidcDeviceClient(json: json) {
+        case .success(let client):
+            return client
+        case .failure(let error):
+            LogManager.logger.e("Failed to create OidcDeviceClient from JSON: \(error.localizedDescription)", error: error)
+            return nil
+        }
+    }
+
     // MARK: - Persistence Helpers
     
-    /// Loads all configurations: defaults plus user-added configs from UserDefaults.
+    /// Loads all configurations: defaults, bundled JSON files, then user-added configs from UserDefaults.
     private static func loadConfigurations() -> [Configuration] {
         var configs = defaultConfigurations
+        configs.append(contentsOf: JsonConfigLoader.load())
         if let data = UserDefaults.standard.data(forKey: userConfigsKey),
            let userConfigs = try? JSONDecoder().decode([Configuration].self, from: data) {
             configs.append(contentsOf: userConfigs)
         }
         return configs
     }
+
+    /// Returns the parsed JSON dictionary for a JSON-backed config, or nil for non-JSON configs.
+    private static func resolveJson(for config: Configuration) -> [String: Any]? {
+        guard let filename = config.jsonFileName else { return nil }
+        return loadBundledJson(filename)
+    }
+
+    private static var jsonCache: [String: [String: Any]] = [:]
+
+    /// Loads a bundled JSON file by filename and returns its parsed dictionary.
+    private static func loadBundledJson(_ filename: String) -> [String: Any]? {
+        if let cached = jsonCache[filename] { return cached }
+        let name = URL(fileURLWithPath: filename).deletingPathExtension().lastPathComponent
+        guard let url = Bundle.main.url(forResource: name, withExtension: "json", subdirectory: "Configs"),
+              let data = try? Data(contentsOf: url),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        jsonCache[filename] = json
+        return json
+    }
     
-    /// Persists user-added configurations (non-defaults) to UserDefaults.
+    /// Persists user-added configurations (non-defaults, non-JSON) to UserDefaults.
     private func saveUserConfigurations() {
-        let userConfigs = configurations.filter { !$0.isDefault }
+        let userConfigs = configurations.filter { !$0.isDefault && !$0.isJsonBased }
         if let data = try? JSONEncoder().encode(userConfigs) {
             UserDefaults.standard.set(data, forKey: ConfigurationManager.userConfigsKey)
         }

--- a/SampleApps/PingExample/PingExample/ConfigurationViewModel.swift
+++ b/SampleApps/PingExample/PingExample/ConfigurationViewModel.swift
@@ -19,7 +19,13 @@ import Foundation
 //    Configurations are persisted as a diff overlay on top of defaultConfigurations in UserDefaults.
 
 /// Holds all settings for a single SDK configuration entry.
-struct Configuration: Codable, Sendable {
+struct Configuration: Codable, Sendable, Identifiable {
+    var id: String {
+        if let jsonFileName {
+            return "\(type.rawValue):\(jsonFileName)"
+        }
+        return "\(type.rawValue):\(name)"
+    }
     var name: String
     var type: ConfigType
     var clientId: String
@@ -35,11 +41,17 @@ struct Configuration: Codable, Sendable {
     var acrValues: String?
     /// Enable PAR (Pushed Authorization Request) RFC 9126.
     var par: Bool?
-    
+    /// The bundled JSON filename this config was loaded from (e.g. `"journey-rn-forgeblocks.json"`).
+    /// Non-nil indicates the config is read-only and the SDK should be built from the raw JSON.
+    var jsonFileName: String?
+
     /// Whether this configuration is a bundled default (immutable in the UI).
     var isDefault: Bool {
-        defaultConfigurations.contains(where: { $0.name == name })
+        defaultConfigurations.contains(where: { $0.name == name && $0.type == type })
     }
+
+    /// Whether this configuration was loaded from a bundled JSON file (immutable in the UI).
+    var isJsonBased: Bool { jsonFileName != nil }
 }
 
 enum ConfigType: String, Codable, CaseIterable, Sendable {

--- a/SampleApps/PingExample/PingExample/JsonConfigLoader.swift
+++ b/SampleApps/PingExample/PingExample/JsonConfigLoader.swift
@@ -14,8 +14,9 @@ import PingOidc
 
 enum JsonConfigLoader {
     /// Loads all bundled unified SDK configuration JSON files from the Configs/ folder in Bundle.main.
-    /// Each file is emitted as its natural type (Journey or DaVinci) AND as an OIDC (Web) entry,
-    /// since the unified JSON schema is compatible with all three SDK types.
+    /// Each file is emitted as its natural type (Journey or DaVinci). Files that also contain an
+    /// `oidc` sub-dict additionally emit OidcWeb and Device entries; Journey-only files (no `oidc`)
+    /// emit only the Journey entry.
     static func load() -> [Configuration] {
         guard let urls = Bundle.main.urls(forResourcesWithExtension: "json", subdirectory: "Configs") else {
             return []
@@ -34,35 +35,55 @@ enum JsonConfigLoader {
             LogManager.logger.w("JsonConfigLoader: '\(filename)' is not valid JSON", error: nil)
             return []
         }
-        guard let oidc = json[JsonConfigKey.oidc] as? [String: Any] else {
+        let name = nameFromFilename(filename)
+        let journeyDict = json[JsonConfigKey.journey] as? [String: Any]
+        let oidc = json[JsonConfigKey.oidc] as? [String: Any]
+        let naturalType: ConfigType = journeyDict != nil ? .journey : .davinci
+
+        // For Journey configs, serverUrl is required inside the journey sub-dict
+        if naturalType == .journey {
+            guard journeyDict?[JsonConfigKey.serverUrl] as? String != nil else {
+                LogManager.logger.w("JsonConfigLoader: '\(filename)' missing required 'journey.serverUrl'", error: nil)
+                return []
+            }
+        }
+
+        // For non-Journey configs, oidc is required
+        if naturalType != .journey && oidc == nil {
             LogManager.logger.w("JsonConfigLoader: '\(filename)' missing required 'oidc' object", error: nil)
             return []
         }
-        guard let clientId = oidc[JsonConfigKey.clientId] as? String else {
-            LogManager.logger.w("JsonConfigLoader: '\(filename)' missing required 'oidc.clientId'", error: nil)
-            return []
-        }
-        guard let discoveryEndpoint = oidc[JsonConfigKey.discoveryEndpoint] as? String else {
-            LogManager.logger.w("JsonConfigLoader: '\(filename)' missing required 'oidc.discoveryEndpoint'", error: nil)
-            return []
-        }
-        guard let rawScopes = oidc[JsonConfigKey.scopes] as? [String] else {
-            LogManager.logger.w("JsonConfigLoader: '\(filename)' missing required 'oidc.scopes'", error: nil)
-            return []
-        }
-        guard let redirectUri = oidc[JsonConfigKey.redirectUri] as? String else {
-            LogManager.logger.w("JsonConfigLoader: '\(filename)' missing required 'oidc.redirectUri'", error: nil)
-            return []
+
+        // Validate oidc fields when present
+        if let oidc {
+            guard oidc[JsonConfigKey.clientId] as? String != nil else {
+                LogManager.logger.w("JsonConfigLoader: '\(filename)' missing required 'oidc.clientId'", error: nil)
+                return []
+            }
+            guard oidc[JsonConfigKey.discoveryEndpoint] as? String != nil else {
+                LogManager.logger.w("JsonConfigLoader: '\(filename)' missing required 'oidc.discoveryEndpoint'", error: nil)
+                return []
+            }
+            guard oidc[JsonConfigKey.scopes] as? [String] != nil else {
+                LogManager.logger.w("JsonConfigLoader: '\(filename)' missing required 'oidc.scopes'", error: nil)
+                return []
+            }
+            guard oidc[JsonConfigKey.redirectUri] as? String != nil else {
+                LogManager.logger.w("JsonConfigLoader: '\(filename)' missing required 'oidc.redirectUri'", error: nil)
+                return []
+            }
         }
 
-        let name = nameFromFilename(filename)
-        let naturalType: ConfigType = json[JsonConfigKey.serverUrl] != nil ? .journey : .davinci
-        let serverUrl = json[JsonConfigKey.serverUrl] as? String
-        let realm = json[JsonConfigKey.realm] as? String
-        let cookieName = json[JsonConfigKey.cookieName] as? String
-        let signOutUri = oidc[JsonConfigKey.signOutRedirectUri] as? String
-        let acrValues = oidc[JsonConfigKey.acrValues] as? String
-        let environment = deriveEnvironment(from: discoveryEndpoint)
+        let clientId = oidc?[JsonConfigKey.clientId] as? String ?? ""
+        let discoveryEndpoint = oidc?[JsonConfigKey.discoveryEndpoint] as? String ?? ""
+        let rawScopes = oidc?[JsonConfigKey.scopes] as? [String] ?? []
+        let redirectUri = oidc?[JsonConfigKey.redirectUri] as? String ?? ""
+        let serverUrl = journeyDict?[JsonConfigKey.serverUrl] as? String
+        let realm = journeyDict?[JsonConfigKey.realm] as? String
+        let cookieName = journeyDict?[JsonConfigKey.cookieName] as? String
+        let signOutUri = oidc?[JsonConfigKey.signOutRedirectUri] as? String
+        let acrValues = oidc?[JsonConfigKey.acrValues] as? String
+        let environment = discoveryEndpoint.isEmpty ? "" : deriveEnvironment(from: discoveryEndpoint)
 
         let base = Configuration(
             name: name,
@@ -79,6 +100,11 @@ enum JsonConfigLoader {
             acrValues: acrValues,
             jsonFileName: filename
         )
+
+        // Only emit OidcWeb and Device entries when oidc is present
+        guard let oidc else {
+            return [base]
+        }
 
         var oidcWeb = base
         oidcWeb.type = .oidcWeb

--- a/SampleApps/PingExample/PingExample/JsonConfigLoader.swift
+++ b/SampleApps/PingExample/PingExample/JsonConfigLoader.swift
@@ -1,0 +1,102 @@
+//
+//  JsonConfigLoader.swift
+//  PingExample
+//
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import Foundation
+import PingLogger
+import PingOidc
+
+enum JsonConfigLoader {
+    /// Loads all bundled unified SDK configuration JSON files from the Configs/ folder in Bundle.main.
+    /// Each file is emitted as its natural type (Journey or DaVinci) AND as an OIDC (Web) entry,
+    /// since the unified JSON schema is compatible with all three SDK types.
+    static func load() -> [Configuration] {
+        guard let urls = Bundle.main.urls(forResourcesWithExtension: "json", subdirectory: "Configs") else {
+            return []
+        }
+        return urls.flatMap { parse(url: $0) }
+    }
+
+    private static func parse(url: URL) -> [Configuration] {
+        let filename = url.lastPathComponent
+
+        guard let data = try? Data(contentsOf: url) else {
+            LogManager.logger.w("JsonConfigLoader: could not read '\(filename)'", error: nil)
+            return []
+        }
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            LogManager.logger.w("JsonConfigLoader: '\(filename)' is not valid JSON", error: nil)
+            return []
+        }
+        guard let oidc = json[JsonConfigKey.oidc] as? [String: Any] else {
+            LogManager.logger.w("JsonConfigLoader: '\(filename)' missing required 'oidc' object", error: nil)
+            return []
+        }
+        guard let clientId = oidc[JsonConfigKey.clientId] as? String else {
+            LogManager.logger.w("JsonConfigLoader: '\(filename)' missing required 'oidc.clientId'", error: nil)
+            return []
+        }
+        guard let discoveryEndpoint = oidc[JsonConfigKey.discoveryEndpoint] as? String else {
+            LogManager.logger.w("JsonConfigLoader: '\(filename)' missing required 'oidc.discoveryEndpoint'", error: nil)
+            return []
+        }
+        guard let rawScopes = oidc[JsonConfigKey.scopes] as? [String] else {
+            LogManager.logger.w("JsonConfigLoader: '\(filename)' missing required 'oidc.scopes'", error: nil)
+            return []
+        }
+        guard let redirectUri = oidc[JsonConfigKey.redirectUri] as? String else {
+            LogManager.logger.w("JsonConfigLoader: '\(filename)' missing required 'oidc.redirectUri'", error: nil)
+            return []
+        }
+
+        let name = nameFromFilename(filename)
+        let naturalType: ConfigType = json[JsonConfigKey.serverUrl] != nil ? .journey : .davinci
+        let serverUrl = json[JsonConfigKey.serverUrl] as? String
+        let realm = json[JsonConfigKey.realm] as? String
+        let cookieName = json[JsonConfigKey.cookieName] as? String
+        let signOutUri = oidc[JsonConfigKey.signOutRedirectUri] as? String
+        let acrValues = oidc[JsonConfigKey.acrValues] as? String
+        let environment = deriveEnvironment(from: discoveryEndpoint)
+
+        let base = Configuration(
+            name: name,
+            type: naturalType,
+            clientId: clientId,
+            scopes: rawScopes,
+            redirectUri: redirectUri,
+            signOutUri: signOutUri,
+            discoveryEndpoint: discoveryEndpoint,
+            environment: environment,
+            cookieName: cookieName,
+            serverUrl: serverUrl,
+            realm: realm,
+            acrValues: acrValues,
+            jsonFileName: filename
+        )
+
+        var oidcWeb = base
+        oidcWeb.type = .oidcWeb
+
+        var device = base
+        device.type = .device
+        device.deviceAuthorizationEndpoint = (oidc[JsonConfigKey.openId] as? [String: Any])?[JsonConfigKey.deviceAuthorizationEndpoint] as? String
+
+        return [base, oidcWeb, device]
+    }
+
+    private static func nameFromFilename(_ filename: String) -> String {
+        URL(fileURLWithPath: filename).deletingPathExtension().lastPathComponent
+    }
+
+    private static func deriveEnvironment(from discoveryEndpoint: String) -> String {
+        let lower = discoveryEndpoint.lowercased()
+        if lower.contains("forgeblocks") || lower.contains("openam") { return "AIC" }
+        return "PingOne"
+    }
+}

--- a/SampleApps/PingExample/PingExample/JsonConfigPreviewView.swift
+++ b/SampleApps/PingExample/PingExample/JsonConfigPreviewView.swift
@@ -1,0 +1,48 @@
+//
+//  JsonConfigPreviewView.swift
+//  PingExample
+//
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import SwiftUI
+
+struct JsonConfigPreviewView: View {
+    let config: Configuration
+    @Environment(\.dismiss) private var dismiss
+
+    private var jsonContent: String {
+        guard let filename = config.jsonFileName else { return "" }
+        let name = URL(fileURLWithPath: filename).deletingPathExtension().lastPathComponent
+        guard let url = Bundle.main.url(forResource: name, withExtension: "json", subdirectory: "Configs"),
+              let data = try? Data(contentsOf: url),
+              let json = try? JSONSerialization.jsonObject(with: data),
+              let pretty = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted),
+              let text = String(data: pretty, encoding: .utf8)
+        else { return "Unable to load file." }
+        return text
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                Text(jsonContent)
+                    .font(.system(.footnote, design: .monospaced))
+                    .foregroundColor(.primary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(16)
+            }
+            .background(Color(.systemGroupedBackground))
+            .navigationTitle(config.name)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
[SDKS-5066](https://pingidentity.atlassian.net/browse/SDKS-5066)[iOS] Standardize SDK configuration

  Introduce a platform-neutral JSON schema for configuring DaVinci,
  Journey, OidcWebClient, and OidcDeviceClient from a single dictionary,
  enabling config-file-driven SDK initialisation across platforms.

  - Add JsonConfigParser / JsonConfigError / JsonConfigKey (PingOidc)
  - Add OidcClientConfig.apply(json:) for validated OIDC sub-dict parsing
  - Add createXxx(json:) factory on DaVinci, Journey, OidcWebClient,
    OidcDeviceClient — all return Result<T, Error>
  - Add LogManager.logger(forLevel:) mapping JSON log-level strings
  - Add JsonConfigLoader + JsonConfigPreviewView to sample app; load
    bundled JSON files from Configs/ folder reference at runtime
  - Cache parsed JSON dictionaries to avoid repeated disk reads
  - Gitignore Configs/ so local JSON files are never committed