### PR TITLE
SDKS-5281 Test new DaVinci components- #233

### DIFF
--- a/Davinci/Davinci.xcodeproj/project.pbxproj
+++ b/Davinci/Davinci.xcodeproj/project.pbxproj
@@ -68,12 +68,12 @@
 		AA4785031F0000000000AA01 /* DaVinciDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4785021F0000000000AA01 /* DaVinciDeviceTests.swift */; };
 		BB4928012F0900000000BB01 /* ReadOnlyTextCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4928002F0900000000BB01 /* ReadOnlyTextCollector.swift */; };
 		BB4928032F0900000000BB01 /* ReadOnlyTextCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4928022F0900000000BB01 /* ReadOnlyTextCollectorTests.swift */; };
-		CC5143012F0000000000CC01 /* ImageCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5143002F0000000000CC01 /* ImageCollector.swift */; };
-		CC5143032F0000000000CC01 /* ImageCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5143022F0000000000CC01 /* ImageCollectorTests.swift */; };
 		BB4928052F0900000000BB01 /* MetadataCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4928042F0900000000BB01 /* MetadataCollector.swift */; };
 		BB4928072F0900000000BB01 /* MetadataCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4928062F0900000000BB01 /* MetadataCollectorTests.swift */; };
 		BBBBBBBB00000001FAA0E2E0 /* DaVinciPARE2ETest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBBBBBB00000000FAA0E2E0 /* DaVinciPARE2ETest.swift */; };
 		BBBBBBBB00000003FAA0E2E0 /* RecordingHttpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBBBBBB00000002FAA0E2E0 /* RecordingHttpClient.swift */; };
+		CC5143012F0000000000CC01 /* ImageCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5143002F0000000000CC01 /* ImageCollector.swift */; };
+		CC5143032F0000000000CC01 /* ImageCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5143022F0000000000CC01 /* ImageCollectorTests.swift */; };
 		DA0000022F0000000000DA01 /* DeviceAuthorizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0000012F0000000000DA01 /* DeviceAuthorizationTests.swift */; };
 		EC5C81C92ECF7A1700C91570 /* PingDavinciPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC5C81C82ECF7A1700C91570 /* PingDavinciPlugin.framework */; };
 		EC5C81CA2ECF7A1700C91570 /* PingDavinciPlugin.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EC5C81C82ECF7A1700C91570 /* PingDavinciPlugin.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -91,6 +91,8 @@
 		SDKS50660003000000000002 /* DaVinciJsonConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS50660003000000000001 /* DaVinciJsonConfigTests.swift */; };
 		SDKS50680002000000000002 /* DaVinciJsonConfigE2ETest.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS50680002000000000001 /* DaVinciJsonConfigE2ETest.swift */; };
 		SDKS50680004000000000002 /* DeviceClientJsonConfigE2ETest.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS50680004000000000001 /* DeviceClientJsonConfigE2ETest.swift */; };
