### PR TITLE
Extend ActionKeyProvider conformance to SubmitCollector, FlowCollector, and MetadataCollector

### DIFF
--- a/Davinci/Davinci/collector/Collectors.swift
+++ b/Davinci/Davinci/collector/Collectors.swift
@@ -35,10 +35,8 @@ extension Collectors {
         }
         // Second pass: fall back to ActionKeyProvider-based event types (e.g. FIDO errors).
         for collector in self {
-            if let submittable = collector as? Submittable {
-                if collector.payload() != nil {
-                    return submittable.eventType()
-                }
+            if let submittable = collector as? any Submittable, collector.payload() != nil {
+                return submittable.eventType()
             }
         }
         return nil
@@ -55,13 +53,9 @@ extension Collectors {
         var formData: [String: Any] = [:]
         for collector in self {
             switch collector {
-            case let collector as SubmitCollector:
-                if collector.value.isEmpty == false {
-                    jsonObject[Constants.actionKey] = collector.id
-                }
-            case let collector as FlowCollector:
-                if collector.value.isEmpty == false {
-                    jsonObject[Constants.actionKey] = collector.id
+            case let collector as (any ActionKeyProvider) where collector is SubmitCollector || collector is FlowCollector:
+                if let key = collector.actionKey {
+                    jsonObject[Constants.actionKey] = key
                 }
             case let collector as MetadataCollector:
                 if let payload = collector.anyPayload() {

--- a/Davinci/Davinci/collector/Collectors.swift
+++ b/Davinci/Davinci/collector/Collectors.swift
@@ -1,6 +1,6 @@
 // 
 //  Collectors.swift
-//  PingDavinciPlugin
+//  PingDavinci
 //
 //  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
@@ -17,17 +17,19 @@ public typealias Collectors = [any Collector]
 
 extension Collectors {
     /// Finds the event type from a list of collectors.
-    /// This function iterates over the list of collectors and returns the value if the collector's value is not empty.
-    /// Submit/Flow collectors take precedence over ActionKeyProvider collectors so a failed FIDO
-    /// collector cannot shadow an explicit user action in the same node.
+    /// Returns the event type from the first `SubmitCollector` or `FlowCollector` whose `actionKey`
+    /// is non-nil (i.e. the user has selected that button), then falls back to the first `Submittable`
+    /// whose `payload()` is non-nil (e.g. a failed FIDO collector reporting a WebAuthn error).
+    /// Submit/Flow collectors take precedence so a concurrently-failed FIDO collector cannot shadow
+    /// an explicit user action in the same node.
     /// - Returns: The event type as a String if found, otherwise nil.
     public func eventType() -> String? {
         // First pass: honour explicit Submit/Flow actions.
         for collector in self {
             switch collector {
-            case let collector as SubmitCollector where !collector.value.isEmpty:
+            case let collector as SubmitCollector where collector.actionKey != nil:
                 return collector.eventType()
-            case let collector as FlowCollector where !collector.value.isEmpty:
+            case let collector as FlowCollector where collector.actionKey != nil:
                 return collector.eventType()
             default:
                 break
@@ -45,8 +47,9 @@ extension Collectors {
     /// Represents a list of collectors as a JSON object for posting to the server.
     /// This function takes a list of collectors and represents it as a JSON object. It iterates over the list of collectors,
     /// adding each collector's key and value to the JSON object if the collector's value is not empty.
-    /// `SubmitCollector` and `FlowCollector` always take precedence for `actionKey`; an `ActionKeyProvider`
-    /// (e.g. a failed FIDO collector) only sets `actionKey` when it has not already been set.
+    /// `SubmitCollector`, `FlowCollector`, and `MetadataCollector` always take precedence for `actionKey`;
+    /// any other `ActionKeyProvider` (e.g. a failed FIDO collector) only sets `actionKey` when it has not
+    /// already been set.
     /// - Returns: JSON object representing the list of collectors.
     public func asJson() -> [String: Any] {
         var jsonObject: [String: Any] = [:]
@@ -58,9 +61,9 @@ extension Collectors {
                     jsonObject[Constants.actionKey] = key
                 }
             case let collector as MetadataCollector:
-                if let payload = collector.anyPayload() {
-                    jsonObject[Constants.actionKey] = collector.id
-                    formData[collector.id] = payload
+                if let key = collector.actionKey, let payload = collector.anyPayload() {
+                    jsonObject[Constants.actionKey] = key
+                    formData[key] = payload
                 }
             default:
                 if let actionKeyProvider = collector as? any ActionKeyProvider,

--- a/Davinci/Davinci/collector/FlowCollector.swift
+++ b/Davinci/Davinci/collector/FlowCollector.swift
@@ -17,13 +17,15 @@ import PingOrchestrate
 ///
 /// This class is used to handle user interactions that trigger a flow action,
 /// like navigating to a different part of the flow.
-public class FlowCollector: SingleValueCollector, Submittable, Closeable, @unchecked Sendable {
-    
+public class FlowCollector: SingleValueCollector, Submittable, ActionKeyProvider, Closeable, @unchecked Sendable {
+
+    public var actionKey: String? { value.isEmpty ? nil : id }
+
     /// Resets the collector's state by clearing its value.
     public func close() {
         self.value = ""
     }
-    
+
     /// Returns the event type for this collector.
     /// - Returns: A string representing the event type, which is "action".
     public func eventType() -> String {

--- a/Davinci/Davinci/collector/FlowCollector.swift
+++ b/Davinci/Davinci/collector/FlowCollector.swift
@@ -2,7 +2,7 @@
 //  FlowCollector.swift
 //  PingDavinci
 //
-//  Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -19,6 +19,8 @@ import PingOrchestrate
 /// like navigating to a different part of the flow.
 public class FlowCollector: SingleValueCollector, Submittable, ActionKeyProvider, Closeable, @unchecked Sendable {
 
+    /// The action key to include in the submission payload.
+    /// Returns the collector's `id` when selected by the user, `nil` otherwise.
     public var actionKey: String? { value.isEmpty ? nil : id }
 
     /// Resets the collector's state by clearing its value.

--- a/Davinci/Davinci/collector/MetadataCollector.swift
+++ b/Davinci/Davinci/collector/MetadataCollector.swift
@@ -39,6 +39,8 @@ public class MetadataCollector: AnyFieldCollector, Submittable, ActionKeyProvide
 
     public var id: String { key }
 
+    /// The action key to include in the submission payload.
+    /// Returns the collector's `id` once a result has been set via `setResult(_:)` or `setError(code:message:)`, `nil` otherwise.
     public var actionKey: String? { result != nil ? id : nil }
 
     /// The form field key. Per spec always `"sdkMetadata"`.

--- a/Davinci/Davinci/collector/MetadataCollector.swift
+++ b/Davinci/Davinci/collector/MetadataCollector.swift
@@ -35,9 +35,11 @@ import PingDavinciPlugin
 ///    signal the connector's client-error branch.
 /// 3. Continue the flow as usual — the SDK serialises the result and POSTs
 ///    the resume envelope to DaVinci.
-public class MetadataCollector: AnyFieldCollector, Submittable, Validator, Closeable, @unchecked Sendable {
+public class MetadataCollector: AnyFieldCollector, Submittable, ActionKeyProvider, Validator, Closeable, @unchecked Sendable {
 
     public var id: String { key }
+
+    public var actionKey: String? { result != nil ? id : nil }
 
     /// The form field key. Per spec always `"sdkMetadata"`.
     public private(set) var key: String = ""

--- a/Davinci/Davinci/collector/SubmitCollector.swift
+++ b/Davinci/Davinci/collector/SubmitCollector.swift
@@ -16,13 +16,15 @@ import PingOrchestrate
 /// A collector for form submission actions.
 ///
 /// This class is used to handle the submission of a form, triggering the next step in the flow.
-public class SubmitCollector: SingleValueCollector, Submittable, Closeable, @unchecked Sendable {
-    
+public class SubmitCollector: SingleValueCollector, Submittable, ActionKeyProvider, Closeable, @unchecked Sendable {
+
+    public var actionKey: String? { value.isEmpty ? nil : id }
+
     /// Resets the collector's state by clearing its value.
     public func close() {
         self.value = ""
     }
-    
+
     /// Returns the event type for this collector.
     /// - Returns: A string representing the event type, which is "submit".
     public func eventType() -> String {

--- a/Davinci/Davinci/collector/SubmitCollector.swift
+++ b/Davinci/Davinci/collector/SubmitCollector.swift
@@ -2,7 +2,7 @@
 //  SubmitCollector.swift
 //  PingDavinci
 //
-//  Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -18,6 +18,8 @@ import PingOrchestrate
 /// This class is used to handle the submission of a form, triggering the next step in the flow.
 public class SubmitCollector: SingleValueCollector, Submittable, ActionKeyProvider, Closeable, @unchecked Sendable {
 
+    /// The action key to include in the submission payload.
+    /// Returns the collector's `id` when selected by the user, `nil` otherwise.
     public var actionKey: String? { value.isEmpty ? nil : id }
 
     /// Resets the collector's state by clearing its value.

--- a/Davinci/DavinciTests/FlowCollectorTests.swift
+++ b/Davinci/DavinciTests/FlowCollectorTests.swift
@@ -2,7 +2,7 @@
 //  FlowCollectorTests.swift
 //  DavinciTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -69,7 +69,7 @@ class FlowCollectorTests: XCTestCase {
 
     func testActionKeyIsIdWhenValueSet() {
         let flowCollector = FlowCollector(with: ["key": "flowBtn"])
-        flowCollector.value = "flowBtn"
+        flowCollector.value = "some-user-selection"
         XCTAssertEqual("flowBtn", flowCollector.actionKey)
     }
 }

--- a/Davinci/DavinciTests/FlowCollectorTests.swift
+++ b/Davinci/DavinciTests/FlowCollectorTests.swift
@@ -61,4 +61,15 @@ class FlowCollectorTests: XCTestCase {
         flowCollector.value = "value2"
         XCTAssertEqual("value2", flowCollector.payload())
     }
+
+    func testActionKeyIsNilWhenValueEmpty() {
+        let flowCollector = FlowCollector(with: ["key": "flowBtn"])
+        XCTAssertNil(flowCollector.actionKey)
+    }
+
+    func testActionKeyIsIdWhenValueSet() {
+        let flowCollector = FlowCollector(with: ["key": "flowBtn"])
+        flowCollector.value = "flowBtn"
+        XCTAssertEqual("flowBtn", flowCollector.actionKey)
+    }
 }

--- a/Davinci/DavinciTests/MetadataCollectorTests.swift
+++ b/Davinci/DavinciTests/MetadataCollectorTests.swift
@@ -121,6 +121,17 @@ class MetadataCollectorTests: XCTestCase {
         XCTAssertNil(collector.payload())
     }
 
+    func testActionKeyIsNilWhenNoResult() {
+        let collector = MetadataCollector(with: buildJson())
+        XCTAssertNil(collector.actionKey)
+    }
+
+    func testActionKeyIsIdWhenResultSet() {
+        let collector = MetadataCollector(with: buildJson())
+        collector.setResult(["ok": true])
+        XCTAssertEqual("sdkMetadata", collector.actionKey)
+    }
+
     // MARK: - Collectors pipeline integration
 
     func testCollectorsAsJsonProducesResumeEnvelope() {

--- a/Davinci/DavinciTests/SubmitCollectorTests.swift
+++ b/Davinci/DavinciTests/SubmitCollectorTests.swift
@@ -2,7 +2,7 @@
 //  SubmitCollectorTests.swift
 //  DavinciTests
 //
-//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -53,7 +53,7 @@ final class SubmitCollectorTests: XCTestCase {
 
     func testActionKeyIsIdWhenValueSet() {
         let submitCollector = SubmitCollector(with: ["key": "submitBtn"])
-        submitCollector.value = "submitBtn"
+        submitCollector.value = "some-user-selection"
         XCTAssertEqual("submitBtn", submitCollector.actionKey)
     }
 }

--- a/Davinci/DavinciTests/SubmitCollectorTests.swift
+++ b/Davinci/DavinciTests/SubmitCollectorTests.swift
@@ -45,4 +45,15 @@ final class SubmitCollectorTests: XCTestCase {
         submitCollector.value = "submit2"
         XCTAssertEqual("submit2", submitCollector.payload())
     }
+
+    func testActionKeyIsNilWhenValueEmpty() {
+        let submitCollector = SubmitCollector(with: ["key": "submitBtn"])
+        XCTAssertNil(submitCollector.actionKey)
+    }
+
+    func testActionKeyIsIdWhenValueSet() {
+        let submitCollector = SubmitCollector(with: ["key": "submitBtn"])
+        submitCollector.value = "submitBtn"
+        XCTAssertEqual("submitBtn", submitCollector.actionKey)
+    }
 }


### PR DESCRIPTION
[SDKS-5290](https://pingidentity.atlassian.net/browse/SDKS-5290) iOS SDK: Extend ActionKeyProvider conformance to SubmitCollector, FlowCollector, and MetadataCollector

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved action-key handling for flow, submit, and metadata collection.
  * Empty or unavailable values no longer produce invalid action keys.
  * JSON output now consistently uses valid configured action keys.

* **Tests**
  * Added coverage for action-key behavior across supported collector types.
  * Verified action keys remain unavailable until the required value or result is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->