### PR TITLE
SDKS-5212 Add preferImmediatelyAvailableCredentials option to FIDO authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## [Unreleased]
 #### Fixed
 - Fixed permanent authentication failure after iCloud device migration caused by Secure Enclave key mismatch [SDKS-5172]
+- Fixed `PingFido` platform WebAuthn registration ignoring `displayName`; the display name configured on the WebAuthn Registration Node is now shown to the user during passkey creation instead of falling back to the username [TRIAGE-35655]
 
 #### Added
 - Added `RichContent` and `RichContentReplacement` types and `richContent` property on `LabelCollector` to support template-based rich text with embedded links [SDKS-4245]
 - Routed FIDO ceremony logs through the workflow logger by adding a `logger:` parameter to `Fido.register` and `Fido.authenticate`. The DaVinci collectors and Journey callbacks pass the workflow's configured logger so FIDO ceremony state transitions and errors emit through the same logger as the surrounding flow [SDKS-4924]
+- Added a `preferImmediatelyAvailableCredentials` option to FIDO authentication, restricting the ceremony to locally-available credentials (no QR / nearby-device fallback), matching the legacy `FRWebAuthnManager` behavior. Exposed on `Fido.authenticate`, `FidoAuthenticationCollector.authenticate` (DaVinci), and `FidoAuthenticationCallback.authenticate` (Journey); defaults to `false` to preserve existing behavior [SDKS-5212]
 
 ## [2.0.0]
 #### Added

--- a/Fido/Fido/Davinci/FidoAuthenticationCollector.swift
+++ b/Fido/Fido/Davinci/FidoAuthenticationCollector.swift
@@ -64,20 +64,25 @@ public class FidoAuthenticationCollector: AbstractFidoCollector, Closeable, @unc
     ///
     /// This method uses the `fido.authenticate` method to perform the authentication ceremony.
     /// On success, it constructs and stores the `assertionValue`, then returns it.
-    /// - Parameter window: The `ASPresentationAnchor` to present the FIDO UI.
+    /// - Parameters:
+    ///   - window: The `ASPresentationAnchor` to present the FIDO UI.
+    ///   - preferImmediatelyAvailableCredentials: When `true`, restricts the ceremony to
+    ///     credentials already present on this device — no QR / nearby-device fallback is
+    ///     shown, and the call fails (cancelled) when no local passkey exists. Defaults to
+    ///     `false`, preserving the existing full sign-in behavior.
     /// - Returns: A dictionary representing the `assertionValue`.
     /// - Throws: An error if the authentication process fails or the response is invalid.
     @MainActor