+		SDKS52810001000000000002 /* MetadataCollectorE2ETest.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS52810001000000000001 /* MetadataCollectorE2ETest.swift */; };
+		SDKS52810002000000000002 /* ImageCollectorE2ETest.swift in Sources */ = {isa = PBXBuildFile; fileRef = SDKS52810002000000000001 /* ImageCollectorE2ETest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -180,12 +182,12 @@
 		AA4785021F0000000000AA01 /* DaVinciDeviceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinciDeviceTests.swift; sourceTree = "<group>"; };
 		BB4928002F0900000000BB01 /* ReadOnlyTextCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadOnlyTextCollector.swift; sourceTree = "<group>"; };
 		BB4928022F0900000000BB01 /* ReadOnlyTextCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadOnlyTextCollectorTests.swift; sourceTree = "<group>"; };
-		CC5143002F0000000000CC01 /* ImageCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCollector.swift; sourceTree = "<group>"; };
-		CC5143022F0000000000CC01 /* ImageCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCollectorTests.swift; sourceTree = "<group>"; };
 		BB4928042F0900000000BB01 /* MetadataCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataCollector.swift; sourceTree = "<group>"; };
 		BB4928062F0900000000BB01 /* MetadataCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataCollectorTests.swift; sourceTree = "<group>"; };
 		BBBBBBBB00000000FAA0E2E0 /* DaVinciPARE2ETest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinciPARE2ETest.swift; sourceTree = "<group>"; };
 		BBBBBBBB00000002FAA0E2E0 /* RecordingHttpClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RecordingHttpClient.swift; path = ../Network/NetworkTests/RecordingHttpClient.swift; sourceTree = SOURCE_ROOT; };
+		CC5143002F0000000000CC01 /* ImageCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCollector.swift; sourceTree = "<group>"; };
+		CC5143022F0000000000CC01 /* ImageCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCollectorTests.swift; sourceTree = "<group>"; };
 		DA0000012F0000000000DA01 /* DeviceAuthorizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceAuthorizationTests.swift; sourceTree = "<group>"; };
 		EC5C81C82ECF7A1700C91570 /* PingDavinciPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PingDavinciPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC5C81FB2ED0CAA100C91570 /* Collectors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Collectors.swift; sourceTree = "<group>"; };
@@ -204,6 +206,8 @@
 		SDKS50660003000000000001 /* DaVinciJsonConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinciJsonConfigTests.swift; sourceTree = "<group>"; };
 		SDKS50680002000000000001 /* DaVinciJsonConfigE2ETest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaVinciJsonConfigE2ETest.swift; sourceTree = "<group>"; };
 		SDKS50680004000000000001 /* DeviceClientJsonConfigE2ETest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceClientJsonConfigE2ETest.swift; sourceTree = "<group>"; };
+		SDKS52810001000000000001 /* MetadataCollectorE2ETest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataCollectorE2ETest.swift; sourceTree = "<group>"; };
+		SDKS52810002000000000001 /* ImageCollectorE2ETest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCollectorE2ETest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -331,6 +335,8 @@
 				959249A82D405A4600A6DA9C /* FormFieldsTests.swift */,
 				95C256782DF22BFB004266AB /* MFADeviceTests.swift */,
 				FA130AA38471485588EED6A1 /* PollingCollectorIntegrationTests.swift */,
+				SDKS52810001000000000001 /* MetadataCollectorE2ETest.swift */,
+				SDKS52810002000000000001 /* ImageCollectorE2ETest.swift */,
 				BBBBBBBB00000002FAA0E2E0 /* RecordingHttpClient.swift */,
 			);
 			path = "integration tests";
@@ -551,6 +557,8 @@
 				A5EFAA082D3F30E600F771FE /* LabelCollectorTests.swift in Sources */,
 				959249A92D405A4600A6DA9C /* FormFieldsTests.swift in Sources */,
 				8FE3EB1B92044038A76D2CB3 /* PollingCollectorIntegrationTests.swift in Sources */,
+				SDKS52810001000000000002 /* MetadataCollectorE2ETest.swift in Sources */,
+				SDKS52810002000000000002 /* ImageCollectorE2ETest.swift in Sources */,
 				DA0000022F0000000000DA01 /* DeviceAuthorizationTests.swift in Sources */,
 				A5EFAA142D3F51CC00F771FE /* TextCollectorTests.swift in Sources */,
 				A5EFAA122D3F518B00F771FE /* SubmitCollectorTests.swift in Sources */,

