### PR TITLE
Enhance FIDO2 Error Handling

### DIFF
--- a/Davinci/Davinci/collector/Collectors.swift
+++ b/Davinci/Davinci/collector/Collectors.swift
@@ -18,8 +18,22 @@ public typealias Collectors = [any Collector]
 extension Collectors {
     /// Finds the event type from a list of collectors.
     /// This function iterates over the list of collectors and returns the value if the collector's value is not empty.
+    /// Submit/Flow collectors take precedence over ActionKeyProvider collectors so a failed FIDO
+    /// collector cannot shadow an explicit user action in the same node.
     /// - Returns: The event type as a String if found, otherwise nil.
     public func eventType() -> String? {
+        // First pass: honour explicit Submit/Flow actions.
+        for collector in self {
+            switch collector {
+            case let collector as SubmitCollector where !collector.value.isEmpty:
+                return collector.eventType()
+            case let collector as FlowCollector where !collector.value.isEmpty:
+                return collector.eventType()
+            default:
+                break
+            }
+        }
+        // Second pass: fall back to ActionKeyProvider-based event types (e.g. FIDO errors).
         for collector in self {
             if let submittable = collector as? Submittable {
                 if collector.payload() != nil {
@@ -33,6 +47,8 @@ extension Collectors {
     /// Represents a list of collectors as a JSON object for posting to the server.
     /// This function takes a list of collectors and represents it as a JSON object. It iterates over the list of collectors,
     /// adding each collector's key and value to the JSON object if the collector's value is not empty.
+    /// `SubmitCollector` and `FlowCollector` always take precedence for `actionKey`; an `ActionKeyProvider`
+    /// (e.g. a failed FIDO collector) only sets `actionKey` when it has not already been set.
     /// - Returns: JSON object representing the list of collectors.
     public func asJson() -> [String: Any] {
         var jsonObject: [String: Any] = [:]
@@ -49,7 +65,8 @@ extension Collectors {
                 }
             default:
                 if let actionKeyProvider = collector as? any ActionKeyProvider,
-                   let key = actionKeyProvider.actionKey {
+                   let key = actionKeyProvider.actionKey,
+                   jsonObject[Constants.actionKey] == nil {
                     jsonObject[Constants.actionKey] = key
                 } else if let fieldCollector = collector as? (any AnyFieldCollector),
                           let payload = fieldCollector.anyPayload() {

--- a/Davinci/Davinci/collector/Collectors.swift
+++ b/Davinci/Davinci/collector/Collectors.swift
@@ -2,7 +2,7 @@
 //  Collectors.swift
 //  PingDavinciPlugin
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -48,7 +48,11 @@ extension Collectors {
                     jsonObject[Constants.actionKey] = collector.id
                 }
             default:
-                if let fieldCollector = collector as? (any AnyFieldCollector), let payload = fieldCollector.anyPayload() {
+                if let actionKeyProvider = collector as? any ActionKeyProvider,
+                   let key = actionKeyProvider.actionKey {
+                    jsonObject[Constants.actionKey] = key
+                } else if let fieldCollector = collector as? (any AnyFieldCollector),
+                          let payload = fieldCollector.anyPayload() {
                     formData[fieldCollector.id] = payload
                 }
             }

--- a/DavinciPlugin/DavinciPlugin/Submittable.swift
+++ b/DavinciPlugin/DavinciPlugin/Submittable.swift
@@ -2,7 +2,7 @@
 //  Submittable.swift
 //  PingDavinciPlugin
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -15,5 +15,11 @@
 public protocol Submittable {
     /// Returns the event type string to use for submission.
     func eventType() -> String
+}
+
+/// Adopted by collectors that supply an `actionKey` directly rather than contributing to `formData`.
+/// Used by the FIDO error path to propagate WebAuthn DOMException names to the DaVinci server.
+public protocol ActionKeyProvider {
+    var actionKey: String? { get }
 }
 

--- a/Fido/Fido/Davinci/AbstractFidoCollector.swift
+++ b/Fido/Fido/Davinci/AbstractFidoCollector.swift
@@ -15,12 +15,18 @@ import PingOrchestrate
 import AuthenticationServices
 
 /// An abstract base class for Fido collectors in a DaVinci flow.
-public class AbstractFidoCollector: AnyFieldCollector, DaVinciAware, Submittable, @unchecked Sendable {
-    
+public class AbstractFidoCollector: AnyFieldCollector, DaVinciAware, Submittable, ActionKeyProvider, @unchecked Sendable {
+
     public private(set) var type: String = ""
     public private(set) var key: String = ""
     public private(set) var label: String = ""
     public private(set) var required: Bool = false
+
+    /// DOMException name set when a FIDO operation fails; drives the DaVinci error response.
+    public var errorCode: String?
+
+    /// Supplies the DOMException name as `actionKey` when a FIDO error has occurred.
+    public var actionKey: String? { errorCode }
     
     /// The UUID of the field collector.
     public var id: String {
@@ -68,9 +74,9 @@ public class AbstractFidoCollector: AnyFieldCollector, DaVinciAware, Submittable
         set { _fido = newValue }
     }
     
-    /// Returns the event type for submission.
+    /// Returns the event type for submission. Returns `"action"` when a FIDO error has occurred.
     public func eventType() -> String {
-        return FidoConstants.EVENT_TYPE_SUBMIT
+        return errorCode != nil ? FidoConstants.EVENT_TYPE_ACTION : FidoConstants.EVENT_TYPE_SUBMIT
     }
     
     /// A factory method to create the appropriate Fido collector based on the action specified in the JSON payload.
@@ -94,64 +100,80 @@ public class AbstractFidoCollector: AnyFieldCollector, DaVinciAware, Submittable
     
     /// Handles errors that occur during FIDO operations and transforms them into WebAuthn-spec-compliant errors.
     ///
-    /// This method converts `ASAuthorizationError` codes and `FidoError` types into human-readable error information
-    /// based on the WebAuthn specification. The transformed error is returned to the caller.
+    /// Sets `errorCode` to the appropriate WebAuthn DOMException name so the DaVinci server receives
+    /// an `actionKey` on the next submission. Returns the transformed `FidoError` to the caller.
     ///
     /// - Parameter error: The error to handle and transform.
     /// - Returns: A transformed `FidoError` that is more human-readable and spec-compliant.
     public func handleError(error: Error) -> FidoError {
         logger.e("Handling FIDO error: \(error.localizedDescription)", error: error)
-        
-        // Check if it's a FidoError first
+
         if let fidoError = error as? FidoError {
             switch fidoError {
             case .timeout:
                 logger.d("FIDO operation timed out")
+                errorCode = FidoConstants.ERROR_TIMEOUT
                 return .timeout
             case .unsupportedAction(let message):
                 logger.d("FIDO ERROR NOT SUPPORTED: \(message)")
+                errorCode = FidoConstants.ERROR_NOT_SUPPORTED
                 return .unsupportedAction(message)
             case .invalidResponse:
                 logger.d("FIDO invalid response")
+                errorCode = FidoConstants.ERROR_INVALID_STATE
                 return .invalidResponse
             case .invalidChallenge:
                 logger.d("FIDO invalid challenge")
+                errorCode = FidoConstants.ERROR_INVALID_STATE
                 return .invalidChallenge
             case .invalidWindow:
                 logger.d("FIDO invalid window")
+                errorCode = FidoConstants.ERROR_UNKNOWN
                 return .invalidWindow
             case .invalidAction:
                 logger.d("FIDO invalid action")
+                errorCode = FidoConstants.ERROR_NOT_SUPPORTED
                 return .invalidAction
             case .missingParameters(let message):
                 logger.d("FIDO missing parameters: \(message)")
+                errorCode = FidoConstants.ERROR_NOT_SUPPORTED
                 return .missingParameters(message)
             }
         }
-        
+
         let nsError = error as NSError
-        
+
         switch nsError.domain {
         case ASAuthorizationError.errorDomain:
             switch nsError.code {
             case ASAuthorizationError.canceled.rawValue:
                 logger.d("Credential operation cancelled")
+                errorCode = FidoConstants.ERROR_NOT_ALLOWED
+                return .unsupportedAction(FidoConstants.ERROR_NOT_ALLOWED_MESSAGE)
+            case ASAuthorizationError.failed.rawValue:
+                logger.d("Credential operation failed")
+                errorCode = FidoConstants.ERROR_NOT_ALLOWED
                 return .unsupportedAction(FidoConstants.ERROR_NOT_ALLOWED_MESSAGE)
             case ASAuthorizationError.invalidResponse.rawValue:
                 logger.d("DOM exception occurred: InvalidStateError")
+                errorCode = FidoConstants.ERROR_INVALID_STATE
                 return .invalidResponse
             case ASAuthorizationError.notHandled.rawValue:
                 logger.d("DOM exception occurred: NotSupportedError")
+                errorCode = FidoConstants.ERROR_NOT_SUPPORTED
                 return .unsupportedAction("Operation not supported")
             case ASAuthorizationError.unknown.rawValue:
                 logger.d("Unknown error occurred")
+                errorCode = FidoConstants.ERROR_UNKNOWN
                 return .unsupportedAction("Unknown error: \(error.localizedDescription)")
             default:
                 logger.d("Unknown authorization error occurred")
+                errorCode = FidoConstants.ERROR_UNKNOWN
                 return .unsupportedAction("Unknown error: \(error.localizedDescription)")
             }
         default:
             logger.d("Unknown error occurred")
+            errorCode = FidoConstants.ERROR_UNKNOWN
             return .unsupportedAction("Unknown error: \(error.localizedDescription)")
         }
     }

--- a/Fido/Fido/Davinci/FidoAuthenticationCollector.swift
+++ b/Fido/Fido/Davinci/FidoAuthenticationCollector.swift
@@ -129,6 +129,7 @@ public class FidoAuthenticationCollector: AbstractFidoCollector, Closeable, @unc
             ]
             
             logger.d("assertionValue object created successfully")
+            self.errorCode = nil
             self.assertionValue = newAssertionValue // Store the value (side effect)
             
             // 4. Return success with the constructed assertionValue

--- a/Fido/Fido/Davinci/FidoAuthenticationCollector.swift
+++ b/Fido/Fido/Davinci/FidoAuthenticationCollector.swift
@@ -22,9 +22,10 @@ import PingCommons
 /// A collector for FIDO authentication within a DaVinci flow.
 public class FidoAuthenticationCollector: AbstractFidoCollector, Closeable, @unchecked Sendable {
     
-    /// Resets the collector's state by clearing the assertion value.
+    /// Resets the collector's state by clearing the assertion value and any recorded error code.
     public func close() {
         self.assertionValue = nil
+        self.errorCode = nil
     }
     
     /// The public key credential request options provided by the server.
@@ -49,8 +50,13 @@ public class FidoAuthenticationCollector: AbstractFidoCollector, Closeable, @unc
     
     /// The payload to be sent to the DaVinci server.
     ///
-    /// - Returns: A dictionary containing the assertion value, or `nil` if authentication has not been completed.
+    /// Returns an empty dictionary when a FIDO error has occurred (non-nil sentinel so
+    /// `Collectors.eventType()` picks up this collector and the `actionKey` error path fires).
+    /// Returns `nil` when no FIDO operation has been completed yet.
     override public func payload() -> [String: Any]? {
+        if errorCode != nil {
+            return [:]
+        }
         guard let assertionValue = assertionValue else {
             logger.d("No assertion value available, returning null payload")
             return nil

--- a/Fido/Fido/Davinci/FidoRegistrationCollector.swift
+++ b/Fido/Fido/Davinci/FidoRegistrationCollector.swift
@@ -119,6 +119,7 @@ public class FidoRegistrationCollector: AbstractFidoCollector, Closeable, @unche
             ]
             
             logger.d("attestationValue object created successfully")
+            self.errorCode = nil
             self.attestationValue = newAttestationValue // Store the value (side effect)
             
             // 4. Return success with the constructed attestationValue

--- a/Fido/Fido/Davinci/FidoRegistrationCollector.swift
+++ b/Fido/Fido/Davinci/FidoRegistrationCollector.swift
@@ -21,9 +21,10 @@ import PingCommons
 /// A collector for FIDO registration within a DaVinci flow.
 public class FidoRegistrationCollector: AbstractFidoCollector, Closeable, @unchecked Sendable {
     
-    /// Resets the collector's state by clearing the attestation value.
+    /// Resets the collector's state by clearing the attestation value and any recorded error code.
     public func close() {
         self.attestationValue = nil
+        self.errorCode = nil
     }
     
     /// The public key credential creation options provided by the server.
@@ -48,8 +49,13 @@ public class FidoRegistrationCollector: AbstractFidoCollector, Closeable, @unche
     
     /// The payload to be sent to the DaVinci server.
     ///
-    /// - Returns: A dictionary containing the attestation value, or `nil` if registration has not been completed.
+    /// Returns an empty dictionary when a FIDO error has occurred (non-nil sentinel so
+    /// `Collectors.eventType()` picks up this collector and the `actionKey` error path fires).
+    /// Returns `nil` when no FIDO operation has been completed yet.
     override public func payload() -> [String: Any]? {
+        if errorCode != nil {
+            return [:]
+        }
         guard let attestationValue = attestationValue else {
             logger.d("No attestation value available, returning null payload")
             return nil

--- a/Fido/Fido/FidoConstants.swift
+++ b/Fido/Fido/FidoConstants.swift
@@ -160,7 +160,9 @@ public struct FidoConstants {
     public static let WEB_AUTHN_OUTCOME = "webAuthnOutcome"
 
     // MARK: - Error Types
-
+    // An unsupported error type.
+    @available(*, deprecated, renamed: "ERROR_NOT_SUPPORTED")
+    public static let ERROR_UNSUPPORTED = "unsupported"
     /// A timeout error type.
     public static let ERROR_TIMEOUT = "TimeoutError"
     /// The error code for a cancelled operation.

--- a/Fido/Fido/FidoConstants.swift
+++ b/Fido/Fido/FidoConstants.swift
@@ -160,7 +160,7 @@ public struct FidoConstants {
     public static let WEB_AUTHN_OUTCOME = "webAuthnOutcome"
 
     // MARK: - Error Types
-    // An unsupported error type.
+    /// An unsupported error type.
     @available(*, deprecated, renamed: "ERROR_NOT_SUPPORTED")
     public static let ERROR_UNSUPPORTED = "unsupported"
     /// A timeout error type.

--- a/Fido/Fido/FidoConstants.swift
+++ b/Fido/Fido/FidoConstants.swift
@@ -20,9 +20,11 @@ public struct FidoConstants {
     public static let ACTION_AUTHENTICATE = "AUTHENTICATE"
 
     // MARK: - Event Types
-    
+
     /// Event type for submitting a FIDO response.
     public static let EVENT_TYPE_SUBMIT = "submit"
+    /// Event type for reporting a FIDO error back to the DaVinci server.
+    public static let EVENT_TYPE_ACTION = "action"
 
     // MARK: - JSON Fields
     // Key field
@@ -158,9 +160,7 @@ public struct FidoConstants {
     public static let WEB_AUTHN_OUTCOME = "webAuthnOutcome"
 
     // MARK: - Error Types
-    
-    /// An unsupported error type.
-    public static let ERROR_UNSUPPORTED = "unsupported"
+
     /// A timeout error type.
     public static let ERROR_TIMEOUT = "TimeoutError"
     /// The error code for a cancelled operation.

--- a/Fido/PingFidoTests/FidoAuthenticationCollectorTests.swift
+++ b/Fido/PingFidoTests/FidoAuthenticationCollectorTests.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -38,18 +38,29 @@ class FidoAuthenticationCollectorTests: XCTestCase {
     func testCloseShouldAllowReuse() {
         let assertion1 = ["test": "value1"]
         let assertion2 = ["test": "value2"]
-        
+
         collector.assertionValue = assertion1
         var payload = collector.payload()
         XCTAssertNotNil(payload)
         XCTAssertEqual(payload?["assertionValue"] as? [String: String], assertion1)
-        
+
         collector.close()
         XCTAssertNil(collector.payload())
-        
+
         collector.assertionValue = assertion2
         payload = collector.payload()
         XCTAssertNotNil(payload)
         XCTAssertEqual(payload?["assertionValue"] as? [String: String], assertion2)
+    }
+
+    func testCloseShouldClearErrorCode() {
+        collector.errorCode = FidoConstants.ERROR_NOT_ALLOWED
+        XCTAssertNotNil(collector.errorCode)
+        XCTAssertNotNil(collector.payload())
+
+        collector.close()
+
+        XCTAssertNil(collector.errorCode)
+        XCTAssertNil(collector.payload())
     }
 }

--- a/Fido/PingFidoTests/FidoCollectorTests.swift
+++ b/Fido/PingFidoTests/FidoCollectorTests.swift
@@ -1,4 +1,3 @@
-
 //
 //  FidoCollectorTests.swift
 //  PingFidoTests
@@ -10,7 +9,10 @@
 //
 
 import XCTest
+import AuthenticationServices
 @testable import PingFido
+@testable import PingDavinci
+@testable import PingDavinciPlugin
 internal import PingCommons
 
 class FidoCollectorTests: XCTestCase {
@@ -123,6 +125,98 @@ class FidoCollectorTests: XCTestCase {
         }
     }
     
+    // MARK: - Error Propagation Tests
+
+    func testHandleErrorSetsDOMExceptionNameForFidoErrors() {
+        let collector = FidoAuthenticationCollector(with: [FidoConstants.FIELD_PUBLIC_KEY_CREDENTIAL_REQUEST_OPTIONS: ["challenge": "test"]])
+
+        let cases: [(FidoError, String)] = [
+            (.timeout, FidoConstants.ERROR_TIMEOUT),
+            (.unsupportedAction("msg"), FidoConstants.ERROR_NOT_SUPPORTED),
+            (.invalidResponse, FidoConstants.ERROR_INVALID_STATE),
+            (.invalidChallenge, FidoConstants.ERROR_INVALID_STATE),
+            (.invalidWindow, FidoConstants.ERROR_UNKNOWN),
+            (.invalidAction, FidoConstants.ERROR_NOT_SUPPORTED),
+            (.missingParameters("msg"), FidoConstants.ERROR_NOT_SUPPORTED),
+        ]
+
+        for (fidoError, expectedCode) in cases {
+            collector.errorCode = nil
+            _ = collector.handleError(error: fidoError)
+            XCTAssertEqual(collector.errorCode, expectedCode, "Expected errorCode \(expectedCode) for \(fidoError)")
+        }
+    }
+
+    func testHandleErrorSetsDOMExceptionNameForASAuthorizationErrors() {
+        let collector = FidoAuthenticationCollector(with: [FidoConstants.FIELD_PUBLIC_KEY_CREDENTIAL_REQUEST_OPTIONS: ["challenge": "test"]])
+
+        let cases: [(Int, String)] = [
+            (ASAuthorizationError.canceled.rawValue, FidoConstants.ERROR_NOT_ALLOWED),
+            (ASAuthorizationError.failed.rawValue, FidoConstants.ERROR_NOT_ALLOWED),
+            (ASAuthorizationError.invalidResponse.rawValue, FidoConstants.ERROR_INVALID_STATE),
+            (ASAuthorizationError.notHandled.rawValue, FidoConstants.ERROR_NOT_SUPPORTED),
+            (ASAuthorizationError.unknown.rawValue, FidoConstants.ERROR_UNKNOWN),
+        ]
+
+        for (code, expectedCode) in cases {
+            collector.errorCode = nil
+            let nsError = NSError(domain: ASAuthorizationError.errorDomain, code: code, userInfo: nil)
+            _ = collector.handleError(error: nsError)
+            XCTAssertEqual(collector.errorCode, expectedCode, "Expected errorCode \(expectedCode) for ASAuthorizationError code \(code)")
+        }
+    }
+
+    func testEventTypeIsSubmitByDefault() {
+        let collector = FidoAuthenticationCollector(with: [FidoConstants.FIELD_PUBLIC_KEY_CREDENTIAL_REQUEST_OPTIONS: ["challenge": "test"]])
+        XCTAssertEqual(collector.eventType(), FidoConstants.EVENT_TYPE_SUBMIT)
+    }
+
+    func testEventTypeIsActionAfterError() {
+        let collector = FidoAuthenticationCollector(with: [FidoConstants.FIELD_PUBLIC_KEY_CREDENTIAL_REQUEST_OPTIONS: ["challenge": "test"]])
+        collector.errorCode = FidoConstants.ERROR_NOT_ALLOWED
+        XCTAssertEqual(collector.eventType(), FidoConstants.EVENT_TYPE_ACTION)
+    }
+
+    func testPayloadIsNonNilAfterError() {
+        let collector = FidoAuthenticationCollector(with: [FidoConstants.FIELD_PUBLIC_KEY_CREDENTIAL_REQUEST_OPTIONS: ["challenge": "test"]])
+        XCTAssertNil(collector.payload())
+
+        collector.errorCode = FidoConstants.ERROR_NOT_ALLOWED
+        let payload = collector.payload()
+        XCTAssertNotNil(payload)
+        XCTAssertTrue(payload?.isEmpty == true, "Error-path payload must be empty dict so formData stays empty")
+    }
+
+    func testActionKeyMatchesErrorCode() {
+        let collector = FidoAuthenticationCollector(with: [FidoConstants.FIELD_PUBLIC_KEY_CREDENTIAL_REQUEST_OPTIONS: ["challenge": "test"]])
+        XCTAssertNil(collector.actionKey)
+
+        collector.errorCode = FidoConstants.ERROR_NOT_ALLOWED
+        XCTAssertEqual(collector.actionKey, FidoConstants.ERROR_NOT_ALLOWED)
+    }
+
+    func testAsJsonContainsActionKeyOnAuthenticationError() {
+        let collector = FidoAuthenticationCollector(with: [FidoConstants.FIELD_PUBLIC_KEY_CREDENTIAL_REQUEST_OPTIONS: ["challenge": "test"]])
+        _ = collector.handleError(error: NSError(domain: ASAuthorizationError.errorDomain, code: ASAuthorizationError.canceled.rawValue, userInfo: nil))
+
+        let collectors: Collectors = [collector]
+        let json = collectors.asJson()
+
+        XCTAssertEqual(json["actionKey"] as? String, FidoConstants.ERROR_NOT_ALLOWED)
+        XCTAssertTrue((json["formData"] as? [String: Any])?.isEmpty == true)
+    }
+
+    func testAsJsonContainsActionKeyOnRegistrationError() {
+        let collector = FidoRegistrationCollector(with: [FidoConstants.FIELD_PUBLIC_KEY_CREDENTIAL_CREATION_OPTIONS: ["rp": ["name": "test"]]])
+        _ = collector.handleError(error: FidoError.timeout)
+
+        let collectors: Collectors = [collector]
+        let json = collectors.asJson()
+
+        XCTAssertEqual(json["actionKey"] as? String, FidoConstants.ERROR_TIMEOUT)
+        XCTAssertTrue((json["formData"] as? [String: Any])?.isEmpty == true)
+    }
+
     @MainActor
     func testFidoAuthenticationCollectorForwardsPreferImmediatelyAvailableCredentials() async {
         let successResponse: [String: Any] = [

--- a/Fido/PingFidoTests/FidoRegistrationCollectorTests.swift
+++ b/Fido/PingFidoTests/FidoRegistrationCollectorTests.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -38,18 +38,29 @@ class FidoRegistrationCollectorTests: XCTestCase {
     func testCloseShouldAllowReuse() {
         let attestation1 = ["test": "value1"]
         let attestation2 = ["test": "value2"]
-        
+
         collector.attestationValue = attestation1
         var payload = collector.payload()
         XCTAssertNotNil(payload)
         XCTAssertEqual(payload?["attestationValue"] as? [String: String], attestation1)
-        
+
         collector.close()
         XCTAssertNil(collector.payload())
-        
+
         collector.attestationValue = attestation2
         payload = collector.payload()
         XCTAssertNotNil(payload)
         XCTAssertEqual(payload?["attestationValue"] as? [String: String], attestation2)
+    }
+
+    func testCloseShouldClearErrorCode() {
+        collector.errorCode = FidoConstants.ERROR_NOT_ALLOWED
+        XCTAssertNotNil(collector.errorCode)
+        XCTAssertNotNil(collector.payload())
+
+        collector.close()
+
+        XCTAssertNil(collector.errorCode)
+        XCTAssertNil(collector.payload())
     }
 }

--- a/SampleApps/PingExample/PingExample/Collectors/FidoAuthenticationCollectorView.swift
+++ b/SampleApps/PingExample/PingExample/Collectors/FidoAuthenticationCollectorView.swift
@@ -44,6 +44,7 @@ struct FidoAuthenticationCollectorView: View {
                         onNext()
                     case .failure(let error):
                         print("FIDO Authentication failed: \(error.localizedDescription)")
+                        onNext()
                     }
                 }
             }) {

--- a/SampleApps/PingExample/PingExample/Collectors/FidoRegistrationCollectorView.swift
+++ b/SampleApps/PingExample/PingExample/Collectors/FidoRegistrationCollectorView.swift
@@ -2,7 +2,7 @@
 //  FidoRegistrationCollectorView.swift
 //  PingExample
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -51,9 +51,8 @@ struct FidoRegistrationCollectorView: View {
                         // Call onNext only on success
                         onNext()
                     case .failure(let error):
-                        // Handle errors
                         print("FIDO Registration failed: \(error.localizedDescription)")
-                        // Optionally: show an alert to the user here
+                        onNext()
                     }
                 }
             }) {


### PR DESCRIPTION
[SDKS-4478](https://pingidentity.atlassian.net/browse/SDKS-4478) [iOS] Enhance FIDO2 Error Handling


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Exposed standardized FIDO failure context via an action key and added a new `"action"` event type when errors occur.
  - Collectors’ JSON output now prefers action keys when available, otherwise falls back to form data.

- **Bug Fixes**
  - Improved collector cleanup: authentication/registration collectors now clear recorded error state (and related payload signals) on reuse.
  - Sample app flows now continue correctly after failed FIDO authentication/registration.

- **Tests**
  - Expanded coverage for error propagation, event type switching, payload behavior, action key propagation, JSON output, and close/reuse behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->