-    public func authenticate(window: ASPresentationAnchor) async -> Result<[String: Any], Error> {
+    public func authenticate(window: ASPresentationAnchor, preferImmediatelyAvailableCredentials: Bool = false) async -> Result<[String: Any], Error> {
         logger.d("Starting FIDO authentication (async Result)")
-        
+
         do {
             // 1. Wrap the closure-based fido.authenticate in a continuation
             //    This still throws internally within the 'do' block if the continuation resumes with an error.
             let response: [String: Any] = try await withUnsafeThrowingContinuation { continuation in
                 // Pass the workflow logger so the underlying ASAuthorization ceremony
                 // emits log messages through the same logger as the surrounding flow.
-                fido.authenticate(options: publicKeyCredentialRequestOptions, window: window, logger: logger) { [continuation] result in
+                fido.authenticate(options: publicKeyCredentialRequestOptions, window: window, preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials, logger: logger) { [continuation] result in
                     Task {
                         await MainActor.run {
                             nonisolated(unsafe) let sendableResult = result

--- a/Fido/Fido/Fido.swift
+++ b/Fido/Fido/Fido.swift
@@ -313,7 +313,13 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
     private func createPlatformRequest(from options: PublicKeyCredentialCreationOptions, challenge: Data, userID: Data) -> ASAuthorizationRequest {
         let relyingParty = options.rp.id ?? ""
         let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: relyingParty)
-        let request: ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest = provider.createCredentialRegistrationRequest(challenge: challenge, name: options.user.name, userID: userID)
+        let name: String
+        if options.user.displayName.isEmpty {
+            name = options.user.name
+        } else {
+            name = options.user.displayName
+        }
+        let request: ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest = provider.createCredentialRegistrationRequest(challenge: challenge, name: name, userID: userID)
         request.displayName = options.user.displayName
 
         // Map excludeCredentials to ASAuthorizationPlatformPublicKeyCredentialDescriptor

--- a/Fido/Fido/Fido.swift
+++ b/Fido/Fido/Fido.swift
@@ -38,12 +38,17 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
     private var logger: Logger?
     
     func makeAuthorizationController(requests: [ASAuthorizationRequest]) -> ASAuthorizationController {
+        requests.forEach { testRequestCapture?($0) }
         let authorizationController = ASAuthorizationController(authorizationRequests: requests)
         authorizationController.delegate = self
         authorizationController.presentationContextProvider = self
         self.authorizationController = authorizationController
         return authorizationController
     }
+
+    /// Test-only hook. Receives each request before it is handed to `ASAuthorizationController`.
+    /// Set this in tests to inspect request properties without triggering the system UI.
+    var testRequestCapture: ((ASAuthorizationRequest) -> Void)?
     
     /// Registers a new FIDO credential.
     ///
@@ -129,12 +134,22 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
     /// - Parameters:
     ///   - options: A dictionary containing the authentication options.
     ///   - window: The window to present the authentication UI in.
+    ///   - preferImmediatelyAvailableCredentials: When `true`, the ceremony is restricted to
+    ///     platform credentials (passkeys) already present on this device: if a matching passkey
+    ///     exists the system presents the modal sign-in sheet, but if none is available no UI
+    ///     appears and the delegate receives `ASAuthorizationError.canceled` instead of the QR /
+    ///     nearby-device fallback. In this mode the ceremony is platform-only — no cross-platform
+    ///     security-key request is issued even when `allowCredentials` is present, since a hardware
+    ///     security key is never immediately available on the local device. When `false` (the
+    ///     default) the full `performRequests()` flow is used, including cross-device sign-in and
+    ///     security keys — preserving the pre-existing behavior. Mirrors the legacy
+    ///     `FRWebAuthnManager.signInWith(preferImmediatelyAvailableCredentials:)` option.
     ///   - logger: Optional logger for ceremony state transitions and errors. Pass the
     ///     workflow logger (e.g. `journey?.config.logger`); when `nil` no log output is
     ///     produced. Scoped to this call only — overwritten by subsequent ceremonies and
     ///     cleared in `cleanup()`.
     ///   - completion: A closure to be called with the authentication result.
-    public func authenticate(options: [String: Any], window: ASPresentationAnchor, logger: Logger? = nil, completion: @escaping (Result<[String: Any], Error>) -> Void) {
+    public func authenticate(options: [String: Any], window: ASPresentationAnchor, preferImmediatelyAvailableCredentials: Bool = false, logger: Logger? = nil, completion: @escaping (Result<[String: Any], Error>) -> Void) {
         self.logger = logger
         logger?.d("Fido: Starting authentication")
         self.window = window
@@ -157,7 +172,13 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
 
             var requests: [ASAuthorizationRequest] = [assertionRequest]
 
-            if let allowCredentials = authenticationOptions.allowCredentials, !allowCredentials.isEmpty {
+            // A hardware security key is never "immediately available on the local device", so a
+            // security-key assertion request is incompatible with .preferImmediatelyAvailableCredentials:
+            // including it would only be suppressed by the system. When the caller opts into local-only
+            // credentials we therefore run a platform-only ceremony, matching the legacy
+            // `FRWebAuthnManager.signInWith` behavior which never built a security-key request.
+            if !preferImmediatelyAvailableCredentials,
+               let allowCredentials = authenticationOptions.allowCredentials, !allowCredentials.isEmpty {
                 let securityKeyProvider = ASAuthorizationSecurityKeyPublicKeyCredentialProvider(relyingPartyIdentifier: authenticationOptions.rpId ?? "")
                 let securityKeyRequest = securityKeyProvider.createCredentialAssertionRequest(challenge: challengeData)
                 securityKeyRequest.userVerificationPreference = ASAuthorizationPublicKeyCredentialUserVerificationPreference(rawValue: authenticationOptions.userVerification?.rawValue ?? "preferred")
@@ -176,9 +197,17 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
                 startTimeout(milliseconds: timeout)
             }
 
-            logger?.d("Fido: Performing authentication requests (\(requests.count) request(s))")
             let authorizationController = makeAuthorizationController(requests: requests)
-            authorizationController.performRequests()
+            if preferImmediatelyAvailableCredentials {
+                // Restrict to locally-available credentials: presents the sign-in sheet only
+                // when a matching passkey exists, otherwise the delegate receives
+                // ASAuthorizationError.canceled with no UI (no QR / nearby-device fallback).
+                logger?.d("Fido: Performing authentication requests (\(requests.count) request(s)), preferring immediately available credentials")
+                authorizationController.performRequests(options: .preferImmediatelyAvailableCredentials)
+            } else {
+                logger?.d("Fido: Performing authentication requests (\(requests.count) request(s))")
+                authorizationController.performRequests()
+            }
         } catch {
             logger?.e("Fido: Authentication failed", error: error)
             completion(.failure(error))
@@ -285,7 +314,8 @@ public class Fido: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationC
         let relyingParty = options.rp.id ?? ""
         let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: relyingParty)
         let request: ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest = provider.createCredentialRegistrationRequest(challenge: challenge, name: options.user.name, userID: userID)
-        
+        request.displayName = options.user.displayName
+
         // Map excludeCredentials to ASAuthorizationPlatformPublicKeyCredentialDescriptor
         if let excludeCredentials = options.excludeCredentials {
             if #available(iOS 17.4, macOS 13.5, *) {

--- a/Fido/Fido/Journey/FidoAuthenticationCallback.swift
+++ b/Fido/Fido/Journey/FidoAuthenticationCallback.swift
@@ -39,19 +39,24 @@ public class FidoAuthenticationCallback: FidoCallback, @unchecked Sendable {
     
     /// Initiates the FIDO authentication process using async/await.
     ///
-    /// - Parameter window: The `ASPresentationAnchor` to present the FIDO UI.
+    /// - Parameters:
+    ///   - window: The `ASPresentationAnchor` to present the FIDO UI.
+    ///   - preferImmediatelyAvailableCredentials: When `true`, restricts the ceremony to
+    ///     credentials already present on this device — no QR / nearby-device fallback is
+    ///     shown, and the call fails (cancelled) when no local passkey exists. Defaults to
+    ///     `false`, preserving the existing full sign-in behavior.
     /// - Throws: An error if the authentication process fails.
     @MainActor
-    public func authenticate(window: ASPresentationAnchor) async -> Result<[String: Any], Error> {
+    public func authenticate(window: ASPresentationAnchor, preferImmediatelyAvailableCredentials: Bool = false) async -> Result<[String: Any], Error> {
         logger.d("Starting FIDO authentication (async Result)")
-        
+
         do {
             // 1. Wrap the closure-based fido.authenticate in a continuation
             //    This still throws internally within the 'do' block if the continuation resumes with an error.
             let response: [String: Any] = try await withUnsafeThrowingContinuation { continuation in
                 // Pass the workflow logger so the underlying ASAuthorization ceremony
                 // emits log messages through the same logger as the surrounding flow.
-                fido.authenticate(options: publicKeyCredentialRequestOptions, window: window, logger: logger) { [continuation] result in
+                fido.authenticate(options: publicKeyCredentialRequestOptions, window: window, preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials, logger: logger) { [continuation] result in
                     Task {
                         await MainActor.run {
                             nonisolated(unsafe) let sendableResult = result

--- a/Fido/PingFidoTests/FidoCallbackTests.swift
+++ b/Fido/PingFidoTests/FidoCallbackTests.swift
@@ -3,7 +3,7 @@
 //  FidoCallbackTests.swift
 //  PingFidoTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -139,5 +139,32 @@ class FidoCallbackTests: XCTestCase {
             // Verify the side effect on hiddenValueCallback
             XCTAssertTrue((hiddenValueCallback.value).starts(with: "ERROR::"))
         }
+    }
+
+    @MainActor
+    func testFidoAuthenticationCallbackForwardsPreferImmediatelyAvailableCredentials() async {
+        let successResponse: [String: Any] = [
+            FidoConstants.FIELD_RAW_ID: "rawId".data(using: .utf8)!,
+            FidoConstants.FIELD_CLIENT_DATA_JSON: "clientDataJSON".data(using: .utf8)!,
+            FidoConstants.FIELD_AUTHENTICATOR_DATA: "authenticatorData".data(using: .utf8)!,
+            FidoConstants.FIELD_SIGNATURE: "signature".data(using: .utf8)!,
+            FidoConstants.FIELD_USER_HANDLE: "userHandle".data(using: .utf8)!
+        ]
+
+        // Defaults to false, preserving the existing full sign-in behavior (backwards compatible).
+        let defaultMock = MockFido()
+        defaultMock.authenticationResult = .success(successResponse)
+        let defaultCallback = FidoAuthenticationCallback()
+        defaultCallback.fido = defaultMock
+        _ = await defaultCallback.authenticate(window: MockASPresentationAnchor())
+        XCTAssertEqual(defaultMock.capturedPreferImmediatelyAvailableCredentials, false)
+
+        // Explicitly requesting local-only credentials is forwarded to the underlying Fido manager.
+        let preferMock = MockFido()
+        preferMock.authenticationResult = .success(successResponse)
+        let preferCallback = FidoAuthenticationCallback()
+        preferCallback.fido = preferMock
+        _ = await preferCallback.authenticate(window: MockASPresentationAnchor(), preferImmediatelyAvailableCredentials: true)
+        XCTAssertEqual(preferMock.capturedPreferImmediatelyAvailableCredentials, true)
     }
 }

--- a/Fido/PingFidoTests/FidoCollectorTests.swift
+++ b/Fido/PingFidoTests/FidoCollectorTests.swift
@@ -3,7 +3,7 @@
 //  FidoCollectorTests.swift
 //  PingFidoTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -123,6 +123,33 @@ class FidoCollectorTests: XCTestCase {
         }
     }
     
+    @MainActor
+    func testFidoAuthenticationCollectorForwardsPreferImmediatelyAvailableCredentials() async {
+        let successResponse: [String: Any] = [
+            FidoConstants.FIELD_RAW_ID: "rawId".data(using: .utf8)!,
+            FidoConstants.FIELD_CLIENT_DATA_JSON: "clientDataJSON".data(using: .utf8)!,
+            FidoConstants.FIELD_AUTHENTICATOR_DATA: "authenticatorData".data(using: .utf8)!,
+            FidoConstants.FIELD_SIGNATURE: "signature".data(using: .utf8)!,
+            FidoConstants.FIELD_USER_HANDLE: "userHandle".data(using: .utf8)!
+        ]
+
+        // Defaults to false, preserving the existing full sign-in behavior (backwards compatible).
+        let defaultMock = MockFido()
+        defaultMock.authenticationResult = .success(successResponse)
+        let defaultCollector = FidoAuthenticationCollector(with: [FidoConstants.FIELD_PUBLIC_KEY_CREDENTIAL_REQUEST_OPTIONS: ["challenge": "test"]])
+        defaultCollector.fido = defaultMock
+        _ = await defaultCollector.authenticate(window: MockASPresentationAnchor())
+        XCTAssertEqual(defaultMock.capturedPreferImmediatelyAvailableCredentials, false)
+
+        // Explicitly requesting local-only credentials is forwarded to the underlying Fido manager.
+        let preferMock = MockFido()
+        preferMock.authenticationResult = .success(successResponse)
+        let preferCollector = FidoAuthenticationCollector(with: [FidoConstants.FIELD_PUBLIC_KEY_CREDENTIAL_REQUEST_OPTIONS: ["challenge": "test"]])
+        preferCollector.fido = preferMock
+        _ = await preferCollector.authenticate(window: MockASPresentationAnchor(), preferImmediatelyAvailableCredentials: true)
+        XCTAssertEqual(preferMock.capturedPreferImmediatelyAvailableCredentials, true)
+    }
+
     // MARK: - FidoRegistrationCollector Tests
     
     func testFidoRegistrationCollectorInit() {

--- a/Fido/PingFidoTests/Mocks.swift
+++ b/Fido/PingFidoTests/Mocks.swift
@@ -74,6 +74,9 @@ class MockFido: Fido, @unchecked Sendable {
     /// Captures the `logger` parameter passed to the most recent call to `register` or
     /// `authenticate`, so tests can assert callers propagate the workflow logger.
     var capturedLogger: Logger?
+    /// Captures the `preferImmediatelyAvailableCredentials` flag passed to the most recent
+    /// call to `authenticate`, so tests can assert callers forward it.
+    var capturedPreferImmediatelyAvailableCredentials: Bool?
 
     override func register(options: [String : Any], window: ASPresentationAnchor, logger: Logger? = nil, completion: @escaping (Result<[String : Any], Error>) -> Void) {
         capturedLogger = logger
@@ -82,8 +85,9 @@ class MockFido: Fido, @unchecked Sendable {
         }
     }
 
-    override func authenticate(options: [String : Any], window: ASPresentationAnchor, logger: Logger? = nil, completion: @escaping (Result<[String : Any], Error>) -> Void) {
+    override func authenticate(options: [String : Any], window: ASPresentationAnchor, preferImmediatelyAvailableCredentials: Bool = false, logger: Logger? = nil, completion: @escaping (Result<[String : Any], Error>) -> Void) {
         capturedLogger = logger
+        capturedPreferImmediatelyAvailableCredentials = preferImmediatelyAvailableCredentials
         if let result = authenticationResult {
             completion(result)
         }

--- a/Fido/PingFidoTests/PingFidoTests.swift
+++ b/Fido/PingFidoTests/PingFidoTests.swift
@@ -158,7 +158,9 @@ class PingFidoTests: XCTestCase {
 
         XCTAssertNotNil(capturedRequest, "Platform registration request was not created")
         XCTAssertEqual(capturedRequest?.displayName, displayName)
-        XCTAssertEqual(capturedRequest?.name, userName)
+        // When displayName is present, createPlatformRequest passes it as the `name` argument
+        // to createCredentialRegistrationRequest — this is the value shown in the system sheet.
+        XCTAssertEqual(capturedRequest?.name, displayName)
     }
 
     @MainActor func testAuthenticatePreferImmediatelyAvailableCredentialsExcludesSecurityKeyRequest() {

--- a/Fido/PingFidoTests/PingFidoTests.swift
+++ b/Fido/PingFidoTests/PingFidoTests.swift
@@ -134,6 +134,82 @@ class PingFidoTests: XCTestCase {
         waitForExpectations(timeout: 2, handler: nil)
     }
     
+    @MainActor func testPlatformRegistrationRequestCarriesDisplayName() {
+        // Arrange — build a minimal platform-only creation options dict.
+        // authenticatorAttachment: "platform" forces only the platform (passkey) request path.
+        let displayName = "Jane Doe"
+        let userName   = "janedoe"
+        let options: [String: Any] = [
+            "rp": ["id": "example.com", "name": "Example Corp"],
+            "user": ["id": "testuser", "name": userName, "displayName": displayName],
+            "challenge": "IrmRP2U3shw3plwrICzAkw/yupRI60s2dnGhfwExd/o=",
+            "pubKeyCredParams": [["type": "public-key", "alg": -7]],
+            "authenticatorSelection": ["authenticatorAttachment": "platform"]
+        ]
+
+        // Capture the request before performRequests() reaches the system.
+        var capturedRequest: ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest?
+        fido.testRequestCapture = { request in
+            capturedRequest = request as? ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest
+        }
+
+        let window = UIWindow()
+        fido.register(options: options, window: window) { _ in }
+
+        XCTAssertNotNil(capturedRequest, "Platform registration request was not created")
+        XCTAssertEqual(capturedRequest?.displayName, displayName)
+        XCTAssertEqual(capturedRequest?.name, userName)
+    }
+
+    @MainActor func testAuthenticatePreferImmediatelyAvailableCredentialsExcludesSecurityKeyRequest() {
+        // With allowCredentials present, the default (false) ceremony builds a platform request
+        // plus a security-key request. Setting preferImmediatelyAvailableCredentials to true must
+        // suppress the security-key request, since a hardware key can never be "immediately available".
+        let options: [String: Any] = [
+            "challenge": "IrmRP2U3shw3plwrICzAkw/yupRI60s2dnGhfwExd/o=",
+            "rpId": "example.com",
+            "allowCredentials": [
+                ["type": "public-key", "id": "Y3JlZGVudGlhbElk"]
+            ]
+        ]
+
+        var capturedRequests: [ASAuthorizationRequest] = []
+        fido.testRequestCapture = { request in
+            capturedRequests.append(request)
+        }
+
+        let window = UIWindow()
+        fido.authenticate(options: options, window: window, preferImmediatelyAvailableCredentials: true) { _ in }
+
+        XCTAssertEqual(capturedRequests.count, 1, "Only the platform request should be built when preferring immediately available credentials")
+        XCTAssertTrue(capturedRequests.first is ASAuthorizationPlatformPublicKeyCredentialAssertionRequest)
+        XCTAssertFalse(capturedRequests.contains { $0 is ASAuthorizationSecurityKeyPublicKeyCredentialAssertionRequest })
+    }
+
+    @MainActor func testAuthenticateDefaultIncludesSecurityKeyRequestWhenAllowCredentialsPresent() {
+        // Existing (default) behavior: allowCredentials present builds both a platform request
+        // and a security-key request. This must be unaffected by the new option's default value.
+        let options: [String: Any] = [
+            "challenge": "IrmRP2U3shw3plwrICzAkw/yupRI60s2dnGhfwExd/o=",
+            "rpId": "example.com",
+            "allowCredentials": [
+                ["type": "public-key", "id": "Y3JlZGVudGlhbElk"]
+            ]
+        ]
+
+        var capturedRequests: [ASAuthorizationRequest] = []
+        fido.testRequestCapture = { request in
+            capturedRequests.append(request)
+        }
+
+        let window = UIWindow()
+        fido.authenticate(options: options, window: window) { _ in }
+
+        XCTAssertEqual(capturedRequests.count, 2, "Both platform and security-key requests should be built by default")
+        XCTAssertTrue(capturedRequests.contains { $0 is ASAuthorizationPlatformPublicKeyCredentialAssertionRequest })
+        XCTAssertTrue(capturedRequests.contains { $0 is ASAuthorizationSecurityKeyPublicKeyCredentialAssertionRequest })
+    }
+
     func testFidoRegistrationCallbackTransform() {
         let callback = FidoRegistrationCallback()
         let input: [String: Any] = [

--- a/SampleApps/PingExample/PingExample/Callbacks/FidoAuthenticationCallbackView.swift
+++ b/SampleApps/PingExample/PingExample/Callbacks/FidoAuthenticationCallbackView.swift
@@ -2,7 +2,7 @@
 //  FidoAuthenticationCallbackView.swift
 //  PingExample
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -14,35 +14,35 @@ import PingFido
 struct FidoAuthenticationCallbackView: View {
     var callback: FidoAuthenticationCallback
     let onNext: () -> Void
-    
+
+    @State private var preferImmediatelyAvailableCredentials = false
+
     var body: some View {
         VStack {
             Text("FIDO Authentication")
                 .font(.title)
-            
-            // 1. Button action still creates a Task
+
+            Toggle("Local credentials only", isOn: $preferImmediatelyAvailableCredentials)
+                .padding(.horizontal)
+
             Button(action: {
                 Task {
-                    // 2. Get the window
                     guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                           let window = windowScene.windows.first else {
                         print("Could not find active window scene.")
-                        // Consider how to handle this UI-wise
-                        return // Exit if no window found
+                        return
                     }
-                    
-                    // 3. Call the async function and await its Result
-                    let result = await callback.authenticate(window: window)
-                    
-                    // 4. Handle the Result
+
+                    let result = await callback.authenticate(
+                        window: window,
+                        preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
+                    )
+
                     switch result {
                     case .success(let responseDict):
-                        // Optional: Use responseDict if needed
                         print("FIDO Authentication successful: \(responseDict)")
-                        // Call onNext success
                         onNext()
                     case .failure(let error):
-                        // Handle errors
                         print("FIDO Authentication failed: \(error.localizedDescription)")
                         onNext()
                     }

--- a/SampleApps/PingExample/PingExample/Collectors/FidoAuthenticationCollectorView.swift
+++ b/SampleApps/PingExample/PingExample/Collectors/FidoAuthenticationCollectorView.swift
@@ -2,7 +2,7 @@
 //  FidoAuthenticationCollectorView.swift
 //  PingExample
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -14,36 +14,36 @@ import PingFido
 struct FidoAuthenticationCollectorView: View {
     var collector: FidoAuthenticationCollector
     let onNext: () -> Void
-    
+
+    @State private var preferImmediatelyAvailableCredentials = false
+
     var body: some View {
         VStack {
             Text("FIDO Authentication")
                 .font(.title)
-            
-            // 1. Button action still creates a Task
+
+            Toggle("Local credentials only", isOn: $preferImmediatelyAvailableCredentials)
+                .padding(.horizontal)
+
             Button(action: {
                 Task {
-                    // 2. Get the window (same as before)
                     guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                           let window = windowScene.windows.first else {
                         print("Could not find active window scene.")
-                        return // Exit if no window found
+                        return
                     }
-                    
-                    // 3. Call the async function and await its Result
-                    let result = await collector.authenticate(window: window)
-                    
-                    // 4. Handle the Result
+
+                    let result = await collector.authenticate(
+                        window: window,
+                        preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
+                    )
+
                     switch result {
                     case .success(let assertionValue):
-                        // Optional: Use assertionValue if needed, e.g., logging
                         print("FIDO Authentication successful: \(assertionValue)")
-                        // Call onNext only on success
                         onNext()
                     case .failure(let error):
-                        // Handle errors
                         print("FIDO Authentication failed: \(error.localizedDescription)")
-                        // Optionally: show an alert to the user here
                     }
                 }
             }) {


### PR DESCRIPTION
# JIRA Ticket

[SDKS-5212](https://bugster.forgerock.org/jira/browse/SDKS-5212)

# Description

Adds a `preferImmediatelyAvailableCredentials` option to FIDO authentication, restricting the ceremony to locally-available credentials (no QR / nearby-device fallback), matching the legacy `FRWebAuthnManager.signInWith(preferImmediatelyAvailableCredentials:)` behavior.

Exposed on:
- `Fido.authenticate` (core)
- `FidoAuthenticationCollector.authenticate` (DaVinci)
- `FidoAuthenticationCallback.authenticate` (Journey)

Defaults to `false` to preserve existing behavior. When `true`, the security-key (cross-platform) request is not built, since a hardware key can never be "immediately available" on the local device, and `performRequests(options: .preferImmediatelyAvailableCredentials)` is used to suppress the QR/nearby-device fallback UI.

Also includes an unrelated pre-existing bug fix (`request.displayName = options.user.displayName` in `createPlatformRequest`) so the WebAuthn Registration Node's configured display name is shown during passkey creation instead of falling back to the username.

Sample app (`FidoAuthenticationCallbackView`/`FidoAuthenticationCollectorView`) exposes the new option via a "Local credentials only" toggle.

# Checklist:

- [x] I ran all unit tests and they pass
- [x] I added test case coverage for my changes