--- a/Davinci/DavinciTests/integration tests/ImageCollectorE2ETest.swift
+++ b/Davinci/DavinciTests/integration tests/ImageCollectorE2ETest.swift
@@ -1,0 +1,158 @@
+//
+//  ImageCollectorIntegrationTests.swift
+//  DavinciTests
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+@testable import PingOrchestrate
+@testable import PingLogger
+@testable import PingOidc
+@testable import PingStorage
+@testable import PingDavinci
+
+/// E2E tests for ImageCollector — DaVinci IMAGE-type form field.
+///
+/// The test flow starts with a "Select Test Form" that presents a FlowCollector "Image" button.
+/// Tapping it transitions to the "Automation - Image" showForm node which contains:
+///
+///   index 0 — LabelCollector  (key "title-text", richContent "Image Collector Test")
+///   index 1 — ImageCollector  (key "image", description "Image Collector Test", raster imageUrl, hyperlinkUrl)
+///   index 2 — SubmitCollector (key "submit", label "Continue")
+///
+/// Tapping Continue loops back to the Select Test Form.
+class ImageCollectorIntegrationTests: DaVinciBaseTests, @unchecked Sendable {
+    private var daVinci: DaVinci!
+
+    // MARK: - Index constants
+
+    private let imageButtonIndex = 1  // FlowCollector "Image" on Select Test Form
+    private let labelIndex = 0        // LabelCollector (title-text) on Automation - Image
+    private let imageIndex = 1        // ImageCollector (image) on Automation - Image
+    private let submitIndex = 2       // SubmitCollector "Continue" on Automation - Image
+
+    // MARK: - Expected values
+
+    private let expectedNodeName = "Automation - Image"
+    private let expectedImageKey = "image"
+    private let expectedImageDescription = "Image Collector Test"
+    private let expectedImageUrl = "https://img.magnific.com/free-photo/closeup-shot-beautiful-butterfly-with-interesting-textures-orange-petaled-flower_181624-7640.jpg"
+    private let expectedHyperlinkUrl = "https://www.pingidentity.com/en.html"
+
+    override func setUp() async throws {
+        self.configFileName = "ConfigNew"
+        try await super.setUp()
+
+        HTTPCookieStorage.shared.cookies?.forEach { HTTPCookieStorage.shared.deleteCookie($0) }
+
+        daVinci = DaVinci.createDaVinci { config in
+            config.logger = LogManager.standard
+            config.module(PingDavinci.OidcModule.config) { oidcValue in
+                oidcValue.clientId = self.config.clientId
+                oidcValue.scopes = Set(self.config.scopes)
+                oidcValue.redirectUri = self.config.redirectUri
+                oidcValue.acrValues = "14f7988fc922112d599a14c1016a6ec6"
+                oidcValue.discoveryEndpoint = self.config.discoveryEndpoint
+            }
+        }
+
+        await daVinci.daVinciUser()?.logout()
+    }
+
+    // MARK: - Helper
+
+    /// Navigates from start() to the "Automation - Image" form node.
+    private func navigateToImageForm() async -> ContinueNode? {
+        guard let startNode = await daVinci.start() as? ContinueNode else {
+            XCTFail("Expected ContinueNode from start()")
+            return nil
+        }
+        XCTAssertEqual("Select Test Form", startNode.name)
+        guard let imageButton = startNode.collectors[imageButtonIndex] as? FlowCollector else {
+            XCTFail("Expected FlowCollector at index \(imageButtonIndex)")
+            return nil
+        }
+        XCTAssertEqual("Image", imageButton.label)
+        imageButton.value = "click"
+
+        guard let imageFormNode = await startNode.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after tapping Image button")
+            return nil
+        }
+        return imageFormNode
+    }
+
+    // MARK: - Node shape
+
+    func testAutomationImageNodeHasCorrectName() async throws {
+        guard let node = await navigateToImageForm() else { return }
+        XCTAssertEqual(expectedNodeName, node.name)
+    }
+
+    func testAutomationImageNodeHasThreeCollectors() async throws {
+        guard let node = await navigateToImageForm() else { return }
+        XCTAssertEqual(3, node.collectors.count)
+        XCTAssertTrue(node.collectors[labelIndex] is LabelCollector)
+        XCTAssertTrue(node.collectors[imageIndex] is ImageCollector)
+        XCTAssertTrue(node.collectors[submitIndex] is SubmitCollector)
+    }
+
+    // MARK: - ImageCollector properties
+
+    func testImageCollectorHasCorrectKey() async throws {
+        guard let node = await navigateToImageForm() else { return }
+        let collector = node.collectors[imageIndex] as! ImageCollector
+        XCTAssertEqual(expectedImageKey, collector.key)
+    }
+
+    func testImageCollectorHasCorrectDescription() async throws {
+        guard let node = await navigateToImageForm() else { return }
+        let collector = node.collectors[imageIndex] as! ImageCollector
+        XCTAssertEqual(expectedImageDescription, collector.description)
+    }
+
+    func testImageCollectorHasCorrectImageUrl() async throws {
+        guard let node = await navigateToImageForm() else { return }
+        let collector = node.collectors[imageIndex] as! ImageCollector
+        XCTAssertEqual(expectedImageUrl, collector.imageUrl)
+    }
+
+    func testImageCollectorHasCorrectHyperlinkUrl() async throws {
+        guard let node = await navigateToImageForm() else { return }
+        let collector = node.collectors[imageIndex] as! ImageCollector
+        XCTAssertEqual(expectedHyperlinkUrl, collector.hyperlinkUrl)
+    }
+
+    func testImageCollectorIdReturnsKey() async throws {
+        guard let node = await navigateToImageForm() else { return }
+        let collector = node.collectors[imageIndex] as! ImageCollector
+        XCTAssertEqual(collector.key, collector.id)
+    }
+
+    // MARK: - LabelCollector rich content
+
+    func testLabelCollectorRichContentContainsTitle() async throws {
+        guard let node = await navigateToImageForm() else { return }
+        let label = node.collectors[labelIndex] as! LabelCollector
+        XCTAssertNotNil(label.richContent)
+        XCTAssertEqual("Image Collector Test", label.richContent?.content)
+    }
+
+    // MARK: - Flow navigation
+
+    func testContinueReturnsToSelectTestForm() async throws {
+        guard let node = await navigateToImageForm() else { return }
+        XCTAssertEqual(expectedNodeName, node.name)
+
+        (node.collectors[submitIndex] as! SubmitCollector).value = "click"
+        guard let nextNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode (Select Test Form) after Continue")
+            return
+        }
+        XCTAssertEqual("Select Test Form", nextNode.name)
+    }
+}

