### PR TITLE
SDKS-4783 Add E2E tests for OAuth 2.0 Device Authorization Grant

### DIFF
--- a/Davinci/Davinci.xcodeproj/project.pbxproj
+++ b/Davinci/Davinci.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		AA4785031F0000000000AA01 /* DaVinciDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4785021F0000000000AA01 /* DaVinciDeviceTests.swift */; };
 		BB4928012F0900000000BB01 /* ReadOnlyTextCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4928002F0900000000BB01 /* ReadOnlyTextCollector.swift */; };
 		BB4928032F0900000000BB01 /* ReadOnlyTextCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4928022F0900000000BB01 /* ReadOnlyTextCollectorTests.swift */; };
+		DA0000022F0000000000DA01 /* DeviceAuthorizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0000012F0000000000DA01 /* DeviceAuthorizationTests.swift */; };
 		EC5C81C92ECF7A1700C91570 /* PingDavinciPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC5C81C82ECF7A1700C91570 /* PingDavinciPlugin.framework */; };
 		EC5C81CA2ECF7A1700C91570 /* PingDavinciPlugin.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EC5C81C82ECF7A1700C91570 /* PingDavinciPlugin.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		EC5C81FC2ED0CAA100C91570 /* Collectors.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5C81FB2ED0CAA100C91570 /* Collectors.swift */; };
@@ -170,6 +171,7 @@
 		AA4785021F0000000000AA01 /* DaVinciDeviceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinciDeviceTests.swift; sourceTree = "<group>"; };
 		BB4928002F0900000000BB01 /* ReadOnlyTextCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadOnlyTextCollector.swift; sourceTree = "<group>"; };
 		BB4928022F0900000000BB01 /* ReadOnlyTextCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadOnlyTextCollectorTests.swift; sourceTree = "<group>"; };
+		DA0000012F0000000000DA01 /* DeviceAuthorizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceAuthorizationTests.swift; sourceTree = "<group>"; };
 		EC5C81C82ECF7A1700C91570 /* PingDavinciPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingDavinciPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC5C81FB2ED0CAA100C91570 /* Collectors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Collectors.swift; sourceTree = "<group>"; };
 		EC7279AD2DF98CD6005D9E28 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
@@ -300,6 +302,7 @@
 			isa = PBXGroup;
 			children = (
 				A51D4CF72C65978300FE09E0 /* DaVinciIntegrationTests.swift */,
+				DA0000012F0000000000DA01 /* DeviceAuthorizationTests.swift */,
 				959249A62D405A1C00A6DA9C /* FormFieldValidationTests.swift */,
 				959249A82D405A4600A6DA9C /* FormFieldsTests.swift */,
 				95C256782DF22BFB004266AB /* MFADeviceTests.swift */,
@@ -519,6 +522,7 @@
 				A5EFAA082D3F30E600F771FE /* LabelCollectorTests.swift in Sources */,
 				959249A92D405A4600A6DA9C /* FormFieldsTests.swift in Sources */,
 				8FE3EB1B92044038A76D2CB3 /* PollingCollectorIntegrationTests.swift in Sources */,
+				DA0000022F0000000000DA01 /* DeviceAuthorizationTests.swift in Sources */,
 				A5EFAA142D3F51CC00F771FE /* TextCollectorTests.swift in Sources */,
 				A5EFAA122D3F518B00F771FE /* SubmitCollectorTests.swift in Sources */,
 				A51D4CF62C65743100FE09E0 /* MockAPIEndpoint.swift in Sources */,