--- a/Davinci/DavinciTests/integration tests/MetadataCollectorE2ETest.swift
+++ b/Davinci/DavinciTests/integration tests/MetadataCollectorE2ETest.swift
@@ -1,0 +1,273 @@
+//
+//  MetadataCollectorIntegrationTests.swift
+//  DavinciTests
+//
+//  Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+import PingDavinciPlugin
+@testable import PingOrchestrate
+@testable import PingLogger
+@testable import PingOidc
+@testable import PingStorage
+@testable import PingDavinci
+
+/// E2E tests for MetadataCollector — DaVinci SDK Integrator connector
+/// (`exchangeCustomMetadata` capability).
+///
+/// The test flow starts with a "Select Test Form" that presents a "Metadata" submit button.
+/// Tapping it transitions to an `exchangeCustomMetadata` node that returns a single METADATA
+/// field with key "sdkMetadata" and payload {"testkey":"testValue"}.
+/// After the SDK submits its response the flow transitions to an "Automation - Message" form
+/// which echoes the submitted value back to the client, confirming what DaVinci received.
+class MetadataCollectorIntegrationTests: DaVinciBaseTests, @unchecked Sendable {
+    private var daVinci: DaVinci!
+
+    // MARK: - Index constants
+
+    private let metadataButtonIndex = 0    // SubmitCollector "Metadata" on Select Test Form
+    private let metadataCollectorIndex = 0 // MetadataCollector on exchangeCustomMetadata node
+    private let labelIndex = 0             // LabelCollector (echoed value) on Automation - Message
+    private let submitIndex = 1            // SubmitCollector "Continue" on Automation - Message
+
+    override func setUp() async throws {
+        self.configFileName = "ConfigNew"
+        try await super.setUp()
+
+        HTTPCookieStorage.shared.cookies?.forEach { HTTPCookieStorage.shared.deleteCookie($0) }
+
+        daVinci = DaVinci.createDaVinci { config in
+            config.logger = LogManager.standard
+            config.module(PingDavinci.OidcModule.config) { oidcValue in
+                oidcValue.clientId = self.config.clientId
+                oidcValue.scopes = Set(self.config.scopes)
+                oidcValue.redirectUri = self.config.redirectUri
+                oidcValue.acrValues = "14f7988fc922112d599a14c1016a6ec6"
+                oidcValue.discoveryEndpoint = self.config.discoveryEndpoint
+            }
+        }
+
+        await daVinci.daVinciUser()?.logout()
+    }
+
+    // MARK: - Helper
+
+    /// Navigates from start() to the exchangeCustomMetadata node.
+    private func navigateToMetadataNode() async -> ContinueNode? {
+        guard let startNode = await daVinci.start() as? ContinueNode else {
+            XCTFail("Expected ContinueNode from start()")
+            return nil
+        }
+        XCTAssertEqual("Select Test Form", startNode.name)
+        guard let metadataButton = startNode.collectors[metadataButtonIndex] as? SubmitCollector else {
+            XCTFail("Expected SubmitCollector at index \(metadataButtonIndex)")
+            return nil
+        }
+        XCTAssertEqual("Metadata", metadataButton.label)
+        metadataButton.value = "click"
+
+        guard let metadataNode = await startNode.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode after tapping Metadata button")
+            return nil
+        }
+        return metadataNode
+    }
+
+    // MARK: - Collector shape and payload
+
+    func testMetadataCollectorIsPresentWithCorrectShape() async throws {
+        guard let node = await navigateToMetadataNode() else { return }
+
+        XCTAssertEqual(1, node.collectors.count)
+        XCTAssertTrue(node.collectors[metadataCollectorIndex] is MetadataCollector)
+
+        let collector = node.collectors[metadataCollectorIndex] as! MetadataCollector
+        XCTAssertEqual("sdkMetadata", collector.key)
+        XCTAssertEqual("METADATA", collector.type)
+        XCTAssertEqual("testValue", collector.metadata["testkey"] as? String)
+    }
+
+    func testMetadataCollectorPayloadIsNilBeforeSetResultOrSetError() async throws {
+        guard let node = await navigateToMetadataNode() else { return }
+        let collector = node.collectors[metadataCollectorIndex] as! MetadataCollector
+        XCTAssertNil(collector.payload())
+    }
+
+    // MARK: - Validation
+
+    func testValidateRequiresResponseBeforeSubmit() async throws {
+        guard let node = await navigateToMetadataNode() else { return }
+        let collector = node.collectors[metadataCollectorIndex] as! MetadataCollector
+
+        let errors = collector.validate()
+        XCTAssertFalse(errors.isEmpty)
+        XCTAssertEqual([ValidationError.required], errors)
+    }
+
+    func testValidatePassesAfterSetResult() async throws {
+        guard let node = await navigateToMetadataNode() else { return }
+        let collector = node.collectors[metadataCollectorIndex] as! MetadataCollector
+
+        collector.setResult(["status": "success"])
+        XCTAssertTrue(collector.validate().isEmpty)
+    }
+
+    func testValidatePassesAfterSetError() async throws {
+        guard let node = await navigateToMetadataNode() else { return }
+        let collector = node.collectors[metadataCollectorIndex] as! MetadataCollector
+
+        collector.setError(code: "100", message: "An error occurred")
+        XCTAssertTrue(collector.validate().isEmpty)
+    }
+
+    // MARK: - Success path — setResult
+
+    func testSetResultAdvancesFlowToSuccessBranch() async throws {
+        guard var node = await navigateToMetadataNode() else { return }
+        let collector = node.collectors[metadataCollectorIndex] as! MetadataCollector
+
+        collector.setResult(["status": "success"])
+
+        guard let messageNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode (Automation - Message) after setResult submit")
+            return
+        }
+        node = messageNode
+        XCTAssertEqual("Automation - Message", node.name)
+
+        let label = node.collectors[labelIndex] as! LabelCollector
+        XCTAssertTrue(
+            label.content.contains("success"),
+            "Expected echoed label to contain 'success', was: \(label.content)"
+        )
+
+        // Continue back to the Select Test Form — confirms the success branch completed
+        (node.collectors[submitIndex] as! SubmitCollector).value = "click"
+        guard let selectNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode (Select Test Form) after Continue")
+            return
+        }
+        XCTAssertEqual("Select Test Form", selectNode.name)
+    }
+
+    func testSetResultPayloadContainsProvidedData() async throws {
+        guard let node = await navigateToMetadataNode() else { return }
+        let collector = node.collectors[metadataCollectorIndex] as! MetadataCollector
+
+        collector.setResult(["status": "success"])
+
+        let payload = collector.payload()
+        XCTAssertNotNil(payload)
+        XCTAssertEqual("success", payload?["status"] as? String)
+    }
+
+    // MARK: - Error path — setError
+
+    func testSetErrorAdvancesFlowToErrorBranch() async throws {
+        guard var node = await navigateToMetadataNode() else { return }
+        let collector = node.collectors[metadataCollectorIndex] as! MetadataCollector
+
+        collector.setError(code: "100", message: "An error occurred")
+
+        guard let messageNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode (Automation - Message) after setError submit")
+            return
+        }
+        node = messageNode
+        XCTAssertEqual("Automation - Message", node.name)
+
+        let label = node.collectors[labelIndex] as! LabelCollector
+        XCTAssertTrue(
+            label.content.contains("100"),
+            "Expected echoed label to contain error code '100', was: \(label.content)"
+        )
+        XCTAssertTrue(
+            label.content.contains("An error occurred"),
+            "Expected echoed label to contain error message, was: \(label.content)"
+        )
+
+        // Continue back to Select Test Form — confirms the error branch completed
+        (node.collectors[submitIndex] as! SubmitCollector).value = "click"
+        guard let selectNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode (Select Test Form) after Continue")
+            return
+        }
+        XCTAssertEqual("Select Test Form", selectNode.name)
+    }
+
+    func testSetErrorPayloadContainsStructuredErrorEnvelope() async throws {
+        guard let node = await navigateToMetadataNode() else { return }
+        let collector = node.collectors[metadataCollectorIndex] as! MetadataCollector
+
+        collector.setError(code: "100", message: "An error occurred")
+
+        let payload = collector.payload()
+        XCTAssertNotNil(payload)
+
+        let error = payload?["error"] as? [String: Any]
+        XCTAssertNotNil(error)
+        XCTAssertEqual("100", error?["code"] as? String)
+        XCTAssertEqual("An error occurred", error?["message"] as? String)
+    }
+
+    // MARK: - Repeated iterations (loop)
+
+    func testMetadataFlowCanBeTraversedTwiceInTheSameSession() async throws {
+        // First iteration — success
+        guard var node = await navigateToMetadataNode() else { return }
+        var collector = node.collectors[metadataCollectorIndex] as! MetadataCollector
+
+        collector.setResult(["status": "success"])
+
+        guard let messageNode1 = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode (Automation - Message) on iteration 1")
+            return
+        }
+        node = messageNode1
+        XCTAssertEqual("Automation - Message", node.name)
+
+        (node.collectors[submitIndex] as! SubmitCollector).value = "click"
+        guard let selectNode = await node.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode (Select Test Form) after iteration 1")
+            return
+        }
+        XCTAssertEqual("Select Test Form", selectNode.name)
+
+        // Second iteration — error; the new collector must be independent of the first
+        (selectNode.collectors[metadataButtonIndex] as! SubmitCollector).value = "click"
+        guard let node2 = await selectNode.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode (exchangeCustomMetadata) on iteration 2")
+            return
+        }
+
+        XCTAssertEqual(1, node2.collectors.count)
+        XCTAssertTrue(node2.collectors[metadataCollectorIndex] is MetadataCollector)
+
+        collector = node2.collectors[metadataCollectorIndex] as! MetadataCollector
+        // Payload from the previous iteration must not carry over
+        XCTAssertNil(collector.payload())
+        XCTAssertEqual("testValue", collector.metadata["testkey"] as? String)
+
+        collector.setError(code: "100", message: "An error occurred")
+
+        guard let messageNode2 = await node2.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode (Automation - Message) on iteration 2")
+            return
+        }
+        XCTAssertEqual("Automation - Message", messageNode2.name)
+
+        let label = messageNode2.collectors[labelIndex] as! LabelCollector
+        XCTAssertTrue(label.content.contains("100"))
+
+        (messageNode2.collectors[submitIndex] as! SubmitCollector).value = "click"
+        guard let selectNode2 = await messageNode2.next() as? ContinueNode else {
+            XCTFail("Expected ContinueNode (Select Test Form) after iteration 2")
+            return
+        }
+        XCTAssertEqual("Select Test Form", selectNode2.name)
+    }
+}


### PR DESCRIPTION
# JIRA Ticket

[SDKS-5281](https://pingidentity.atlassian.net/browse/SDKS-5281) Test new DaVinci components

# Description

Adds iOS e2e integration tests for `MetadataCollector` and `ImageCollector`, mirroring the Android coverage in [PR #233](https://github.com/ForgeRock/ping-android-sdk/pull/233):

- `MetadataCollectorIntegrationTests` (10 tests) — covers collector payload, nil payload before `setResult` and `setError`, validation gating, success and error flow paths.
- `ImageCollectorIntegrationTests` (8 tests) — covers the collector properties

Both test files use the "ConfigNew" config with `acrValues` set to `14f7988fc922112d599a14c1016a6ec6` (the shared "Misc-Collectors" flow).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for image collection workflows, including form navigation, collector configuration, and continuation behavior.
  * Added end-to-end coverage for custom metadata exchange workflows, including successful and error responses, validation, payload handling, and repeated runs.
  * Expanded integration test project configuration so these scenarios run as part of the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->