--- a/Davinci/DavinciTests/Configuration/Config.swift
+++ b/Davinci/DavinciTests/Configuration/Config.swift
@@ -32,6 +32,13 @@ class Config: NSObject {
     var redirectUri: String
     var acrValues: String
     var configPlistFileName: String?
+
+    // Device Authorization Grant (RFC 8628) — requesting-device OIDC client
+    var deviceClientId: String = ""
+
+    // Device Authorization Grant — shared test credentials
+    var deviceUsername: String = ""
+    var devicePassword: String = ""
     
     var configJSON: [String: Any]?
     
@@ -109,6 +116,12 @@ class Config: NSObject {
                       .filter { !$0.isEmpty }
                     self.redirectUri = redirectUri
                     self.acrValues = acrValues
+
+                    // Device Authorization Grant fields are optional — tests that don't
+                    // exercise device flow simply read empty strings from the config.
+                    self.deviceClientId = config["deviceClientId"] as? String ?? ""
+                    self.deviceUsername = config["deviceUsername"] as? String ?? ""
+                    self.devicePassword = config["devicePassword"] as? String ?? ""
                 }
                 else {
                     throw ConfigError.invalidConfiguration("\(configFileName) is invalid or missing some value")

--- a/Davinci/DavinciTests/Configuration/ConfigNew.json
+++ b/Davinci/DavinciTests/Configuration/ConfigNew.json
@@ -10,5 +10,9 @@
     "discoveryEndpoint" : "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration",
     "scopes" : "openid email address phone profile",
     "redirectUri" : "org.forgerock.demo://oauth2redirect",
-    "acrValues" : "fae6bc3d08a5c4f5b8ff95175b117278"
+    "acrValues" : "fae6bc3d08a5c4f5b8ff95175b117278",
+    
+    "deviceClientId" : "d6505e10-d019-4f9d-ae76-d0648ca9c9c3",
+    "deviceUsername" : "e2euser",
+    "devicePassword" : "2222"
 }

--- a/Davinci/DavinciTests/integration tests/DeviceAuthorizationTests.swift
+++ b/Davinci/DavinciTests/integration tests/DeviceAuthorizationTests.swift
@@ -1,0 +1,341 @@
+//
+//  DeviceAuthorizationTests.swift
+//  DavinciTests
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+@testable import PingOrchestrate
+@testable import PingLogger
+@testable import PingOidc
+@testable import PingStorage
+@testable import PingDavinci
+
+/// E2E tests for the OAuth 2.0 Device Authorization Grant (RFC 8628) flow against PingOne/DaVinci.
+///
+/// Configuration is loaded from `ConfigDeviceAuth.json`. The file is committed with blank values;
+/// the real values are injected by CI or set locally before running these tests.
+///
+/// Test topology:
+/// - `client` — the requesting device, drives `OidcDeviceClient.deviceAuthorization()`.
+/// - `approvingDaVinci` — the approving device, drives a DaVinci login flow using
+///   `verificationUriComplete` so the server links the session to the pending device code.
+class DeviceAuthorizationTests: DaVinciBaseTests, @unchecked Sendable {
+
+    private var client: OidcDeviceClient!
+    private var approvingDaVinci: DaVinci!
+
+    override func setUp() async throws {
+        self.configFileName = "ConfigNew"
+        try await super.setUp()
+
+        client = OidcDeviceClient.createOidcDeviceClient { config in
+            config.logger = LogManager.standard
+            config.clientId = self.config.deviceClientId
+            config.discoveryEndpoint = self.config.discoveryEndpoint
+            config.scopes = Set(["openid", "email", "address", "phone", "profile"])
+            config.storage = KeychainStorage<Token>(account: "device_flow_test")
+        }
+
+        approvingDaVinci = DaVinci.createDaVinci { config in
+            config.logger = LogManager.standard
+            config.module(PingDavinci.OidcModule.config) { oidcValue in
+                oidcValue.clientId = self.config.clientId
+                oidcValue.discoveryEndpoint = self.config.discoveryEndpoint
+                oidcValue.scopes = Set(["openid", "email", "address", "phone", "profile"])
+                oidcValue.redirectUri = ""
+                oidcValue.storage = KeychainStorage<Token>(account: "device_flow_approver_test")
+            }
+        }
+
+        // Clear any leftover token so each test starts fresh.
+        await client.user()?.logout()
+        await approvingDaVinci.daVinciUser()?.logout()
+    }
+
+    // =========================================================================
+    // TC-01: Start device authorization flow — verify user code and polling
+    // =========================================================================
+
+    /// Starts the device flow, waits for the first `.polling` emission, then cancels.
+    /// Keeps the test well under 20 s (one 5 s poll interval) instead of waiting for expiry.
+    ///
+    /// Verifies:
+    /// - First emission is `.started` with a well-formed `DeviceAuthorizationResponse`.
+    /// - `userCode` matches the XXXX-XXXX pattern.
+    /// - `verificationUri` begins with the expected PingOne base URL.
+    /// - `verificationUriComplete` is present and contains `user_code=`.
+    /// - At least one `.polling` emission follows with `pollCount == 1` and the
+    ///   server-specified `pollInterval`.
+    func testStartFlowEmitsStartedThenPolling() async throws {
+        let stream = try await client.deviceAuthorization()
+
+        var started: DeviceFlowStatus? = nil
+        var firstPolling: DeviceFlowStatus? = nil
+
+        for try await status in stream {
+            switch status {
+            case .started:
+                started = status
+            case .polling:
+                firstPolling = status
+                // Cancel after the first poll — no need to wait for expiry.
+                break
+            default:
+                break
+            }
+            if firstPolling != nil { break }
+        }
+
+        // --- .started ---
+        guard case .started(let response) = started else {
+            XCTFail("First emission must be .started")
+            return
+        }
+
+        XCTAssertFalse(response.userCode.isEmpty, "userCode must not be empty")
+        XCTAssertTrue(
+            response.userCode.range(of: #"^[A-Z0-9]{4}-[A-Z0-9]{4}$"#, options: .regularExpression) != nil,
+            "userCode '\(response.userCode)' must match pattern XXXX-XXXX"
+        )
+
+        XCTAssertFalse(response.verificationUri.isEmpty, "verificationUri must not be empty")
+        XCTAssertTrue(
+            response.verificationUri.hasPrefix("https://auth.pingone.ca/"),
+            "verificationUri should start with 'https://auth.pingone.ca/', got: \(response.verificationUri)"
+        )
+
+        XCTAssertNotNil(response.verificationUriComplete, "verificationUriComplete must be present")
+        XCTAssertTrue(
+            response.verificationUriComplete?.contains("user_code=") == true,
+            "verificationUriComplete must contain 'user_code='"
+        )
+
+        XCTAssertFalse(response.deviceCode.isEmpty, "deviceCode must not be empty")
+        XCTAssertGreaterThan(response.expiresIn, 0, "expiresIn must be positive")
+        XCTAssertEqual(5, response.interval, "PingOne default interval is 5 seconds")
+
+        // --- .polling ---
+        guard case .polling(let pollCount, let pollInterval, _) = firstPolling else {
+            XCTFail("Expected at least one .polling emission")
+            return
+        }
+        XCTAssertEqual(1, pollCount, "first pollCount must be 1")
+        XCTAssertEqual(response.interval, pollInterval, "pollInterval must match the server-specified interval")
+    }
+
+    // =========================================================================
+    // TC-02: Successful device authorization via DaVinci approval
+    // =========================================================================
+
+    /// Starts the device flow, drives a DaVinci login on the approving side using
+    /// `verificationUriComplete`, taps "Approve Device", and waits for the requesting
+    /// side to emit `.success`.
+    ///
+    /// Verifies:
+    /// - Terminal emission on the requesting side is `.success`.
+    /// - The access token is retrievable from the returned `User`.
+    /// - `client.user()` is non-nil after the flow completes.
+    func testDeviceAuthorizationApprovalViaDaVinci() async throws {
+        let stream = try await client.deviceAuthorization()
+
+        var allStatuses: [DeviceFlowStatus] = []
+        var approvalTask: Task<Void, Never>?
+
+        // Iterate the stream on this task. When .started arrives, fire the approving-side
+        // flow in a background Task so polling and approval run concurrently — same pattern
+        // as testChallengePollingApproval in PollingCollectorIntegrationTests.
+        for try await status in stream {
+            allStatuses.append(status)
+
+            if case .started(let response) = status, approvalTask == nil {
+                guard let uriComplete = response.verificationUriComplete else {
+                    XCTFail("verificationUriComplete must be present for DaVinci approval")
+                    return
+                }
+                let approvingDaVinci = self.approvingDaVinci!
+                let username = config.deviceUsername
+                let password = config.devicePassword
+
+                approvalTask = Task {
+                    // Step 1: start the approving DaVinci flow with the verification URI.
+                    var node = await approvingDaVinci.start { options in
+                        options.verificationUriComplete = URL(string: uriComplete)
+                    }
+                    guard let continueNode = node as? ContinueNode else {
+                        XCTFail("Expected ContinueNode from approvingDaVinci.start, got \(type(of: node))")
+                        return
+                    }
+                    node = continueNode
+
+                    // Step 2: Sign On form — username + password.
+                    (continueNode.collectors[0] as? TextCollector)?.value = username
+                    (continueNode.collectors[1] as? PasswordCollector)?.value = password
+                    (continueNode.collectors[2] as? SubmitCollector)?.value = "Sign On"
+                    node = await continueNode.next()
+                    guard let deviceFormNode = node as? ContinueNode else {
+                        XCTFail("Expected ContinueNode after sign-on, got \(type(of: node))")
+                        return
+                    }
+
+                    // Step 3: Device Code form — tap "Approve Device" (FlowCollector at index 1).
+                    // Layout: index 0 = TEXT (device-code display), index 1 = FLOW_BUTTON (approve),
+                    //         index 2 = FLOW_BUTTON (reject).
+                    (deviceFormNode.collectors[1] as? FlowCollector)?.value = "click"
+                    let approvalResult = await deviceFormNode.next()
+                    // The approval returns a DaVinci ContinueNode wrapping the redirect response —
+                    // not a SuccessNode. What matters is the requesting side receives .success.
+                    XCTAssertTrue(approvalResult is ContinueNode,
+                                  "Approval should return a ContinueNode (DaVinci redirect), got \(type(of: approvalResult))")
+                }
+            }
+
+            if case .success = status { break }
+            if case .accessDenied = status { break }
+            if case .expired = status { break }
+            if case .failure = status { break }
+        }
+
+        await approvalTask?.value
+
+        // Requesting side must have received .success as the terminal emission.
+        guard case .success(let user) = allStatuses.last else {
+            XCTFail("Expected .success as terminal status, got \(String(describing: allStatuses.last))")
+            return
+        }
+
+        let tokenResult = await user.token()
+        switch tokenResult {
+        case .success(let token):
+            XCTAssertNotNil(token.accessToken, "accessToken must not be nil")
+        case .failure(let error):
+            XCTFail("token() should succeed after approval, got error: \(error)")
+        }
+
+        let userAfterFlow = await client.user()
+        XCTAssertNotNil(userAfterFlow, "client.user() must be non-nil after successful device flow")
+
+        // Clean up.
+        await client.user()?.logout()
+        await approvingDaVinci.daVinciUser()?.logout()
+    }
+
+    // =========================================================================
+    // TC-03: Device authorization denied via DaVinci
+    // =========================================================================
+
+    /// Starts the device flow, drives a DaVinci login, taps "Reject Device", and confirms
+    /// the requesting side receives `.accessDenied`.
+    ///
+    /// Verifies:
+    /// - The DaVinci reject step returns an `ErrorNode` (server returns 400 with the rejection).
+    /// - Terminal emission on the requesting side is `.accessDenied`.
+    /// - `client.user()` is nil — no token was stored.
+    func testDeviceAuthorizationRejectedViaDaVinci() async throws {
+        let stream = try await client.deviceAuthorization()
+
+        var allStatuses: [DeviceFlowStatus] = []
+        var rejectionTask: Task<Void, Never>?
+
+        for try await status in stream {
+            allStatuses.append(status)
+
+            if case .started(let response) = status, rejectionTask == nil {
+                guard let uriComplete = response.verificationUriComplete else {
+                    XCTFail("verificationUriComplete must be present for DaVinci rejection")
+                    return
+                }
+                let approvingDaVinci = self.approvingDaVinci!
+                let username = config.deviceUsername
+                let password = config.devicePassword
+
+                rejectionTask = Task {
+                    var node = await approvingDaVinci.start { options in
+                        options.verificationUriComplete = URL(string: uriComplete)
+                    }
+                    guard let continueNode = node as? ContinueNode else {
+                        XCTFail("Expected ContinueNode from approvingDaVinci.start, got \(type(of: node))")
+                        return
+                    }
+                    node = continueNode
+
+                    // Sign On.
+                    (continueNode.collectors[0] as? TextCollector)?.value = username
+                    (continueNode.collectors[1] as? PasswordCollector)?.value = password
+                    (continueNode.collectors[2] as? SubmitCollector)?.value = "Sign On"
+                    node = await continueNode.next()
+                    guard let deviceFormNode = node as? ContinueNode else {
+                        XCTFail("Expected ContinueNode after sign-on, got \(type(of: node))")
+                        return
+                    }
+
+                    // Tap "Reject Device" (FlowCollector at index 2).
+                    (deviceFormNode.collectors[2] as? FlowCollector)?.value = "click"
+                    let rejectionResult = await deviceFormNode.next()
+                    // The server returns 400 with the rejection, surfaced as an ErrorNode.
+                    XCTAssertTrue(rejectionResult is ErrorNode,
+                                  "Rejection should return an ErrorNode, got \(type(of: rejectionResult))")
+                }
+            }
+
+            if case .success = status { break }
+            if case .accessDenied = status { break }
+            if case .expired = status { break }
+            if case .failure = status { break }
+        }
+
+        await rejectionTask?.value
+
+        // Requesting side must have received .accessDenied as the terminal emission.
+        guard case .accessDenied = allStatuses.last else {
+            XCTFail("Expected .accessDenied as terminal status, got \(String(describing: allStatuses.last))")
+            return
+        }
+
+        let userAfterRejection = await client.user()
+        XCTAssertNil(userAfterRejection, "client.user() must be nil after a rejected device flow")
+    }
+
+    // =========================================================================
+    // TC-04: Device code expires without approval
+    // =========================================================================
+
+    /// Starts the device flow without approving and waits for the polling loop to exhaust
+    /// the device-code lifetime. The terminal emission must be `.expired`.
+    ///
+    /// Disabled by default: this test waits for the full device-code lifetime (~30 s on this
+    /// tenant) before asserting `.expired`, which makes it too slow for routine CI runs.
+    /// Enable it manually when verifying expiry behaviour (e.g. after changes to the polling
+    /// loop or token storage).
+    func disabled_testDeviceCodeExpiresWithoutApproval() async throws {
+        let stream = try await client.deviceAuthorization()
+        var allStatuses: [DeviceFlowStatus] = []
+
+        for try await status in stream {
+            allStatuses.append(status)
+        }
+
+        guard case .started = allStatuses.first else {
+            XCTFail("First emission must be .started")
+            return
+        }
+
+        let pollingEmissions = allStatuses.compactMap { status -> DeviceFlowStatus? in
+            if case .polling = status { return status }
+            return nil
+        }
+        XCTAssertFalse(pollingEmissions.isEmpty, "Expected at least one .polling emission before expiry")
+
+        guard case .expired = allStatuses.last else {
+            XCTFail("Expected .expired as terminal status, got \(String(describing: allStatuses.last))")
+            return
+        }
+
+        let userAfterExpiry = await client.user()
+        XCTAssertNil(userAfterExpiry, "client.user() must be nil after device-code expiry")
+    }
+}


### PR DESCRIPTION
# JIRA Ticket

[SDKS-4783](https://pingidentity.atlassian.net/browse/SDKS-4783) QA for Device Authorization Grant Support

# Description

- Adds `DeviceAuthorizationTests.swift` - four E2E tests covering the device authorization grant flow (RFC 8628) against the PingOne/DaVinci test tenant:
  - **TC-01** (`testStartFlowEmitsStartedThenPolling`) — verifies `DeviceAuthorizationResponse` fields (user code format, verification URI, interval) and that polling starts; cancelled after the first `Polling` emission to keep the test under ~10 s
  - **TC-02** (`testDeviceAuthorizationApprovalViaDaVinci`) — full happy-path approval: DaVinci login → Approve Device → `.success` with a valid stored token
  - **TC-03** (`testDeviceAuthorizationRejectedViaDaVinci`) — rejection path: DaVinci login → Reject Device → `ErrorNode` on approver side → `accessDenied` on requesting side, no token stored
  - **TC-04** (`testDeviceCodeExpiresWithoutApproval`) — expiry path; disabled to avoid ~30 s runtime in CI, enable manually when testing expiry behaviour